### PR TITLE
Code Coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ workflows:
           name: test-gcc
           requires:
             - build-gcc
+      - coverage:
+          requires:
+            - test-gcc
 
       - build:
           name: build-clang
@@ -72,6 +75,8 @@ jobs:
     environment:
       CC: << parameters.cc >>
       CXX: << parameters.cxx >>
+    working_directory:
+      /tmp/object-introspection
     steps:
       - run:
           name: Install dependencies
@@ -110,7 +115,7 @@ jobs:
       - run:
           name: Build
           command: |
-            cmake -G Ninja -B build/ -DWITH_TESTS=On
+            cmake -G Ninja -B build/ -DWITH_TESTS=On -DCODE_COVERAGE=On
             cmake --build build/
             # Testing rubbish:
             cp test/ci.oid.toml build/testing.oid.toml
@@ -123,6 +128,8 @@ jobs:
 
   test:
     executor: big-boy
+    working_directory:
+      /tmp/object-introspection
     steps:
       - attach_workspace:
           at: .
@@ -147,3 +154,50 @@ jobs:
               --output-junit results.xml
       - store_test_results:
           path: build/test/results.xml
+      - persist_to_workspace:
+          # Save code coverage data
+          root: .
+          paths:
+            - build/*
+
+  coverage:
+    executor: ubuntu-docker
+    working_directory:
+      /tmp/object-introspection
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt-get update
+            apt-get install -y \
+              curl \
+              git \
+              gpg \
+              lcov
+      - attach_workspace:
+          at: .
+      - run:
+          name: Code Coverage
+          when: always
+          command: |
+            lcov --directory . --capture --rc lcov_branch_coverage=1 --output-file coverage.info
+            lcov --extract coverage.info '/tmp/object-introspection/src/*' '/tmp/object-introspection/include/*' --rc lcov_branch_coverage=1 --output-file coverage.info
+            lcov --list --rc lcov_branch_coverage=1 coverage.info
+
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+
+            # It appears that codecov wants to scan through all directories
+            # other than "build", looking for files to upload, even if we
+            # specify a file name on the command line.
+            #
+            # "extern" is huge and makes uploading the coverage report take
+            # forever. Delete it for a speedup.
+            rm -rf extern
+
+            ./codecov -Z -f coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ include(cmake/CompilerWarnings.cmake)
 
 option(STATIC_LINK "Statically link oid" OFF)
 option(ASAN "Enable address sanitizer" OFF)
+option(CODE_COVERAGE "Enable code coverage" OFF)
 option(WITH_TESTS "Build with tests" Off)
 option(FORCE_BOOST_STATIC "Build with static boost" On)
 option(FORCE_LLVM_STATIC "Build with static llvm and clang" On)
@@ -28,6 +29,11 @@ option(FORCE_LLVM_STATIC "Build with static llvm and clang" On)
 if (ASAN)
   add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
   add_link_options(-fsanitize=address)
+endif()
+
+if (CODE_COVERAGE)
+  add_compile_options(--coverage)
+  add_link_options(--coverage)
 endif()
 
 


### PR DESCRIPTION
    CI: Add code coverage reporting
    
    Add CODE_COVERAGE option to enable coverage instrumentation in builds.
    
    Add new CI job to upload coverage reports to CodeCov.io.
    
    Reports can be found by navigating the codecov.io UI, or by going to
    the URL printed at the end of the "Code Coverage" CI job. More CodeCov
    integration could be set up later once we have coverage reporting on the
    main branch.