### PR TITLE
Correct link to code to point to github

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -92,7 +92,7 @@ const config = {
             items: [
               {
                 label: 'GitHub',
-                href: 'https://github.com/facebook/docusaurus',
+                href: 'https://facebookexperimental.github.io/object-introspection/',
               },
             ],
           },


### PR DESCRIPTION
## Summary
Correct link to code to point to github

## Test plan
```
<a href="https://facebookexperimental.github.io/object-introspection/" target="_blank" rel="noopener noreferrer" class="footer__link-item">GitHub<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" class="iconExternalLink_nPIU"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z" style="--darkreader-inline-fill: currentColor;" data-darkreader-inline-fill=""></path></svg></a>
```
Is the generated code
