### PR TITLE
Split codegen into separate build targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,19 +224,17 @@ add_library(oid_parser STATIC ${BISON_Parser_OUTPUTS} ${FLEX_Lexer_OUTPUTS})
 target_link_libraries(oid_parser glog::glog)
 
 ### Core OI
+add_subdirectory(src)
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/src)
 add_library(oicore
-  src/ContainerInfo.cpp
   src/Descs.cpp
-  src/FuncGen.cpp
   src/Metrics.cpp
   src/OICache.cpp
-  src/OICodeGen.cpp
   src/OICompiler.cpp
   src/OIUtils.cpp
   src/PaddingHunter.cpp
   src/Serialize.cpp
-  src/SymbolService.cpp
 )
 add_dependencies(oicore libdrgn)
 set_project_warnings(oicore)
@@ -245,10 +243,11 @@ target_compile_definitions(oicore PRIVATE ${LLVM_DEFINITIONS})
 
 llvm_map_components_to_libnames(llvm_libs core native mcjit x86disassembler)
 target_link_libraries(oicore
+  codegen
+
   ${Boost_LIBRARIES}
   Boost::headers
   glog::glog
-  tomlplusplus::tomlplusplus
 )
 if (FORCE_LLVM_STATIC)
   target_link_libraries(oicore
@@ -296,9 +295,11 @@ target_link_libraries(oil oicore)
 add_executable(oilgen
   tools/OILGen.cpp
   src/OIGenerator.cpp
-  src/DrgnUtils.cpp
 )
-target_link_libraries(oilgen oicore)
+target_link_libraries(oilgen
+  drgn_utils
+  oicore
+)
 
 ### Object Introspection cache Printer (OIP)
 add_executable(oip tools/OIP.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,36 @@
+add_library(drgn_utils DrgnUtils.cpp)
+target_link_libraries(drgn_utils
+  glog::glog
+
+  "-L${DRGN_PATH}/.libs"
+  drgn
+)
+add_dependencies(drgn_utils libdrgn)
+
+add_library(symbol_service
+  Descs.cpp
+  SymbolService.cpp
+)
+target_link_libraries(symbol_service
+  drgn_utils
+
+  Boost::headers
+  ${Boost_LIBRARIES}
+  glog::glog
+
+  dw
+)
+
+add_library(codegen
+  ContainerInfo.cpp
+  FuncGen.cpp
+  OICodeGen.cpp
+)
+target_link_libraries(codegen
+  symbol_service
+
+  Boost::headers
+  ${Boost_LIBRARIES}
+  glog::glog
+  tomlplusplus::tomlplusplus
+)

--- a/src/DrgnUtils.cpp
+++ b/src/DrgnUtils.cpp
@@ -16,6 +16,8 @@
 
 #include "DrgnUtils.h"
 
+#include <glog/logging.h>
+
 extern "C" {
 #include <drgn.h>
 }
@@ -93,3 +95,68 @@ const char* symbol::name(drgn_symbol* sym) {
 }
 
 }  // namespace drgnplusplus
+
+namespace drgn_utils {
+
+void getDrgnArrayElementType(drgn_type* type, drgn_type** outElemType,
+                             size_t& outNumElems) {
+  size_t elems = 1;
+
+  // for multi dimensional arrays
+  auto* arrayElementType = type;
+  while (drgn_type_kind(arrayElementType) == DRGN_TYPE_ARRAY) {
+    size_t l = drgn_type_length(arrayElementType);
+    elems *= l;
+    auto qtype = drgn_type_type(arrayElementType);
+    arrayElementType = qtype.type;
+  }
+
+  *outElemType = arrayElementType;
+  outNumElems = elems;
+}
+
+std::string typeToName(drgn_type* type) {
+  std::string typeName;
+  if (drgn_type_has_tag(type)) {
+    const char* typeTag = drgn_type_tag(type);
+    if (typeTag != nullptr) {
+      typeName = typeTag;
+    } else {
+      typeName = type->_private.oi_name;
+    }
+    // TODO: Lookup unnamed union in type->string flag
+  } else if (drgn_type_has_name(type)) {
+    typeName = drgn_type_name(type);
+  } else if (drgn_type_kind(type) == DRGN_TYPE_POINTER) {
+    char* defStr = nullptr;
+    drgn_qualified_type qtype = {type, {}};
+    if (drgn_format_type_name(qtype, &defStr) != nullptr) {
+      LOG(ERROR) << "Failed to get formatted string for " << type;
+      typeName = "";
+    } else {
+      typeName.assign(defStr);
+      free(defStr);
+    }
+  } else if (drgn_type_kind(type) == DRGN_TYPE_VOID) {
+    return "void";
+  } else if (drgn_type_kind(type) == DRGN_TYPE_ARRAY) {
+    size_t elems = 1;
+    drgn_type* arrayElementType = nullptr;
+    getDrgnArrayElementType(type, &arrayElementType, elems);
+
+    if (drgn_type_has_name(arrayElementType)) {
+      typeName = drgn_type_name(arrayElementType);
+    } else if (drgn_type_has_tag(arrayElementType)) {
+      typeName = drgn_type_tag(arrayElementType);
+    } else {
+      LOG(ERROR) << "Failed4 to get typename ";
+      return "";
+    }
+  } else {
+    LOG(ERROR) << "Failed3 to get typename ";
+    return "";
+  }
+  return typeName;
+}
+
+}  // namespace drgn_utils

--- a/src/DrgnUtils.h
+++ b/src/DrgnUtils.h
@@ -31,6 +31,7 @@ struct drgn_func_iterator;
 struct drgn_program;
 struct drgn_qualified_type;
 struct drgn_symbol;
+struct drgn_type;
 }
 
 namespace drgnplusplus {
@@ -125,3 +126,19 @@ const char* name(drgn_symbol*);
 }
 
 }  // namespace drgnplusplus
