### PR TITLE
Parallel tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,9 +141,8 @@ jobs:
             OMP_NUM_THREADS: 1
           command: |
             echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-            ctest --test-dir build/test/ --test-action Test -j$(nproc) \
+            ctest --test-dir build/test/ --test-action Test -j 4 \
               --no-compress-output --output-on-failure \
-              --exclude-regex 'TestTypes\/ComparativeTest\..*' \
               --schedule-random --timeout 30 --repeat until-pass:2 \
               --output-junit results.xml
       - store_test_results:


### PR DESCRIPTION
    CI: Parallelise tests
    
    This reduces the time to run tests from 5-9 minutes down to 3-4 minutes.
    
    `nproc` is returning `1` on the CI node which is processing our
    config.yml. In the absense of a better way of getting the number of CPUs
    on our executor, just hardcode it.
    
    We actually have 16 cores on our 2xlarge executors, but higher
    parallelism in tests appears to cause oid to sometimes fail with SIGILL.
    I'm still investigating this problem.