### PR TITLE
ci: bump repeat-until-pass to 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
             echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
             ctest --test-dir build/test/ --test-action Test -j 4 \
               --no-compress-output --output-on-failure \
-              --schedule-random --timeout 30 --repeat until-pass:2 \
+              --schedule-random --timeout 30 --repeat until-pass:4 \
               --output-junit results.xml
       - store_test_results:
           path: build/test/results.xml


### PR DESCRIPTION
## Summary

The CI SIGILL failures (#59) have become more common as we've increased the number of tests. Double the the 'repeat-until-pass' number from 2 to 4 to vastly decrease the likelihood of this hitting the top level signal - it should be around 200000x less likely.

## Test Plan

CI