+
+namespace drgn_utils {
+/*
+ * These utils are not intended to be permanent. As part of the transition to
+ * type-graph based CodeGen, we need to break dependencies on legacy OICodeGen
+ * from other parts of OI.
+ *
+ * Parts of OICodeGen used by other parts of OI, but  which only return drgn
+ * data can be moved here.
+ */
+
+void getDrgnArrayElementType(drgn_type* type, drgn_type** outElemType,
+                             size_t& outNumElems);
+std::string typeToName(drgn_type* type);
+
+}  // namespace drgn_utils

--- a/src/OICodeGen.h
+++ b/src/OICodeGen.h
@@ -97,9 +97,6 @@ class OICodeGen {
   TypeHierarchy getTypeHierarchy();
   std::map<std::string, PaddingInfo> getPaddingInfo();
 
-  static void getDrgnArrayElementType(drgn_type *type, drgn_type **outElemType,
-                                      size_t &outNumElems);
-
   bool isContainer(drgn_type *type);
 
   static drgn_type *drgnUnderlyingType(drgn_type *type);
@@ -107,7 +104,6 @@ class OICodeGen {
   bool buildName(drgn_type *type, std::string &text, std::string &outName);
 
   std::string typeToTransformedName(drgn_type *type);
-  static std::string typeToName(drgn_type *type);
 
   bool enumerateTypesRecurse(drgn_type *type);
   static std::string_view drgnKindStr(drgn_type *type);

--- a/src/OIUtils.h
+++ b/src/OIUtils.h
@@ -19,7 +19,9 @@
 #include "OICompiler.h"
 
 namespace OIUtils {
+
 bool processConfigFile(const std::string& configFilePath,
                        OICompiler::Config& compilerConfig,
                        OICodeGen::Config& generatorConfig);
-}
+
+}  // namespace OIUtils

--- a/src/Serialize.cpp
+++ b/src/Serialize.cpp
@@ -20,7 +20,7 @@
 #include <boost/serialization/version.hpp>
 #include <stdexcept>
 
-#include "OICodeGen.h"
+#include "DrgnUtils.h"
 
 namespace boost::serialization {
 
@@ -319,7 +319,7 @@ void serialize(Archive &ar, struct drgn_type &type,
   // `serialize_c_string`.
   std::string oi_name;
   if (Archive::is_saving::value) {
-    oi_name = OICodeGen::typeToName(&type);
+    oi_name = drgn_utils::typeToName(&type);
     type._private.oi_name = oi_name.c_str();
   }
   serialize_c_string(ar, const_cast<char **>(&type._private.oi_name));

--- a/src/SymbolService.cpp
+++ b/src/SymbolService.cpp
@@ -23,7 +23,7 @@
 #include <cstring>
 #include <fstream>
 
-#include "OICodeGen.h"
+#include "DrgnUtils.h"
 #include "OIParser.h"
 
 extern "C" {
@@ -733,7 +733,7 @@ std::string SymbolService::getTypeName(struct drgn_type *type) {
   if (drgn_type_kind(type) == DRGN_TYPE_POINTER) {
     type = drgn_type_type(type).type;
   }
-  return OICodeGen::typeToName(type);
+  return drgn_utils::typeToName(type);
 }
 
 std::optional<RootInfo> SymbolService::getRootType(const irequest &req) {

--- a/src/TreeBuilder.cpp
+++ b/src/TreeBuilder.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 
 #include "ContainerInfo.h"
+#include "DrgnUtils.h"
 #include "Metrics.h"
 #include "OICodeGen.h"
 #include "PaddingHunter.h"
@@ -274,7 +275,7 @@ void TreeBuilder::setPaddedStructs(
 
 static std::string drgnTypeToName(struct drgn_type *type) {
   if (type->_private.program != nullptr) {
-    return OICodeGen::typeToName(type);
+    return drgn_utils::typeToName(type);
   }
 
   return type->_private.oi_name ? type->_private.oi_name : "";
@@ -530,8 +531,8 @@ void TreeBuilder::processContainer(const Variable &variable, Node &node) {
     kind = ARRAY_TYPE;
     struct drgn_type *arrayElementType = nullptr;
     size_t numElems = 0;
-    OICodeGen::getDrgnArrayElementType(variable.type, &arrayElementType,
-                                       numElems);
+    drgn_utils::getDrgnArrayElementType(variable.type, &arrayElementType,
+                                        numElems);
     assert(numElems > 0);
     elementTypes.push_back(
         drgn_qualified_type{arrayElementType, (enum drgn_qualifiers)(0)});


### PR DESCRIPTION
    Split codegen into separate build targets
    
    To help with the transition to type-graph based CodeGen, we need to
    reduce dependencies on legacy CodeGen from other parts of OI.
    
    Pieces of CodeGen referenced by other files, but which only return
    drgn data have been moved into a new "drgn_utils" target, allowing
    us to remove CodeGen dependencies for these functions.
    
    The new "symbol_service" build target can be used in the future by
    other files only needing access to symbol information and not full
    CodeGen.