### PR TITLE
Special case conditional_t type name handling

### DIFF
--- a/src/OICodeGen.cpp
+++ b/src/OICodeGen.cpp
@@ -263,6 +263,14 @@ std::string OICodeGen::stripFullyQualifiedNameWithSeparators(
   std::vector<std::string> stack;
   std::string sep = " ,<>()";
   std::string tmp;
+  constexpr std::string_view cond = "conditional_t";
+  constexpr std::string_view stdCond = "std::conditional_t";
+  static int cond_t_val = 0;
+
+  if ((fullyQualifiedName.starts_with(cond)) ||
+      (fullyQualifiedName.starts_with(stdCond))) {
+    return "conditional_t_" + std::to_string(cond_t_val++);
+  }
 
   for (auto &c : fullyQualifiedName) {
     if (sep.find(c) == std::string::npos) {


### PR DESCRIPTION
## Summary
A '`conditional_t` type's name will often contain conditional expressions so we need to special case this as it causes problems when removing namespaces.

## Test plan
This change fixes issues with volume testing that were being encountered. Current tests have no new failures. A new test needs to be added to include `conditional_t` types (see issue #76 ).
