### PR TITLE
oil: removed unused cache in OILibrary

### DIFF
--- a/src/OILibraryImpl.cpp
+++ b/src/OILibraryImpl.cpp
@@ -25,6 +25,7 @@
 #include <boost/format.hpp>
 #include <fstream>
 
+#include "OIParser.h"
 #include "OIUtils.h"
 
 extern "C" {
@@ -91,19 +92,12 @@ bool OILibraryImpl::unmapSegment() {
 void OILibraryImpl::initCompiler() {
   symbols = std::make_shared<SymbolService>(getpid());
 
-  _cache.symbols = symbols;
-
   compilerConfig.generateJitDebugInfo = _self->opts.generateJitDebugInfo;
 
   generatorConfig.useDataSegment = false;
   generatorConfig.chaseRawPointers = _self->opts.chaseRawPointers;
   generatorConfig.packStructs = true;
   generatorConfig.genPaddingStats = false;
-
-  _cache.basePath = _self->opts.cacheDirPath;
-  _cache.enableUpload = _self->opts.enableUpload;
-  _cache.enableDownload = _self->opts.enableDownload;
-  _cache.abortOnLoadFail = _self->opts.abortOnLoadFail;
 }
 
 bool OILibraryImpl::processConfigFile() {

--- a/src/OILibraryImpl.h
+++ b/src/OILibraryImpl.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include "OICache.h"
 #include "OICodeGen.h"
 #include "OICompiler.h"
 #include "ObjectIntrospection.h"
@@ -45,8 +44,6 @@ class OILibraryImpl {
   OICompiler::Config compilerConfig{};
   OICodeGen::Config generatorConfig{};
   std::shared_ptr<SymbolService> symbols{};
-
-  OICache _cache{};
 
   struct c {
     void *textSegBase = nullptr;


### PR DESCRIPTION
## Summary

Removes an unused cache object from `OILibraryImpl`. This removes the dependency on caching which removes the dependency on internal FB stuff from JIT OIL, massively reducing debug bloat.

## Test plan

- `make test-devel`
- CI
- D43239161
