### PR TITLE
Skipped test cleanup

### DIFF
--- a/test/integration/anonymous.toml
+++ b/test/integration/anonymous.toml
@@ -95,7 +95,7 @@ definitions = '''
       ]}]'''
 
   [cases.anon_struct]
-    oil_skip = "oil can't chase raw pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const AnonStructContainer&"]
     setup = '''
       return AnonStructContainer{
@@ -144,7 +144,7 @@ definitions = '''
     cli_options = ["--chase-raw-pointers"]
 
   [cases.anon_typedef]
-    oil_skip = "oil can't chase raw pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const AnonTypedefContainer&"]
     setup = '''
       return AnonTypedefContainer{
@@ -202,7 +202,7 @@ definitions = '''
     }]'''
 
   [cases.nested_anon_struct]
-    oil_skip = "oil can't chase raw pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const NestedAnonContainer&"]
     setup = 'return NestedAnonContainer{.m = { .v = {.as = {new Node{1, 2, 3}}}}};'
     cli_options = ["--chase-raw-pointers"]

--- a/test/integration/anonymous.toml
+++ b/test/integration/anonymous.toml
@@ -133,7 +133,7 @@ definitions = '''
     }]'''
 
   [cases.anon_struct_ptr]
-    skip = "We don't support pointer to anon-structs yet"
+    skip = "We don't support pointer to anon-structs yet" # https://github.com/facebookexperimental/object-introspection/issues/20
     param_types = ["const AnonStructPtrContainer&"]
     setup = '''
       return AnonStructPtrContainer{

--- a/test/integration/cycles.toml
+++ b/test/integration/cycles.toml
@@ -17,7 +17,7 @@ definitions = '''
 '''
 [cases]
   [cases.raw_ptr]
-    oil_skip = "oil can't chase pointers safely"
+    oil_disable = "oil can't chase pointers safely"
     param_types = ["RawNode*"]
     setup = '''
       RawNode *first  = new RawNode{1, nullptr};

--- a/test/integration/gen_tests.py
+++ b/test/integration/gen_tests.py
@@ -304,6 +304,9 @@ def add_oil_integration_test(f, config, case_name, case):
     case_str = get_case_name(config["suite"], case_name)
     exit_code = case.get("expect_oil_exit_code", 0)
 
+    if case.get("oil_disable", False):
+        return
+
     f.write(
         f"\n"
         f'TEST_F(OilIntegration, {config["suite"]}_{case_name}) {{\n'

--- a/test/integration/ignored.toml
+++ b/test/integration/ignored.toml
@@ -10,7 +10,6 @@ definitions = '''
 
 [cases]
   [cases.a]
-    oil_skip = "OIL doesn't support the 'codegen.ignore' config yet"
     param_types = ["const Bar&"]
     setup = """
       return Bar{

--- a/test/integration/multi_arg.toml
+++ b/test/integration/multi_arg.toml
@@ -20,7 +20,7 @@ definitions = '''
 
   # Test that TreeBuilder failing to run on the first arg doesn't impact the second arg
   [cases.tb_fail_first_arg]
-    oil_skip = "oil doesn't handle invalid strings"
+    oil_disable = "treebuilder tests are oid specific"
     param_types = ["const std::string&", "const NodeA&"]
     args = "arg0,arg1"
     setup = """
@@ -32,7 +32,7 @@ definitions = '''
     expect_json = '[{},{"staticSize":12, "dynamicSize":0}]'
 
   [cases.tb_all_fail_crashes]
-    oil_skip = "oil doesn't handle invalid strings"
+    oil_disable = "treebuilder tests are oid specific"
     param_types = ["const std::string&", "const std::string&"]
     args = "arg0,arg1"
     setup = """

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -14,7 +14,7 @@ definitions = '''
 
 [cases]
   [cases.int]
-    oid_skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["int*"]
     setup = "return new int(1);"
@@ -33,7 +33,7 @@ definitions = '''
       ]
     }]'''
   [cases.int_no_follow]
-    oid_skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["int*"]
     setup = "return new int(1);"
     expect_json = '''[{
@@ -44,7 +44,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.int_null]
-    oid_skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["int*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -57,7 +57,7 @@ definitions = '''
 
 
   [cases.void]
-    oid_skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["void*"]
     setup = "return new int(1);"
@@ -70,7 +70,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.void_no_follow]
-    oid_skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["void*"]
     setup = "return new int(1);"
     expect_json = '''[{
@@ -81,7 +81,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.void_null]
-    oid_skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["void*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -94,7 +94,7 @@ definitions = '''
 
 
   [cases.vector]
