### PR TITLE
Oil interface cleanup

### DIFF
--- a/examples/compile-time-oil/OilVectorOfStrings.cpp
+++ b/examples/compile-time-oil/OilVectorOfStrings.cpp
@@ -32,7 +32,7 @@ int main() {
   foo.strings.push_back("consectetur adipiscing elit,");
 
   size_t size = -1;
-  int ret = ObjectIntrospection::getObjectSize<Foo>(&foo, &size);
+  int ret = ObjectIntrospection::getObjectSize(foo, size);
 
   std::cout << "oil returned: " << ret << "; with size: " << size << std::endl;
 }

--- a/include/ObjectIntrospection.h
+++ b/include/ObjectIntrospection.h
@@ -79,6 +79,8 @@ enum Response : int {
   OIL_UNINITIALISED = 7,
 };
 
+#ifndef OIL_AOT_COMPILATION
+
 struct options {
   std::string configFilePath{};
   std::string debugFilePath{};
@@ -233,6 +235,8 @@ int getObjectSize(T *ObjectAddr, size_t *ObjectSize, const options &opts,
   return CodegenHandler<T>::getObjectSize(ObjectAddr, ObjectSize, opts,
                                           checkOptions);
 }
+
+#endif
 
 /*
  * You may only call this after a call to the previous signature, or a

--- a/include/ObjectIntrospection.h
+++ b/include/ObjectIntrospection.h
@@ -118,7 +118,7 @@ class OILibrary {
  private:
   class OILibraryImpl *pimpl_;
 
-  size_t (*fp)(void *) = nullptr;
+  size_t (*fp)(const void *) = nullptr;
 };
 
 template <class T>
@@ -141,7 +141,7 @@ class CodegenHandler {
     delete lib;
   }
 
-  static int getObjectSize(T &ObjectAddr, size_t &ObjectSize) {
+  static int getObjectSize(const T &ObjectAddr, size_t &ObjectSize) {
     OILibrary *lib;
     if (int responseCode = getLibrary(lib);
         responseCode != Response::OIL_SUCCESS) {
@@ -151,7 +151,7 @@ class CodegenHandler {
     return lib->getObjectSize((void *)&ObjectAddr, ObjectSize);
   }
 
-  static int getObjectSize(T &ObjectAddr, size_t &ObjectSize,
+  static int getObjectSize(const T &ObjectAddr, size_t &ObjectSize,
                            const options &opts, bool checkOptions = true) {
     OILibrary *lib;
     if (int responseCode = getLibrary(lib, opts, checkOptions);
@@ -196,7 +196,7 @@ class CodegenHandler {
       }
       curBoxedLib = getLib();
 
-      int (*sizeFp)(T &, size_t &) = &getObjectSize;
+      int (*sizeFp)(const T &, size_t &) = &getObjectSize;
       void *typedFp = reinterpret_cast<void *>(sizeFp);
       OILibrary *newLib = new OILibrary(typedFp, opts);
 
@@ -230,7 +230,7 @@ class CodegenHandler {
  * Ahead-Of-Time (AOT) compilation.
  */
 template <class T>
-int getObjectSize(T &ObjectAddr, size_t &ObjectSize, const options &opts,
+int getObjectSize(const T &ObjectAddr, size_t &ObjectSize, const options &opts,
                   bool checkOptions = true) {
   return CodegenHandler<T>::getObjectSize(ObjectAddr, ObjectSize, opts,
                                           checkOptions);
@@ -248,7 +248,8 @@ int getObjectSize(T &ObjectAddr, size_t &ObjectSize, const options &opts,
  * production system.
  */
 template <class T>
-int __attribute__((weak)) getObjectSize(T &ObjectAddr, size_t &ObjectSize) {
+int __attribute__((weak))
+getObjectSize(const T &ObjectAddr, size_t &ObjectSize) {
 #ifdef OIL_AOT_COMPILATION
   return Response::OIL_UNINITIALISED;
 #else

--- a/include/ObjectIntrospection.h
+++ b/include/ObjectIntrospection.h
@@ -38,7 +38,7 @@
  * -- SINGLE-THREADED
  * ObjectIntrospection::options opts = { .configFilePath = "sample.oid.toml" };
  * size_t size;
- * int responseCode = ObjectIntrospection::getObjectSize(&obj, &size, opts);
+ * int responseCode = ObjectIntrospection::getObjectSize(obj, size, opts);
  * if (responseCode != ObjectIntrospection::Response::OIL_SUCCESS) {
  *   // handle error
  * }
@@ -46,7 +46,7 @@
  * -- MULTI-THREADED (NO SETUP)
  * ObjectIntrospection::options opts = { .configFilePath = "sample.oid.toml" };
  * size_t size;
- * int responseCode = ObjectIntrospection::getObjectSize(&obj, &size, opts);
+ * int responseCode = ObjectIntrospection::getObjectSize(obj, size, opts);
  * if (responseCode > ObjectIntrospection::Response::OIL_INITIALISING) {
  *   // handle error
  * } else if (responseCode == ObjectIntrospection::Response::OIL_SUCCESS) {
@@ -60,7 +60,7 @@
  *   // handle error
  * }
  * size_t size;
- * int responseCode = ObjectIntrospection::getObjectSize(&obj, &size);
+ * int responseCode = ObjectIntrospection::getObjectSize(obj, size);
  * if (responseCode == ObjectIntrospection::Response::OIL_UNINITIALISED) {
  *   // handle error - impossible if successfully inited
  * }
@@ -111,7 +111,7 @@ class OILibrary {
   OILibrary(void *TemplateFunc, options opt);
   ~OILibrary();
   int init();
-  int getObjectSize(void *ObjectAddr, size_t *size);
+  int getObjectSize(void *ObjectAddr, size_t &size);
 
   options opts;
 
@@ -141,17 +141,17 @@ class CodegenHandler {
     delete lib;
   }
 
-  static int getObjectSize(T *ObjectAddr, size_t *ObjectSize) {
+  static int getObjectSize(T &ObjectAddr, size_t &ObjectSize) {
     OILibrary *lib;
     if (int responseCode = getLibrary(lib);
         responseCode != Response::OIL_SUCCESS) {
       return responseCode;
     }
 
-    return lib->getObjectSize((void *)ObjectAddr, ObjectSize);
+    return lib->getObjectSize((void *)&ObjectAddr, ObjectSize);
   }
 
-  static int getObjectSize(T *ObjectAddr, size_t *ObjectSize,
+  static int getObjectSize(T &ObjectAddr, size_t &ObjectSize,
                            const options &opts, bool checkOptions = true) {
     OILibrary *lib;
     if (int responseCode = getLibrary(lib, opts, checkOptions);
@@ -159,7 +159,7 @@ class CodegenHandler {
       return responseCode;
     }
 
-    return lib->getObjectSize((void *)ObjectAddr, ObjectSize);
+    return lib->getObjectSize((void *)&ObjectAddr, ObjectSize);
   }
 
  private:
@@ -196,7 +196,7 @@ class CodegenHandler {
       }
       curBoxedLib = getLib();
 
-      int (*sizeFp)(T *, size_t *) = &getObjectSize;
+      int (*sizeFp)(T &, size_t &) = &getObjectSize;
       void *typedFp = reinterpret_cast<void *>(sizeFp);
       OILibrary *newLib = new OILibrary(typedFp, opts);
 
@@ -230,7 +230,7 @@ class CodegenHandler {
  * Ahead-Of-Time (AOT) compilation.
  */
 template <class T>
-int getObjectSize(T *ObjectAddr, size_t *ObjectSize, const options &opts,
+int getObjectSize(T &ObjectAddr, size_t &ObjectSize, const options &opts,
                   bool checkOptions = true) {
   return CodegenHandler<T>::getObjectSize(ObjectAddr, ObjectSize, opts,
                                           checkOptions);
@@ -248,7 +248,7 @@ int getObjectSize(T *ObjectAddr, size_t *ObjectSize, const options &opts,
  * production system.
  */
 template <class T>
-int __attribute__((weak)) getObjectSize(T *ObjectAddr, size_t *ObjectSize) {
+int __attribute__((weak)) getObjectSize(T &ObjectAddr, size_t &ObjectSize) {
 #ifdef OIL_AOT_COMPILATION
   return Response::OIL_UNINITIALISED;
 #else

--- a/src/FuncGen.cpp
+++ b/src/FuncGen.cpp
@@ -267,6 +267,28 @@ void FuncGen::DefineTopLevelGetSizeRef(std::string& testCode,
   testCode.append(fmt.str());
 }
 
+void FuncGen::DefineTopLevelGetSizeRefRet(std::string& testCode,
+                                          const std::string& rawType) {
+  std::string func = R"(
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunknown-attributes"
+    /* Raw Type: %1% */
+    size_t __attribute__((used, retain)) getSize(const OIInternal::__ROOT_TYPE__& t)
+    #pragma GCC diagnostic pop
+    {
+      pointers.initialize();
+      size_t ret = 0;
+      pointers.add((uintptr_t)&t);
+      SAVE_DATA((uintptr_t)t);
+      OIInternal::getSizeType(t, ret);
+      return ret;
+    }
+    )";
+
+  boost::format fmt = boost::format(func) % rawType;
+  testCode.append(fmt.str());
+}
+
 void FuncGen::DefineTopLevelGetSizePtr(std::string& testCode,
                                        const std::string& type,
                                        const std::string& rawType) {
@@ -296,28 +318,6 @@ void FuncGen::DefineTopLevelGetSizePtr(std::string& testCode,
 
   boost::format fmt =
       boost::format(func) % type % rawType % std::hash<std::string>{}(rawType);
-  testCode.append(fmt.str());
-}
-
-void FuncGen::DefineTopLevelGetSizePtrRet(std::string& testCode,
-                                          const std::string& rawType) {
-  std::string func = R"(
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wunknown-attributes"
-    /* Raw Type: %1% */
-    size_t __attribute__((used, retain)) getSize(const OIInternal::__ROOT_TYPE__* t)
-    #pragma GCC diagnostic pop
-    {
-      pointers.initialize();
-      size_t ret = 0;
-      pointers.add((uintptr_t)t);
-      SAVE_DATA((uintptr_t)t);
-      OIInternal::getSizeType(*t, ret);
-      return ret;
-    }
-    )";
-
-  boost::format fmt = boost::format(func) % rawType;
   testCode.append(fmt.str());
 }
 

--- a/src/FuncGen.h
+++ b/src/FuncGen.h
@@ -61,7 +61,7 @@ class FuncGen {
   void DefineTopLevelGetSizeRef(std::string& testCode,
                                 const std::string& rawType);
 
-  void DefineTopLevelGetSizePtrRet(std::string& testCode,
+  void DefineTopLevelGetSizeRefRet(std::string& testCode,
                                    const std::string& type);
 
   void DefineTopLevelGetSizeSmartPtr(std::string& testCode,

--- a/src/OICodeGen.cpp
+++ b/src/OICodeGen.cpp
@@ -3200,7 +3200,7 @@ bool OICodeGen::generateJitCode(std::string &code) {
       }
     } else {
       if (linkageName.empty()) {
-        funcGen.DefineTopLevelGetSizePtrRet(functionsCode, rawTypeName);
+        funcGen.DefineTopLevelGetSizeRefRet(functionsCode, rawTypeName);
       } else {
         funcGen.DefineTopLevelGetObjectSize(functionsCode, rawTypeName,
                                             linkageName);

--- a/src/OILibrary.cpp
+++ b/src/OILibrary.cpp
@@ -52,12 +52,12 @@ int OILibrary::init() {
   return pimpl_->compileCode();
 }
 
-int OILibrary::getObjectSize(void* ObjectAddr, size_t* size) {
+int OILibrary::getObjectSize(void* ObjectAddr, size_t& size) {
   if (fp == nullptr) {
     return Response::OIL_UNINITIALISED;
   }
 
-  *size = (*fp)(ObjectAddr);
+  size = (*fp)(ObjectAddr);
   return Response::OIL_SUCCESS;
 }
 }  // namespace ObjectIntrospection

--- a/src/OILibraryImpl.cpp
+++ b/src/OILibraryImpl.cpp
@@ -281,7 +281,7 @@ int OILibraryImpl::compileCode() {
   _self->fp = nullptr;
   for (const auto &[symName, symAddr] : jitSymbols) {
     if (symName.starts_with("_Z7getSize")) {
-      _self->fp = (size_t(*)(void *))symAddr;
+      _self->fp = (size_t(*)(const void *))symAddr;
       break;
     }
   }

--- a/test/integration/gen_tests.py
+++ b/test/integration/gen_tests.py
@@ -121,7 +121,7 @@ def add_test_setup(f, config):
         oil_func_body += '    std::cout << "{\\"results\\": [" << std::endl;\n'
         oil_func_body += '    std::cout << "," << std::endl;\n'.join(
             f"    size_t size{i} = 0;\n"
-            f"    auto ret{i} = ObjectIntrospection::getObjectSize(&a{i}, &size{i}, opts);\n"
+            f"    auto ret{i} = ObjectIntrospection::getObjectSize(a{i}, size{i}, opts);\n"
             f'    std::cout << "{{\\"ret\\": " << ret{i} << ", \\"size\\": " << size{i} << "}}" << std::endl;\n'
             for i in range(len(case["param_types"]))
         )


### PR DESCRIPTION
## Summary

Make a couple of changes to the OIL interface.
- `#ifdef` away the JIT functions which you shouldn't call in compile time mode. They wouldn't work with the header only library (linker failures) but this avoids confusion.
- Change from pointers to references. This is a major change to the API, but they shouldn't have been pointers in the first place as they're always expected to be valid. Bite the bullet now and swap them before we have major consumers.

## Test plan

- CI
- `make test-devel` after each commit
- Manually checked the compile time example after each commit
