### PR TITLE
remove unused ManifoldCache.h from OICompiler

### DIFF
--- a/src/OICompiler.cpp
+++ b/src/OICompiler.cpp
@@ -15,10 +15,6 @@
  */
 #include "OICompiler.h"
 
-#ifndef OSS_ENABLE
-#include "cea/object-introspection/internal/ManifoldCache.h"
-#endif
-
 #include <clang/Basic/LangStandard.h>
 #include <clang/Basic/TargetInfo.h>
 #include <clang/Basic/TargetOptions.h>


### PR DESCRIPTION
## Summary

`ManifoldCache.h` is included but unused in `OICompiler.cpp`. This makes it difficult to split up the exposed targets which require it and the targets that don't. Remove this unused include.

## Test plan

- CI
- `make test-devel`
- D43187545
