### PR TITLE
Stop enumerating template params for sorted_vector_set

### DIFF
--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -1,11 +1,9 @@
 [info]
 typeName = "folly::sorted_vector_set<"
-numTemplateParams = 1
 ctype = "SORTED_VEC_SET_TYPE"
 header = "folly/sorted_vector_types.h"
 ns = ["namespace std", "folly::sorted_vector_set"]
 replaceTemplateParamIndex = [1,2]
-# allocatorIndex = 0
 underlyingContainerIndex = 4
 
 [codegen]


### PR DESCRIPTION
## Summary
The changes in #63 makes us treat a folly::sorted_vector_set as a container adaptor. We also need to remove the configuration which specifies the number of template parameters as container adaptors shouldn't enumerate their template parameters. Guess I should also do issue #62 ...

## Test plan
Tested on an application using a sorted_vector_map and all is now good.