### PR TITLE
integration/primitives.toml: Add char8_t test

### DIFF
--- a/src/OICompiler.cpp
+++ b/src/OICompiler.cpp
@@ -471,6 +471,7 @@ bool OICompiler::compile(const std::string &code, const fs::path &sourcePath,
   compInv->getLangOpts()->GNUCVersion = 11 * 100 * 100;  // 11.0.0
   compInv->getLangOpts()->Bool = true;
   compInv->getLangOpts()->WChar = true;
+  compInv->getLangOpts()->Char8 = true;
   compInv->getLangOpts()->CXXOperatorNames = true;
   compInv->getLangOpts()->DoubleSquareBracketAttributes = true;
   compInv->getLangOpts()->ImplicitInt = false;

--- a/test/integration/primitives.toml
+++ b/test/integration/primitives.toml
@@ -51,6 +51,10 @@
     param_types = ["wchar_t"]
     setup = "return 'a';"
     expect_json = '[{"staticSize":4, "dynamicSize":0}]'
+  [cases.char8_t]
+    param_types = ["char8_t"]
+    setup = "return 'a';"
+    expect_json = '[{"staticSize":1, "dynamicSize":0}]'
   [cases.char16_t]
     param_types = ["char16_t"]
     setup = "return 'a';"


### PR DESCRIPTION
This is a distinct primitive type according to https://en.cppreference.com/w/cpp/language/types
Now all primitive types are tested.