### PR TITLE
Stop over optimising drgn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,9 +182,6 @@ set(DRGN_CONFIGURE_FLAGS "--with-libkdumpfile=no")
 if (ASAN)
   list(APPEND DRGN_CONFIGURE_FLAGS "--enable-asan=yes")
 endif()
-# We always compile drgn with aggressive optimizations because it is
-# responsible for most of the time OID takes to generate caches.
-set(DRGN_CFLAGS "-O3" "-march=broadwell")
 add_custom_target(libdrgn ALL
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/extern/drgn
   COMMAND unset BISON_PKGDATADIR && CC=gcc CFLAGS="${DRGN_CFLAGS}" CONFIGURE_FLAGS="${DRGN_CONFIGURE_FLAGS}" ${PYTHON} ./setup.py build --build-temp build


### PR DESCRIPTION
## Summary

We currently forcibly build `drgn` with `-march=broadwell` and `-O3`. The architecture is particularly bad as it stops us building on more limited architectures, such as a no additional features x86_64 VM. Remove the optimisations too as this should be protected behind a flag and we have a different optimised internal build anyway.

Closes #24 

## Test plan

- `make clean && make test-devel`
- CI