-    oid_skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
@@ -113,7 +113,7 @@ definitions = '''
       ]
     }]'''
   [cases.vector_no_follow]
-    oid_skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
     expect_json = '''[{
@@ -124,7 +124,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.vector_null]
-    oid_skip = "BAD DATA SEGMENT!!! top-level pointers are skipped over"
+    oid_skip = "BAD DATA SEGMENT!!! top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["std::vector<int>*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -223,7 +223,7 @@ definitions = '''
         {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}}
       ]}]'''
   [cases.vector_of_pointers_no_follow]
-    oid_skip = "pointer field is missing from results"
+    oid_skip = "pointer field is missing from results" # https://github.com/facebookexperimental/object-introspection/issues/21
     param_types = ["const std::vector<int*>&"]
     setup = "return {{new int(1), nullptr, new int(3)}};"
     expect_json = '''[{

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -15,7 +15,7 @@ definitions = '''
 [cases]
   [cases.int]
     skip = "top-level pointers are skipped over"
-    oil_skip = "oil can't chase pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["int*"]
     setup = "return new int(1);"
     cli_options = ["--chase-raw-pointers"]
@@ -94,7 +94,7 @@ definitions = '''
 
   [cases.vector]
     skip = "top-level pointers are skipped over"
-    oil_skip = "oil can't chase pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
     cli_options = ["--chase-raw-pointers"]
@@ -136,7 +136,7 @@ definitions = '''
 
 
   [cases.struct_primitive_ptrs]
-    oil_skip = "oil can't chase pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const PrimitivePtrs&"]
     setup = "return PrimitivePtrs{0, new int(0), new int(0)};"
     cli_options = ["--chase-raw-pointers"]
@@ -174,7 +174,7 @@ definitions = '''
 
 
   [cases.struct_vector_ptr]
-    oil_skip = "oil can't chase pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const VectorPtr&"]
     setup = "return VectorPtr{new std::vector<int>{1,2,3}};"
     cli_options = ["--chase-raw-pointers"]
@@ -206,7 +206,7 @@ definitions = '''
 
 
   [cases.vector_of_pointers]
-    oil_skip = "oil can't chase pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const std::vector<int*>&"]
     setup = "return {{new int(1), nullptr, new int(3)}};"
     cli_options = ["--chase-raw-pointers"]

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -14,7 +14,7 @@ definitions = '''
 
 [cases]
   [cases.int]
-    skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over"
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["int*"]
     setup = "return new int(1);"
@@ -33,7 +33,7 @@ definitions = '''
       ]
     }]'''
   [cases.int_no_follow]
-    skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over"
     param_types = ["int*"]
     setup = "return new int(1);"
     expect_json = '''[{
@@ -44,7 +44,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.int_null]
-    skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over"
     param_types = ["int*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -57,7 +57,8 @@ definitions = '''
 
 
   [cases.void]
-    skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["void*"]
     setup = "return new int(1);"
     cli_options = ["--chase-raw-pointers"]
@@ -69,7 +70,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.void_no_follow]
-    skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over"
     param_types = ["void*"]
     setup = "return new int(1);"
     expect_json = '''[{
@@ -80,7 +81,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.void_null]
-    skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over"
     param_types = ["void*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -93,7 +94,7 @@ definitions = '''
 
 
   [cases.vector]
-    skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over"
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
@@ -112,7 +113,7 @@ definitions = '''
       ]
     }]'''
   [cases.vector_no_follow]
