### PR TITLE
Bump minimum CMake version to 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # object-introspection
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.19)
 project(object-introspection)
 
 # Lets find_program() locate SETUID binaries


### PR DESCRIPTION
We are already using CMP0109 which depends on 3.19. This change just provides more useful error messages when using older versions.