### PR TITLE
Oilgen fixes

### DIFF
--- a/include/ObjectIntrospection.h
+++ b/include/ObjectIntrospection.h
@@ -254,7 +254,8 @@ getObjectSizeImpl(const T &objectAddr, size_t &objectSize);
  * production system.
  */
 template <class T>
-int getObjectSize(const T &objectAddr, size_t &objectSize) {
+int __attribute__((noinline))
+getObjectSize(const T &objectAddr, size_t &objectSize) {
 #ifdef OIL_AOT_COMPILATION
   if (!getObjectSizeImpl<T>) {
     return Response::OIL_UNINITIALISED;

--- a/src/FuncGen.cpp
+++ b/src/FuncGen.cpp
@@ -225,6 +225,7 @@ void FuncGen::DefineTopLevelGetObjectSize(std::string& testCode,
     /* RawType: %1% */
     extern "C" int %2%(const OIInternal::__ROOT_TYPE__* ObjectAddr, size_t* ObjectSize)
     {
+      *ObjectSize = 0;
       OIInternal::getSizeType(*ObjectAddr, *ObjectSize);
       return 0;
     }


### PR DESCRIPTION
## Summary

Two things:
- Make `getObjectSize` noinline - this causes issues with higher optimisation levels.
- Set `ObjectSize` to 0 before starting counting into it. Whoops.

## Test plan

- `cd examples/compile-time-oil && make && ./OilVectorOfStrings`
- CI
