### PR TITLE
Remove type path printing debug code 

### DIFF
--- a/src/OICodeGen.cpp
+++ b/src/OICodeGen.cpp
@@ -928,17 +928,6 @@ bool OICodeGen::getMemberDefinition(drgn_type *type) {
   return true;
 }
 
-void OICodeGen::printTypePath() {
-  int cnt = 1;
-  for (auto &type : typePath) {
-    std::string outName;
-    getDrgnTypeNameInt(type, outName);
-    outName = std::string(cnt, ' ') + outName;
-    VLOG(2) << outName;
-    cnt += 1;
-  }
-}
-
 std::string OICodeGen::typeToTransformedName(drgn_type *type) {
   auto typeName = typeToName(type);
   typeName = transformTypeName(type, typeName);
@@ -1658,11 +1647,6 @@ bool OICodeGen::enumerateTypesRecurse(drgn_type *type) {
 
   g_level += 1;
   typePath.push_back(type);
-
-  if (VLOG_IS_ON(2)) {
-    VLOG(2) << "typeDefStr: " << typeDefStr;
-    printTypePath();
-  }
 
   processedTypes.insert(type);
 

--- a/src/OICodeGen.cpp
+++ b/src/OICodeGen.cpp
@@ -2325,7 +2325,7 @@ bool OICodeGen::generateStructDef(drgn_type *e, std::string &code) {
   std::string structDefinition;
 
   if (paddingInfo.paddingSize != 0 && config.genPaddingStats) {
-    structDefinition.append("/* offset    |  size */");
+    structDefinition.append("/* offset    |  size */ ");
   }
 
   if (kind == DRGN_TYPE_STRUCT || kind == DRGN_TYPE_CLASS) {
@@ -2440,10 +2440,10 @@ bool OICodeGen::addPadding(uint64_t padding_bits, std::string &code) {
 
     if (isByteMultiple) {
       info << "/* XXX" << std::setw(3) << std::right << padding_bits / CHAR_BIT
-           << "-byte hole  */";
+           << "-byte hole  */ ";
     } else {
       info << "/* XXX" << std::setw(3) << std::right << padding_bits
-           << "-bit  hole  */";
+           << "-bit  hole  */ ";
     }
 
     code.append(info.str());
@@ -2465,10 +2465,10 @@ static inline void addSizeComment(bool genPaddingStats, std::string &code,
   std::ostringstream info;
   if (isByteMultiple) {
     info << "/* " << std::setw(10) << std::left << offset / CHAR_BIT << "| "
-         << std::setw(5) << std::right << sizeInBytes << " */";
+         << std::setw(5) << std::right << sizeInBytes << " */ ";
   } else {
     info << "/* " << std::setw(4) << std::left << offset / CHAR_BIT
-         << ": 0   | " << std::setw(5) << std::right << sizeInBytes << " */";
+         << ": 0   | " << std::setw(5) << std::right << sizeInBytes << " */ ";
   }
   code.append(info.str());
 }

--- a/src/OICodeGen.h
+++ b/src/OICodeGen.h
@@ -201,7 +201,6 @@ class OICodeGen {
   std::optional<ContainerInfo> getContainerInfo(drgn_type *type);
   void printAllTypes();
   void printAllTypeNames();
-  void printTypePath();
 
   static void addPaddingForBaseClass(drgn_type *type,
                                      std::vector<std::string> &def);

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -4,9 +4,9 @@ numTemplateParams = 1
 ctype = "SORTED_VEC_SET_TYPE"
 header = "folly/sorted_vector_types.h"
 ns = ["namespace std", "folly::sorted_vector_set"]
-replaceTemplateParamIndex = []
+replaceTemplateParamIndex = [1,2]
 # allocatorIndex = 0
-# underlyingContainerIndex = 0
+underlyingContainerIndex = 4
 
 [codegen]
 decl = """


### PR DESCRIPTION
## Summary
When verbose logging is enabled (level 2 and above) we generate a huge amount of debug and a lot of it is coming from the printTypePath() function which is called when we enumerate types. This code iterates over all the known types and prints the name out which generates a lot of noise and makes it more difficult to figure out what is going off.

I've spoken to @arsarwade and he is going to rewrite the debugging code in codegen at some point. In the meantime I'm just removing this before I lose my mind.

## Test plan
`make test-devel`works with no new failures.
