### PR TITLE
remove setcap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,19 +35,6 @@ endif()
 ## System checks
 ## These checks are potentially fatal so perform them first.
 
-### Require sudo and setcap (for setting oid capabilities)
-find_program(SETCAP setcap)
-if(NOT SETCAP)
-  message(FATAL_ERROR "setcap not found - please install")
-endif()
-
-if(NOT EXISTS "/etc/centos-release")
-  find_program(SUDO sudo)
-  if(NOT SUDO)
-    message(FATAL_ERROR "sudo not found - please install")
-  endif()
-endif()
-
 ### (Re)download submodules
 find_package(Git QUIET)
 
@@ -335,10 +322,6 @@ else()
   target_link_libraries(oid gflags_shared)
 endif()
 target_link_libraries(oid oicore treebuilder)
-
-add_custom_command(TARGET oid POST_BUILD
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMAND sudo setcap cap_sys_ptrace+ep ./oid)
 
 ### Object Introspection Tests
 if (WITH_TESTS)


### PR DESCRIPTION
## Summary

This change removes the post build `sudo setcap` step on oid. This enables building in environments which don't have root (e.g. constrained build environments such as `nix`).

## Test plan

- I ran `mttest2` as my user then ran `oid` against it, and it worked fine.
- The version of `mttest2` running as `root` did not attach unless I used `sudo`.
- The version we use in production doesn't have this capability.
- `make clean && make test-devel`
