### PR TITLE
oilgen: add an --exit-code option to fail on noop

### DIFF
--- a/examples/compile-time-oil/Makefile
+++ b/examples/compile-time-oil/Makefile
@@ -16,7 +16,7 @@ oilgen:
 	ln -s ../../build/oilgen oilgen
 
 JitCompiled.o: oilgen OilVectorOfStrings.o
-	DRGN_ENABLE_TYPE_ITERATOR=1 ./oilgen -o JitCompiled.o -c ../../build/sample.oid.toml -d OilVectorOfStrings.o
+	./oilgen --exit-code -o JitCompiled.o -c ../../build/sample.oid.toml -d OilVectorOfStrings.o
 
 OilVectorOfStrings: OilVectorOfStrings.o JitCompiled.o
 	${CXX} ${CXXFLAGS} OilVectorOfStrings.o JitCompiled.o -o OilVectorOfStrings

--- a/src/OIGenerator.cpp
+++ b/src/OIGenerator.cpp
@@ -199,7 +199,11 @@ int OIGenerator::generate(fs::path& primaryObject, SymbolService& symbols) {
   size_t successes = oilTypes.size() - failures;
   LOG(INFO) << "object introspection generation complete. " << successes
             << " successes and " << failures << " failures.";
-  return (failures > 0) ? -1 : 0;
+
+  if (failures > 0 || (failIfNothingGenerated && successes == 0)) {
+    return -1;
+  }
+  return 0;
 }
 
 }  // namespace ObjectIntrospection

--- a/src/OIGenerator.h
+++ b/src/OIGenerator.h
@@ -39,11 +39,15 @@ class OIGenerator {
   void setSourceFileDumpPath(fs::path _sourceFileDumpPath) {
     sourceFileDumpPath = std::move(_sourceFileDumpPath);
   }
+  void setFailIfNothingGenerated(bool fail) {
+    failIfNothingGenerated = fail;
+  }
 
  private:
   fs::path outputPath;
   fs::path configFilePath;
   fs::path sourceFileDumpPath;
+  bool failIfNothingGenerated;
 
   std::unordered_map<std::string, std::string> oilStrongToWeakSymbolsMap(
       drgnplusplus::program& prog);

--- a/tools/OILGen.cpp
+++ b/tools/OILGen.cpp
@@ -34,6 +34,8 @@ constexpr static OIOpts opts{
           "Path to OI configuration file."},
     OIOpt{'d', "dump-jit", optional_argument, "<jit.cpp>",
           "Write generated code to a file (for debugging)."},
+    OIOpt{'e', "exit-code", no_argument, nullptr,
+          "Return a bad exit code if nothing is generated."},
 };
 
 void usage() {
@@ -55,6 +57,7 @@ int main(int argc, char* argv[]) {
   fs::path outputPath = "a.o";
   fs::path configFilePath = "/usr/local/share/oi/base.oid.toml";
   fs::path sourceFileDumpPath = "";
+  bool exitCode = false;
 
   int c;
   while ((c = getopt_long(argc, argv, opts.shortOpts(), opts.longOpts(),
@@ -68,6 +71,9 @@ int main(int argc, char* argv[]) {
         break;
       case 'd':
         sourceFileDumpPath = optarg != nullptr ? optarg : "jit.cpp";
+        break;
+      case 'e':
+        exitCode = true;
         break;
     }
   }
@@ -89,6 +95,7 @@ int main(int argc, char* argv[]) {
   oigen.setOutputPath(std::move(outputPath));
   oigen.setConfigFilePath(std::move(configFilePath));
   oigen.setSourceFileDumpPath(sourceFileDumpPath);
+  oigen.setFailIfNothingGenerated(exitCode);
 
   SymbolService symbols(primaryObject);
 


### PR DESCRIPTION
## Summary

Add an `--exit-code` option to oilgen which causes it to return a bad exit code if no code is generated. We won't generally use this as no generation isn't necessarily a failure, but it's useful for testing.

## Test plan

- CI
- `cd examples/compile-time-oil && make`
  - Removed the OIL call and checked this fails.