-    skip = "top-level pointers are skipped over"
+    oid_skip = "top-level pointers are skipped over"
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
     expect_json = '''[{
@@ -123,7 +124,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.vector_null]
-    skip = "BAD DATA SEGMENT!!! top-level pointers are skipped over"
+    oid_skip = "BAD DATA SEGMENT!!! top-level pointers are skipped over"
     param_types = ["std::vector<int>*"]
     setup = "return nullptr;"
     expect_json = '''[{

--- a/test/integration/pointers_function.toml
+++ b/test/integration/pointers_function.toml
@@ -14,7 +14,7 @@ definitions = '''
 
 [cases]
   [cases.raw]
-    oid_skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{myFunction}};"
     expect_json = '''[{
@@ -29,7 +29,7 @@ definitions = '''
       }]
     }]'''
   [cases.raw_chase] # We should never chase function pointers
-    oid_skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{myFunction}};"
@@ -46,7 +46,7 @@ definitions = '''
       }]
     }]'''
   [cases.raw_null]
-    oid_skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{nullptr}};"
     expect_json = '''[{
@@ -62,7 +62,7 @@ definitions = '''
     }]'''
 
   [cases.std_function]
-    oid_skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["std::function<void(int)> &"]
     setup = "return myFunction;"
     expect_json = '''[{
@@ -73,7 +73,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.std_function_chase] # We should never chase function pointers
-    oid_skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["std::function<void(int)> &"]
     setup = "return myFunction;"
@@ -86,7 +86,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.std_function_null]
-    oid_skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["std::function<void(int)> &"]
     setup = "return nullptr;"
     expect_json = '''[{

--- a/test/integration/pointers_function.toml
+++ b/test/integration/pointers_function.toml
@@ -14,7 +14,7 @@ definitions = '''
 
 [cases]
   [cases.raw]
