### PR TITLE
update to codegen->generate

### DIFF
--- a/src/OIGenerator.cpp
+++ b/src/OIGenerator.cpp
@@ -100,7 +100,7 @@ bool OIGenerator::generateForType(const OICodeGen::Config& generatorConfig,
   codegen->setRootType(type);
   codegen->setLinkageName(linkageName);
 
-  if (!codegen->generateFunctionsForTypesDrgn(code)) {
+  if (!codegen->generate(code)) {
     LOG(ERROR) << "failed to generate code";
     return false;
   }


### PR DESCRIPTION
## Summary

Spotted a deprecation warning that I added about my code (whoops). Update `OIGenerator` from `codegen->generateFunctionsForTypesDrgn` to `codegen->generate`.

## Test plan

- `make test-devel`
- CI
