### PR TITLE
Code coverage: Checkout repo before running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ jobs:
               git \
               gpg \
               lcov
+      - checkout
       - attach_workspace:
           at: .
       - run:


### PR DESCRIPTION
Apparently this is needed for CodeCov.io to work.

Without this patch, no coverage available:
https://app.codecov.io/github/facebookexperimental/object-introspection/commit/208aac162854b98cbcd1734a4d1efed268e0db33

With this patch, coverage available:
https://app.codecov.io/github/facebookexperimental/object-introspection/commit/f9dec417d7b107735d537245a098c3fd23f58ebd