### PR TITLE
OIL gentests top level pointers

### DIFF
--- a/examples/compile-time-oil/OilVectorOfStrings.cpp
+++ b/examples/compile-time-oil/OilVectorOfStrings.cpp
@@ -32,7 +32,7 @@ int main() {
   foo.strings.push_back("consectetur adipiscing elit,");
 
   size_t size = -1;
-  int ret = ObjectIntrospection::getObjectSize<Foo>(&foo, &size);
+  int ret = ObjectIntrospection::getObjectSize(foo, size);
 
   std::cout << "oil returned: " << ret << "; with size: " << size << std::endl;
 }

--- a/include/ObjectIntrospection.h
+++ b/include/ObjectIntrospection.h
@@ -79,6 +79,8 @@ enum Response : int {
   OIL_UNINITIALISED = 7,
 };
 
+#ifndef OIL_AOT_COMPILATION
+
 struct options {
   std::string configFilePath{};
   std::string debugFilePath{};
@@ -233,6 +235,8 @@ int getObjectSize(T *ObjectAddr, size_t *ObjectSize, const options &opts,
   return CodegenHandler<T>::getObjectSize(ObjectAddr, ObjectSize, opts,
                                           checkOptions);
 }
+
+#endif
 
 /*
  * You may only call this after a call to the previous signature, or a

--- a/include/ObjectIntrospection.h
+++ b/include/ObjectIntrospection.h
@@ -111,7 +111,7 @@ class OILibrary {
   OILibrary(void *TemplateFunc, options opt);
   ~OILibrary();
   int init();
-  int getObjectSize(void *ObjectAddr, size_t *size);
+  int getObjectSize(void *ObjectAddr, size_t &size);
 
   options opts;
 
@@ -141,17 +141,17 @@ class CodegenHandler {
     delete lib;
   }
 
-  static int getObjectSize(T *ObjectAddr, size_t *ObjectSize) {
+  static int getObjectSize(T &ObjectAddr, size_t &ObjectSize) {
     OILibrary *lib;
     if (int responseCode = getLibrary(lib);
         responseCode != Response::OIL_SUCCESS) {
       return responseCode;
     }
 
-    return lib->getObjectSize((void *)ObjectAddr, ObjectSize);
+    return lib->getObjectSize((void *)&ObjectAddr, ObjectSize);
   }
 
-  static int getObjectSize(T *ObjectAddr, size_t *ObjectSize,
+  static int getObjectSize(T &ObjectAddr, size_t &ObjectSize,
                            const options &opts, bool checkOptions = true) {
     OILibrary *lib;
     if (int responseCode = getLibrary(lib, opts, checkOptions);
@@ -159,7 +159,7 @@ class CodegenHandler {
       return responseCode;
     }
 
-    return lib->getObjectSize((void *)ObjectAddr, ObjectSize);
+    return lib->getObjectSize((void *)&ObjectAddr, ObjectSize);
   }
 
  private:
@@ -196,7 +196,7 @@ class CodegenHandler {
       }
       curBoxedLib = getLib();
 
-      int (*sizeFp)(T *, size_t *) = &getObjectSize;
+      int (*sizeFp)(T &, size_t &) = &getObjectSize;
       void *typedFp = reinterpret_cast<void *>(sizeFp);
       OILibrary *newLib = new OILibrary(typedFp, opts);
 
@@ -230,7 +230,7 @@ class CodegenHandler {
  * Ahead-Of-Time (AOT) compilation.
  */
 template <class T>
-int getObjectSize(T *ObjectAddr, size_t *ObjectSize, const options &opts,
+int getObjectSize(T &ObjectAddr, size_t &ObjectSize, const options &opts,
                   bool checkOptions = true) {
   return CodegenHandler<T>::getObjectSize(ObjectAddr, ObjectSize, opts,
                                           checkOptions);
@@ -248,7 +248,7 @@ int getObjectSize(T *ObjectAddr, size_t *ObjectSize, const options &opts,
  * production system.
  */
 template <class T>
-int __attribute__((weak)) getObjectSize(T *ObjectAddr, size_t *ObjectSize) {
+int __attribute__((weak)) getObjectSize(T &ObjectAddr, size_t &ObjectSize) {
 #ifdef OIL_AOT_COMPILATION
   return Response::OIL_UNINITIALISED;
 #else

--- a/src/OILibrary.cpp
+++ b/src/OILibrary.cpp
@@ -52,12 +52,12 @@ int OILibrary::init() {
   return pimpl_->compileCode();
 }
 
-int OILibrary::getObjectSize(void* ObjectAddr, size_t* size) {
+int OILibrary::getObjectSize(void* ObjectAddr, size_t& size) {
   if (fp == nullptr) {
     return Response::OIL_UNINITIALISED;
   }
 
-  *size = (*fp)(ObjectAddr);
+  size = (*fp)(ObjectAddr);
   return Response::OIL_SUCCESS;
 }
 }  // namespace ObjectIntrospection

--- a/test/integration/gen_tests.py
+++ b/test/integration/gen_tests.py
@@ -121,7 +121,7 @@ def add_test_setup(f, config):
         oil_func_body += '    std::cout << "{\\"results\\": [" << std::endl;\n'
         oil_func_body += '    std::cout << "," << std::endl;\n'.join(
             f"    size_t size{i} = 0;\n"
-            f"    auto ret{i} = ObjectIntrospection::getObjectSize(&a{i}, &size{i}, opts);\n"
+            f"    auto ret{i} = ObjectIntrospection::getObjectSize(a{i}, size{i}, opts);\n"
             f'    std::cout << "{{\\"ret\\": " << ret{i} << ", \\"size\\": " << size{i} << "}}" << std::endl;\n'
             for i in range(len(case["param_types"]))
         )

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -19,8 +19,8 @@ definitions = '''
 '''
 [cases]
   [cases.raw]
-    oil_disable = "oil can't chase raw pointers safely"
     oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    oil_disable = "this is equivalent to a void pointer which can't be converted to a reference"
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
     cli_options = ["--chase-raw-pointers"]
@@ -33,6 +33,7 @@ definitions = '''
     }]'''
   [cases.raw_no_follow]
     oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    oil_disable = "this is equivalent to a void pointer which can't be converted to a reference"
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
     expect_json = '''[{
@@ -44,6 +45,7 @@ definitions = '''
     }]'''
   [cases.raw_null]
     oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    oil_disable = "this is equivalent to a void pointer which can't be converted to a reference"
     param_types = ["IncompleteType*"]
     setup = "return nullptr;"
     expect_json = '''[{


### PR DESCRIPTION
## Summary

Allow top level pointers in the generated OIL tests. This is a bit of an RFC as it has some shortcomings. Notably this is much harder to do with the references - because both paths of the constexpr must compile unless it's in a generic function it had to be extracted, whereas in the previous implementation an additional pointer layer was fine but wouldn't return much.

As the CI should show this breaks as many tests as it fixes. The change from references to pointers (*&) to references (&) breaks the previous compatibility with no follow tests as the top level reference is deliberately ignored, whereas the previous (** / *&) included one.

## Test plan

It's not.
