### PR TITLE
move extern repos to https addresses

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "extern/drgn"]
-	path = extern/drgn
-  url = git@github.com:JakeHillion/drgn.git
+  path = extern/drgn
+  url = https://github.com/JakeHillion/drgn.git
 [submodule "extern/folly"]
-	path = extern/folly
-	url = git@github.com:jgkamat/folly.git
+  path = extern/folly
+  url = https://github.com/jgkamat/folly.git
 [submodule "extern/rocksdb"]
-	path = extern/rocksdb
-	url = git@github.com:facebook/rocksdb.git
+  path = extern/rocksdb
+  url = https://github.com/facebook/rocksdb.git


### PR DESCRIPTION
## Summary

The extern repos are currently cloned with SSH. This means that attempting to clone them on a system that doesn't have an SSH key which GitHub accepts fails. Change them to HTTPS as they're read only in this context anyway.

## Test plan

Devserver:
- `cd /tmp && git clone https://github.com/JakeHillion/object-introspection.git oi && cd oi && git checkout https-submodules && ... && make test-devel`

NixOS (no SSH keys):
- `cd /tmp && git clone https://github.com/JakeHillion/object-introspection.git oi && mkdir oi/build && cd oi/build && cmake ..` - fails (unable to clone)
- `cd /tmp && git clone https://github.com/JakeHillion/object-introspection.git oi && mkdir oi/build && cd oi/build && git checkout https-submodules && cmake ..` - successfully clones

&& CI.