### PR TITLE
add missing virtual destructors

### DIFF
--- a/test/integration/inheritance_polymorphic.toml
+++ b/test/integration/inheritance_polymorphic.toml
@@ -2,18 +2,21 @@ includes = ["vector"]
 definitions = '''
   class A {
   public:
+    virtual ~A() = default;
     virtual void myfunc() {}
     int int_a;
   };
 
   class B : public A {
   public:
+    virtual ~B() = default;
     virtual void myfunc() override {}
     std::vector<int> vec_b;
   };
 
   class C : public B {
   public:
+    virtual ~C() = default;
     virtual void myfunc() override {}
     int int_c;
   };

--- a/test/integration/inheritance_polymorphic_diamond.toml
+++ b/test/integration/inheritance_polymorphic_diamond.toml
@@ -2,24 +2,28 @@ includes = ["vector"]
 definitions = '''
   class Root {
   public:
+    virtual ~Root() = default;
     virtual void myfunc() {}
     int int_root;
   };
 
   class Middle1 : public Root {
   public:
+    virtual ~Middle1() = default;
     virtual void myfunc() override {}
     std::vector<int> vec_middle1;
   };
 
   class Middle2 : public Root {
   public:
+    virtual ~Middle2() = default;
     virtual void myfunc() override {}
     std::vector<int> vec_middle2;
   };
 
   class Child : public Middle1, public Middle2 {
   public:
+    virtual ~Child() = default;
     virtual void myfunc() override {}
     int int_child;
   };

--- a/test/integration/inheritance_polymorphic_non_dynamic_base.toml
+++ b/test/integration/inheritance_polymorphic_non_dynamic_base.toml
@@ -7,12 +7,14 @@ definitions = '''
 
   class B : public A {
   public:
+    virtual ~B() = default;
     virtual void myfunc() {}
     std::vector<int> vec_b;
   };
 
   class C : public B {
   public:
+    virtual ~C() = default;
     virtual void myfunc() override {}
     int int_c;
   };


### PR DESCRIPTION
## Summary

These tests trigger the `-Wnon-virtual-dtor` warning which we have enabled internally. I added virtual destructors to make these tests happy.

## Test plan

- `make test-devel`
- CI
