### PR TITLE
Fix folly::sorted_vector_set and minor codegen comment change

### DIFF
--- a/src/OICodeGen.cpp
+++ b/src/OICodeGen.cpp
@@ -2325,7 +2325,7 @@ bool OICodeGen::generateStructDef(drgn_type *e, std::string &code) {
   std::string structDefinition;
 
   if (paddingInfo.paddingSize != 0 && config.genPaddingStats) {
-    structDefinition.append("/* offset    |  size */");
+    structDefinition.append("/* offset    |  size */ ");
   }
 
   if (kind == DRGN_TYPE_STRUCT || kind == DRGN_TYPE_CLASS) {
@@ -2440,10 +2440,10 @@ bool OICodeGen::addPadding(uint64_t padding_bits, std::string &code) {
 
     if (isByteMultiple) {
       info << "/* XXX" << std::setw(3) << std::right << padding_bits / CHAR_BIT
-           << "-byte hole  */";
+           << "-byte hole  */ ";
     } else {
       info << "/* XXX" << std::setw(3) << std::right << padding_bits
-           << "-bit  hole  */";
+           << "-bit  hole  */ ";
     }
 
     code.append(info.str());
@@ -2465,10 +2465,10 @@ static inline void addSizeComment(bool genPaddingStats, std::string &code,
   std::ostringstream info;
   if (isByteMultiple) {
     info << "/* " << std::setw(10) << std::left << offset / CHAR_BIT << "| "
-         << std::setw(5) << std::right << sizeInBytes << " */";
+         << std::setw(5) << std::right << sizeInBytes << " */ ";
   } else {
     info << "/* " << std::setw(4) << std::left << offset / CHAR_BIT
-         << ": 0   | " << std::setw(5) << std::right << sizeInBytes << " */";
+         << ": 0   | " << std::setw(5) << std::right << sizeInBytes << " */ ";
   }
   code.append(info.str());
 }

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -4,9 +4,9 @@ numTemplateParams = 1
 ctype = "SORTED_VEC_SET_TYPE"
 header = "folly/sorted_vector_types.h"
 ns = ["namespace std", "folly::sorted_vector_set"]
-replaceTemplateParamIndex = []
+replaceTemplateParamIndex = [1,2]
 # allocatorIndex = 0
-# underlyingContainerIndex = 0
+underlyingContainerIndex = 4
 
 [codegen]
 decl = """


### PR DESCRIPTION
## Summary

This change corrects how we handle folly::sorted_vector_set handling and adds another space into the codegen comments (so you can easily cut'n'paste the symbol without picking up the trailing slash).

I have logged task #62 as this change doesn't contain a test for this container and we need one.

## Test plan
'make test-devel` passes all tests. The integration tests are failing for me currently but it's not owing to anything here (I think!).