-    skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly"
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{myFunction}};"
     expect_json = '''[{
@@ -29,7 +29,8 @@ definitions = '''
       }]
     }]'''
   [cases.raw_chase] # We should never chase function pointers
-    skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{myFunction}};"
     cli_options = ["--chase-raw-pointers"]
@@ -45,7 +46,7 @@ definitions = '''
       }]
     }]'''
   [cases.raw_null]
-    skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly"
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{nullptr}};"
     expect_json = '''[{
@@ -61,7 +62,7 @@ definitions = '''
     }]'''
 
   [cases.std_function]
-    skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly"
     param_types = ["std::function<void(int)> &"]
     setup = "return myFunction;"
     expect_json = '''[{
@@ -72,7 +73,8 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.std_function_chase] # We should never chase function pointers
-    skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["std::function<void(int)> &"]
     setup = "return myFunction;"
     cli_options = ["--chase-raw-pointers"]
@@ -84,7 +86,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.std_function_null]
-    skip = "function pointers are not handled correctly"
+    oid_skip = "function pointers are not handled correctly"
     param_types = ["std::function<void(int)> &"]
     setup = "return nullptr;"
     expect_json = '''[{

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -19,7 +19,8 @@ definitions = '''
 '''
 [cases]
   [cases.raw]
-    skip = "codegen fails on this"
+    oil_disable = "oil can't chase raw pointers safely"
+    oid_skip = "oid codegen fails on this"
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
     cli_options = ["--chase-raw-pointers"]
@@ -31,7 +32,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.raw_no_follow]
-    skip = "codegen fails on this"
+    oid_skip = "oid codegen fails on this"
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
     expect_json = '''[{
@@ -42,7 +43,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.raw_null]
-    skip = "codegen fails on this"
+    oid_skip = "oid codegen fails on this"
     param_types = ["IncompleteType*"]
     setup = "return nullptr;"
     expect_json = '''[{

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -82,7 +82,7 @@ definitions = '''
     expect_json = '[{"staticSize":16, "dynamicSize":0, "NOT":"members"}]'
 
   [cases.containing_struct]
-    oil_skip = "oil can't chase pointers safely"
+    oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const IncompleteTypeContainer&"]
     setup = "return IncompleteTypeContainer{};"
     cli_options = ["--chase-raw-pointers"]

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -20,7 +20,7 @@ definitions = '''
 [cases]
   [cases.raw]
     oil_disable = "oil can't chase raw pointers safely"
-    oid_skip = "oid codegen fails on this"
+    oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
     cli_options = ["--chase-raw-pointers"]
@@ -32,7 +32,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.raw_no_follow]
-    oid_skip = "oid codegen fails on this"
+    oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
     expect_json = '''[{
@@ -43,7 +43,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.raw_null]
-    oid_skip = "oid codegen fails on this"
+    oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
     param_types = ["IncompleteType*"]
     setup = "return nullptr;"
     expect_json = '''[{

--- a/test/integration/references.toml
+++ b/test/integration/references.toml
@@ -9,7 +9,7 @@ definitions = '''
 '''
 [cases]
   [cases.int_ref]
-    skip = "references are being treated as raw pointers"
+    skip = "references are being treated as raw pointers" # https://github.com/facebookexperimental/object-introspection/issues/16
     param_types = ["const IntRef&"]
     setup = "return {{*new int(1)}};"
     expect_json = '''[{
@@ -24,7 +24,7 @@ definitions = '''
         }
       ]}]'''
   [cases.vector_ref]
-    skip = "references are being treated as raw pointers"
+    skip = "references are being treated as raw pointers" # https://github.com/facebookexperimental/object-introspection/issues/16
     param_types = ["const VectorRef&"]
     setup = "return {{*new std::vector<int>{1,2,3}}};"
     expect_json = '''[{

--- a/test/integration/std_smart_ptr.toml
+++ b/test/integration/std_smart_ptr.toml
@@ -80,14 +80,13 @@ definitions = '''
     ]
     '''
   [cases.unique_ptr_void_present]
-    skip = "we don't report the dynamic size"
     param_types = ["std::unique_ptr<void, decltype(&void_int_deleter)>&"]
     setup = "return {std::unique_ptr<void, decltype(&void_int_deleter)>(new int, &void_int_deleter)};"
     expect_json = '''
     [
       {
         "staticSize": 16,
-        "dynamicSize": 8
+        "dynamicSize": 0
       }
     ]
     '''
@@ -165,14 +164,13 @@ definitions = '''
     ]
     '''
   [cases.shared_ptr_void_present]
-    skip = "we don't report the dynamic size"
     param_types = ["std::shared_ptr<void>&"]
     setup = "return {std::shared_ptr<void>(new int)};"
     expect_json = '''
     [
       {
         "staticSize": 16,
-        "dynamicSize": 8
+        "dynamicSize": 0
       }
     ]
     '''

--- a/test/integration/std_unordered_map.toml
+++ b/test/integration/std_unordered_map.toml
@@ -1,7 +1,7 @@
 includes = ["unordered_map"]
 [cases]
   [cases.int_int]
-    skip = true
+    skip = true # https://github.com/facebookexperimental/object-introspection/issues/15
     param_types = ["const std::unordered_map<int, int>&"]
     setup = "return {{{1,2},{3,4}}};"
     # TODO confirm this JSON is correct

--- a/test/integration/std_vector.toml
+++ b/test/integration/std_vector.toml
@@ -9,12 +9,12 @@ includes = ["vector"]
     setup = "return {{1,2,3}};"
     expect_json = '[{"staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4}]'
   [cases.bool_empty]
-    skip = true
+    skip = true # https://github.com/facebookexperimental/object-introspection/issues/14
     param_types = ["const std::vector<bool>&"]
     setup = "return {};"
     expect_json = '[{"staticSize":40, "dynamicSize":0, "length":0, "capacity":0, "elementStaticSize":0.125}]'
   [cases.bool_some]
-    skip = true
+    skip = true # https://github.com/facebookexperimental/object-introspection/issues/14
     param_types = ["const std::vector<bool>&"]
     setup = "return {{true, false, true}};"
     expect_json = '[{"staticSize":40,"dynamicSize":8, "length":3, "capacity":64, "elementStaticSize":0.125}]'


### PR DESCRIPTION
## Summary

This change better documents and tracks our skipped tests.

- Add `oil_disable` and `oid_disable` for cases where a test only makes sense for one part of the software. Specifically, any test with `--chase-raw-pointers` can be `oil_disable` as it will never make sense under OIL - it is not a bug like a skipped test.
- Enable void smart pointer present tests.
  - These tests were disabled as they don't track the dynamic size. However, I don't think there is a dynamic size as the void pointer could contain an object of any size and we have no way of knowing it. Therefore, treat the current behaviour of reporting the dynamic size as 0 as correct.
- There are a set of tests in `pointers_incomplete` that codegen under OIL but not OID. Replace the general `skip` with an `oid_skip` to account for this.
- Similarly, top level pointers are skipped over in OID but this isn't an issue in OIL. Replace `skip` with `oid_skip`.
- A field ignore test was `oil_skip`ped as it didn't support it. Enabling the test suggests that it does.
- As OIL gives less rich data, the tests in `pointers_function` pass under it while failing under OID. Enable the OIL tests where appropriate.
- Document every test that remains skipped with a GitHub issue for tracking and discussion, linked to from the code.

Overall, this brings the number of skipped tests down from 63 to 31.

## Test plan

- `make test-devel`
- CI.
