### PR TITLE
oilgen: set DRGN_ENABLE_TYPE_ITERATOR

### DIFF
--- a/tools/OILGen.cpp
+++ b/tools/OILGen.cpp
@@ -16,6 +16,7 @@
 
 #include <glog/logging.h>
 
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 
@@ -76,6 +77,12 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
   fs::path primaryObject = argv[optind];
+
+  if ((setenv("DRGN_ENABLE_TYPE_ITERATOR", "1", 1)) < 0) {
+    std::cerr << "Failed to set environment variable\
+       DRGN_ENABLE_TYPE_ITERATOR\n";
+    exit(EXIT_FAILURE);
+  }
 
   OIGenerator oigen;
 


### PR DESCRIPTION
## Summary

`oilgen` always uses drgn type iterators but doesn't enable them by itself. Change this so an external environment variable doesn't have to be set.

## Test plan

- `make test-devel`
- CI
