### PR TITLE
Codegen review changes

### DIFF
--- a/src/OICodeGen.h
+++ b/src/OICodeGen.h
@@ -38,7 +38,7 @@ extern "C" {
 namespace fs = std::filesystem;
 
 struct ParentMember {
-  struct drgn_type *type;
+  drgn_type *type;
   uint64_t bit_offset;
 
   bool operator<(const ParentMember &parent) const {
@@ -89,84 +89,77 @@ class OICodeGen {
   // TODO: remove me once all the callsites are gone
   static void initializeCodeGen();
 
-  struct drgn_qualified_type getRootType();
-  void setRootType(struct drgn_qualified_type rt);
+  drgn_qualified_type getRootType();
+  void setRootType(drgn_qualified_type rt);
   void setLinkageName(std::string name) {
     linkageName = name;
   };
   TypeHierarchy getTypeHierarchy();
   std::map<std::string, PaddingInfo> getPaddingInfo();
 
-  static void getDrgnArrayElementType(struct drgn_type *type,
-                                      struct drgn_type **outElemType,
+  static void getDrgnArrayElementType(drgn_type *type, drgn_type **outElemType,
                                       size_t &outNumElems);
 
-  bool isContainer(struct drgn_type *type);
+  bool isContainer(drgn_type *type);
 
-  static struct drgn_type *drgnUnderlyingType(struct drgn_type *type);
+  static drgn_type *drgnUnderlyingType(drgn_type *type);
 
-  bool buildName(struct drgn_type *type, std::string &text,
-                 std::string &outName);
+  bool buildName(drgn_type *type, std::string &text, std::string &outName);
 
-  std::string typeToTransformedName(struct drgn_type *type);
-  static std::string typeToName(struct drgn_type *type);
+  std::string typeToTransformedName(drgn_type *type);
+  static std::string typeToName(drgn_type *type);
 
-  bool enumerateTypesRecurse(struct drgn_type *type);
-  static std::string_view drgnKindStr(struct drgn_type *type);
-  std::set<struct drgn_type *> processedTypes;
+  bool enumerateTypesRecurse(drgn_type *type);
+  static std::string_view drgnKindStr(drgn_type *type);
+  std::set<drgn_type *> processedTypes;
 
  private:
   Config config{};
   FuncGen funcGen;
 
   using ContainerTypeMap =
-      std::pair<ContainerInfo, std::vector<struct drgn_qualified_type>>;
+      std::pair<ContainerInfo, std::vector<drgn_qualified_type>>;
 
   using TemplateParamList =
-      std::vector<std::pair<struct drgn_qualified_type, std::string>>;
+      std::vector<std::pair<drgn_qualified_type, std::string>>;
 
-  using SortedTypeDefMap =
-      std::vector<std::pair<struct drgn_type *, struct drgn_type *>>;
+  using SortedTypeDefMap = std::vector<std::pair<drgn_type *, drgn_type *>>;
 
   std::string rootTypeStr;
   std::string linkageName;
-  std::map<struct drgn_type *, std::string> unnamedUnion;
+  std::map<drgn_type *, std::string> unnamedUnion;
   std::map<std::string, size_t> sizeMap;
-  std::map<struct drgn_type *, ContainerTypeMap> containerTypeMapDrgn;
+  std::map<drgn_type *, ContainerTypeMap> containerTypeMapDrgn;
   std::vector<std::unique_ptr<ContainerInfo>> containerInfoList;
-  std::vector<struct drgn_type *> enumTypes;
-  std::vector<struct drgn_type *> typePath;
+  std::vector<drgn_type *> enumTypes;
+  std::vector<drgn_type *> typePath;
   std::vector<std::string> knownTypes;
-  struct drgn_qualified_type rootType;
-  struct drgn_qualified_type rootTypeToIntrospect;
+  drgn_qualified_type rootType;
+  drgn_qualified_type rootTypeToIntrospect;
 
   std::map<std::string, std::string> typedefMap;
-  std::map<struct drgn_type *, std::vector<ParentMember>> parentClasses;
+  std::map<drgn_type *, std::vector<ParentMember>> parentClasses;
 
   size_t pad_index = 0;
-  std::unordered_map<struct drgn_type *, std::pair<size_t, size_t>>
-      paddingIndexMap;
+  std::unordered_map<drgn_type *, std::pair<size_t, size_t>> paddingIndexMap;
 
-  std::map<struct drgn_type *, struct drgn_type *> typedefTypes;
-  std::map<struct drgn_type *, std::vector<DrgnClassMemberInfo>>
-      classMembersMap;
-  std::map<struct drgn_type *, std::vector<DrgnClassMemberInfo>>
-      classMembersMapCopy;
-  std::map<struct drgn_type *, std::string> typeToNameMap;
-  std::map<std::string, struct drgn_type *> nameToTypeMap;
-  std::set<struct drgn_type *> funcDefTypeList;
-  std::vector<struct drgn_type *> structDefType;
-  std::set<struct drgn_type *> knownDummyTypeList;
-  std::map<struct drgn_type *, struct drgn_type *> pointerToTypeMap;
-  std::set<struct drgn_type *> thriftIssetStructTypes;
-  std::vector<struct drgn_type *> topoSortedStructTypes;
+  std::map<drgn_type *, drgn_type *> typedefTypes;
+  std::map<drgn_type *, std::vector<DrgnClassMemberInfo>> classMembersMap;
+  std::map<drgn_type *, std::vector<DrgnClassMemberInfo>> classMembersMapCopy;
+  std::map<drgn_type *, std::string> typeToNameMap;
+  std::map<std::string, drgn_type *> nameToTypeMap;
+  std::set<drgn_type *> funcDefTypeList;
+  std::vector<drgn_type *> structDefType;
+  std::set<drgn_type *> knownDummyTypeList;
+  std::map<drgn_type *, drgn_type *> pointerToTypeMap;
+  std::set<drgn_type *> thriftIssetStructTypes;
+  std::vector<drgn_type *> topoSortedStructTypes;
 
   std::set<ContainerInfo> containerTypesFuncDef;
 
   std::map<std::string, PaddingInfo> paddedStructs;
 
-  std::map<struct drgn_type *, std::vector<DrgnClassMemberInfo>>
-      &getClassMembersMap();
+  std::map<drgn_type *, std::vector<DrgnClassMemberInfo>> &getClassMembersMap();
 
   class DrgnString {
     struct FreeDeleter {
@@ -193,54 +186,52 @@ class OICodeGen {
       const std::string &fullyQualifiedname);
   static void removeTemplateParamAtIndex(std::vector<std::string> &params,
                                          const size_t index);
-  std::unordered_map<struct drgn_type *, DrgnString> fullyQualifiedNames;
-  std::optional<const std::string_view> fullyQualifiedName(
-      struct drgn_type *type);
+  std::unordered_map<drgn_type *, DrgnString> fullyQualifiedNames;
+  std::optional<const std::string_view> fullyQualifiedName(drgn_type *type);
   static SortedTypeDefMap getSortedTypeDefMap(
-      const std::map<struct drgn_type *, struct drgn_type *> &typedefTypeMap);
+      const std::map<drgn_type *, drgn_type *> &typedefTypeMap);
 
-  std::optional<ContainerInfo> getContainerInfo(struct drgn_type *type);
+  std::optional<ContainerInfo> getContainerInfo(drgn_type *type);
   void printAllTypes();
   void printAllTypeNames();
   void printTypePath();
 
-  static void addPaddingForBaseClass(struct drgn_type *type,
+  static void addPaddingForBaseClass(drgn_type *type,
                                      std::vector<std::string> &def);
-  void addTypeToName(struct drgn_type *type, std::string name);
+  void addTypeToName(drgn_type *type, std::string name);
   bool generateNamesForTypes();
   bool generateJitCode(std::string &code);
   bool generateStructDefs(std::string &code);
-  bool generateStructDef(struct drgn_type *e, std::string &code);
-  bool getDrgnTypeName(struct drgn_type *type, std::string &outName);
+  bool generateStructDef(drgn_type *e, std::string &code);
+  bool getDrgnTypeName(drgn_type *type, std::string &outName);
 
-  bool getDrgnTypeNameInt(struct drgn_type *type, std::string &outName);
+  bool getDrgnTypeNameInt(drgn_type *type, std::string &outName);
   bool populateDefsAndDecls();
   static void memberTransformName(
       std::map<std::string, std::string> &templateTransformMap,
       std::string &typeName);
 
-  bool getMemberDefinition(struct drgn_type *type);
+  bool getMemberDefinition(drgn_type *type);
   bool isKnownType(const std::string &type);
   bool isKnownType(const std::string &type, std::string &matched);
 
   static bool getTemplateParams(
-      struct drgn_type *type, size_t numTemplateParams,
-      std::vector<std::pair<struct drgn_qualified_type, std::string>> &v);
+      drgn_type *type, size_t numTemplateParams,
+      std::vector<std::pair<drgn_qualified_type, std::string>> &v);
 
-  bool enumerateTemplateParamIdxs(struct drgn_type *type,
+  bool enumerateTemplateParamIdxs(drgn_type *type,
                                   const ContainerInfo &containerInfo,
                                   const std::vector<size_t> &paramIdxs,
                                   bool &ifStub);
-  bool getContainerTemplateParams(struct drgn_type *type, bool &ifStub);
-  void getFuncDefinitionStr(std::string &code, struct drgn_type *type,
+  bool getContainerTemplateParams(drgn_type *type, bool &ifStub);
+  void getFuncDefinitionStr(std::string &code, drgn_type *type,
                             const std::string &typeName);
-  std::optional<uint64_t> getDrgnTypeSize(struct drgn_type *type);
+  std::optional<uint64_t> getDrgnTypeSize(drgn_type *type);
 
-  std::optional<std::string> getNameForType(struct drgn_type *type);
+  std::optional<std::string> getNameForType(drgn_type *type);
 
-  static std::string preProcessUniquePtr(struct drgn_type *type,
-                                         std::string name);
-  std::string transformTypeName(struct drgn_type *type, std::string &text);
+  static std::string preProcessUniquePtr(drgn_type *type, std::string name);
+  std::string transformTypeName(drgn_type *type, std::string &text);
   static std::string templateTransformType(const std::string &typeName);
   static std::string structNameTransformType(const std::string &typeName);
 
@@ -252,81 +243,76 @@ class OICodeGen {
       const DrgnClassMemberInfo &m,
       std::unordered_map<std::string, int> &memberNames,
       uint64_t currOffsetBits, std::string &code, bool isInUnion);
-  bool generateParent(struct drgn_type *p,
+  bool generateParent(drgn_type *p,
                       std::unordered_map<std::string, int> &memberNames,
                       uint64_t &currOffsetBits, std::string &code,
                       size_t offsetToNextMember);
-  std::optional<uint64_t> getAlignmentRequirements(struct drgn_type *e);
-  bool generateStructMembers(struct drgn_type *e,
+  std::optional<uint64_t> getAlignmentRequirements(drgn_type *e);
+  bool generateStructMembers(drgn_type *e,
                              std::unordered_map<std::string, int> &memberNames,
                              std::string &code, uint64_t &out_offset_bits,
                              PaddingInfo &paddingInfo,
                              bool &violatesAlignmentRequirement,
                              size_t offsetToNextMember);
-  void getFuncDefClassMembers(std::string &code, struct drgn_type *type,
+  void getFuncDefClassMembers(std::string &code, drgn_type *type,
                               std::unordered_map<std::string, int> &memberNames,
                               bool skipPadding = false);
-  bool isDrgnSizeComplete(struct drgn_type *type);
+  bool isDrgnSizeComplete(drgn_type *type);
 
-  static bool getEnumUnderlyingTypeStr(struct drgn_type *e,
+  static bool getEnumUnderlyingTypeStr(drgn_type *e,
                                        std::string &enumUnderlyingTypeStr);
 
   bool ifEnumerateClass(const std::string &typeName);
 
-  bool enumerateClassParents(struct drgn_type *type,
-                             const std::string &typeName);
-  bool enumerateClassMembers(struct drgn_type *type,
-                             const std::string &typeName, bool &isStubbed);
-  bool enumerateClassTemplateParams(struct drgn_type *type,
+  bool enumerateClassParents(drgn_type *type, const std::string &typeName);
+  bool enumerateClassMembers(drgn_type *type, const std::string &typeName,
+                             bool &isStubbed);
+  bool enumerateClassTemplateParams(drgn_type *type,
                                     const std::string &typeName,
                                     bool &isStubbed);
   bool ifGenerateMemberDefinition(const std::string &typeName);
-  bool generateMemberDefinition(struct drgn_type *type, std::string &typeName);
+  bool generateMemberDefinition(drgn_type *type, std::string &typeName);
   std::optional<std::pair<std::string_view, std::string_view>> isMemberToStub(
       const std::string &type, const std::string &member);
   std::optional<std::string_view> isTypeToStub(const std::string &typeName);
-  bool isTypeToStub(struct drgn_type *type, const std::string &typeName);
-  bool isEmptyClassOrFunctionType(struct drgn_type *type,
-                                  const std::string &typeName);
-  bool enumerateClassType(struct drgn_type *type);
-  bool enumerateTypeDefType(struct drgn_type *type);
-  bool enumerateEnumType(struct drgn_type *type);
-  bool enumeratePointerType(struct drgn_type *type);
-  bool enumeratePrimitiveType(struct drgn_type *type);
-  bool enumerateArrayType(struct drgn_type *type);
+  bool isTypeToStub(drgn_type *type, const std::string &typeName);
+  bool isEmptyClassOrFunctionType(drgn_type *type, const std::string &typeName);
+  bool enumerateClassType(drgn_type *type);
+  bool enumerateTypeDefType(drgn_type *type);
+  bool enumerateEnumType(drgn_type *type);
+  bool enumeratePointerType(drgn_type *type);
+  bool enumeratePrimitiveType(drgn_type *type);
+  bool enumerateArrayType(drgn_type *type);
 
-  bool isUnnamedStruct(struct drgn_type *type);
+  bool isUnnamedStruct(drgn_type *type);
 
-  std::string getAnonName(struct drgn_type *, const char *);
-  std::string getStructName(struct drgn_type *type) {
+  std::string getAnonName(drgn_type *, const char *);
+  std::string getStructName(drgn_type *type) {
     return getAnonName(type, "__anon_struct_");
   }
-  std::string getUnionName(struct drgn_type *type) {
+  std::string getUnionName(drgn_type *type) {
     return getAnonName(type, "__anon_union_");
   }
   static void declareThriftStruct(std::string &code, std::string_view name);
 
-  bool isNumMemberGreaterThanZero(struct drgn_type *type);
-  void getClassMembersIncludingParent(struct drgn_type *type,
+  bool isNumMemberGreaterThanZero(drgn_type *type);
+  void getClassMembersIncludingParent(drgn_type *type,
                                       std::vector<DrgnClassMemberInfo> &out);
   bool staticAssertMemberOffsets(
-      const std::string &struct_name, struct drgn_type *struct_type,
+      const std::string &struct_name, drgn_type *struct_type,
       std::string &assert_str,
       std::unordered_map<std::string, int> &member_names,
       uint64_t base_offset = 0);
-  bool addStaticAssertsForType(struct drgn_type *type,
-                               bool generateAssertsForOffsets,
+  bool addStaticAssertsForType(drgn_type *type, bool generateAssertsForOffsets,
                                std::string &code);
-  bool buildNameInt(struct drgn_type *type, std::string &nameWithoutTemplate,
+  bool buildNameInt(drgn_type *type, std::string &nameWithoutTemplate,
                     std::string &outName);
   void replaceTemplateOperator(
-      std::vector<std::pair<struct drgn_qualified_type, std::string>>
-          &template_params,
+      std::vector<std::pair<drgn_qualified_type, std::string>> &template_params,
       std::vector<std::string> &template_params_strings, size_t index);
   void replaceTemplateParameters(
-      struct drgn_type *type,
-      std::vector<std::pair<struct drgn_qualified_type, std::string>>
-          &template_params,
+      drgn_type *type,
+      std::vector<std::pair<drgn_qualified_type, std::string>> &template_params,
       std::vector<std::string> &template_params_strings,
       const std::string &nameWithoutTemplate);
 };


### PR DESCRIPTION
## Summary
Just doing some code review on OICodeGen* and picking up bits I see as I go along. It's mostly minor stuff here and is mainly composed of:

- Removing 'struct' keyword from a bunch of declarations - this is C++ and not C.
- Converting a bunch of dragon error handling cases to use if initializer constructs. Just keeps thing a bit cleaner. Also added in calls to drgn_error_destroy() where missing.
- Some heavy string generation for debug is called in the when debugging is not enabled (glog) so blocked it with a VLOG_IS_ON() macro. 
- Also changed pretty much all postfix increments on for loops. It doesn't actually matter but it's generally accepted to use prefix unless there is an explicit reason and I can't see that there are any in these instances.

## Test plan
CI passes all tests.