### PR TITLE
Support std::multimap with comparator template parameter

### DIFF
--- a/src/OIDebugger.cpp
+++ b/src/OIDebugger.cpp
@@ -1951,7 +1951,7 @@ OIDebugger::OIDebugger(fs::path debugInfo, std::string configFile,
  */
 bool OIDebugger::writeTargetMemory(void *local_buffer, void *target_addr,
                                    size_t bufsz) const {
-  VLOG(1) << "Writting buffer " << std::hex << local_buffer << ", bufsz "
+  VLOG(1) << "Writing buffer " << std::hex << local_buffer << ", bufsz "
           << std::dec << bufsz << " into target " << std::hex << target_addr;
 
   struct iovec liovecs[] = {{

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -19,6 +19,7 @@ set(INTEGRATION_TEST_CONFIGS
   std_list_del_allocator.toml
   std_deque.toml
   std_map_custom_comparator.toml
+  std_multimap_custom_comparator.toml
   std_optional.toml
   std_pair.toml
   std_queue.toml

--- a/test/integration/std_multimap_custom_comparator.toml
+++ b/test/integration/std_multimap_custom_comparator.toml
@@ -1,0 +1,37 @@
+definitions = '''
+  struct CustomComparator {
+    bool operator()(const int& left, const int& right) const {
+      return left < right;
+    }
+  };
+
+  struct Foo {
+    std::multimap<int, int> m1;
+    std::multimap<int, int, CustomComparator> m2;
+  };
+'''
+includes = ["map"]
+
+[cases]
+  [cases.a]
+    param_types = ["const Foo&"]
+    setup = '''
+      Foo foo;
+
+      for (int i = 0; i < 3; i++) {
+        foo.m1.insert(std::pair<int, int>(i,i));
+      }
+
+      for (int i = 0; i < 5; i++) {
+        foo.m2.insert(std::pair<int, int>(i,i));
+      }
+
+      return {foo};
+    '''
+    expect_json = '''[{
+      "staticSize":96,
+      "dynamicSize":64,
+      "members":[
+        {"name":"m1", "staticSize":48, "dynamicSize":24, "length":3, "capacity":3, "elementStaticSize":8},
+        {"name":"m2", "staticSize":48, "dynamicSize":40, "length":5, "capacity":5, "elementStaticSize":8}
+      ]}]'''

--- a/types/multi_map_type.toml
+++ b/types/multi_map_type.toml
@@ -4,9 +4,8 @@ numTemplateParams = 2
 ctype = "MULTI_MAP_TYPE"
 header = "map"
 ns = ["namespace std"]
-replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
+replaceTemplateParamIndex = [2]
+allocatorIndex = 3
 
 [codegen]
 decl = """


### PR DESCRIPTION
## Summary
A std::multimap which provides a comparator template parameter caused oid to have a number of issues which resulted in failure to codegen (static_asserts in stl headers mainly). This change to the multipmap type definition simply aligns it with the std::map definition by substituting a custom definition for the provided template parameters via config.

## Test plan
I've added a multimap test that provides a comparator. No other test failures occur with this change.
