### PR TITLE
remove funcgeninternal.h

### DIFF
--- a/src/FuncGen.cpp
+++ b/src/FuncGen.cpp
@@ -23,10 +23,6 @@
 
 #include "ContainerInfo.h"
 
-#ifndef OSS_ENABLE
-#include "cea/object-introspection/internal/FuncGenInternal.h"
-#endif
-
 namespace {
 
 const std::string typedValueFunc = R"(
@@ -137,9 +133,6 @@ const std::string typedValueFunc = R"(
   }
   )";
 
-const std::map<ContainerTypeEnum, std::string> defaultTypeToDeclMap = {};
-
-const std::map<ContainerTypeEnum, std::string> defaultTypeToFuncMap = {};
 }  // namespace
 
 void FuncGen::DeclareGetSize(std::string& testCode, const std::string& type) {
@@ -459,18 +452,6 @@ void FuncGen::DeclareGetContainer(std::string& testCode) {
       }
       )";
   testCode.append(func);
-}
-
-// TODO: remove map initialisation once all container configs are removed from
-// the code
-FuncGen::FuncGen()
-    : typeToDeclMap(defaultTypeToDeclMap), typeToFuncMap(defaultTypeToFuncMap) {
-#ifndef OSS_ENABLE
-  typeToDeclMap.insert(typeToDeclMapInternal.begin(),
-                       typeToDeclMapInternal.end());
-  typeToFuncMap.insert(typeToFuncMapInternal.begin(),
-                       typeToFuncMapInternal.end());
-#endif
 }
 
 bool FuncGen::RegisterContainer(ContainerTypeEnum ctype, const fs::path& path) {

--- a/src/FuncGen.h
+++ b/src/FuncGen.h
@@ -25,8 +25,6 @@ namespace fs = std::filesystem;
 
 class FuncGen {
  public:
-  // TODO: remove me once all containers are in toml files
-  FuncGen();
   bool RegisterContainer(ContainerTypeEnum, const fs::path& path);
 
   void DeclareStoreData(std::string& testCode);

--- a/src/OICodeGen.cpp
+++ b/src/OICodeGen.cpp
@@ -34,9 +34,6 @@
 #include "OIParser.h"
 #include "PaddingHunter.h"
 #include "SymbolService.h"
-#ifndef OSS_ENABLE
-#include "cea/object-introspection/internal/FuncGenInternal.h"
-#endif
 
 namespace fs = std::filesystem;
 
@@ -45,13 +42,6 @@ static size_t g_level = 0;
 #undef VLOG
 #define VLOG(verboselevel) \
   LOG_IF(INFO, VLOG_IS_ON(verboselevel)) << std::string(2 * g_level, ' ')
-
-// typeName, numTemplateParams, ctype, header, namespaces...
-// formatting disabled due to line length becoming a mess
-// clang-format off
-static const std::vector<ContainerInfo> defaultContainerInfoList = {
-};
-// clang-format on
 
 std::unique_ptr<OICodeGen> OICodeGen::buildFromConfig(const Config &c) {
   auto cg = std::unique_ptr<OICodeGen>(new OICodeGen(c));
@@ -66,22 +56,7 @@ std::unique_ptr<OICodeGen> OICodeGen::buildFromConfig(const Config &c) {
   return cg;
 }
 
-// TODO: remove containerInfoList initialisation once all container configs are
-// removed from the code
 OICodeGen::OICodeGen(const Config &c) : config{c} {
-#ifndef OSS_ENABLE
-  containerInfoList.reserve(containerInfoListInternal.size() +
-                            defaultContainerInfoList.size());
-  for (const auto &el : containerInfoListInternal) {
-    containerInfoList.push_back(std::make_unique<ContainerInfo>(el));
-  }
-#endif
-
-  containerInfoList.reserve(defaultContainerInfoList.size());
-  for (const auto &el : defaultContainerInfoList) {
-    containerInfoList.push_back(std::make_unique<ContainerInfo>(el));
-  }
-
   // TODO: Should folly::Range just be added as a container?
   auto typesToStub = std::array{
       "SharedMutex",


### PR DESCRIPTION
## Summary

The container information added by `FuncGenInternal.h` has been made redundant by the pluggable containers feature. Remove this legacy difference.

## Test plan

- `make test-devel`
- CI
- D42167455
