### PR TITLE
oilgen: add check for drgn_type_has_name

### DIFF
--- a/src/OIGenerator.cpp
+++ b/src/OIGenerator.cpp
@@ -111,7 +111,11 @@ OIGenerator::findOilTypesAndNames(drgnplusplus::program& prog) {
       throw err;
     }
 
-    LOG(INFO) << "found OIL type: " << drgn_type_name(paramType.type);
+    if (drgn_type_has_name(paramType.type)) {
+      LOG(INFO) << "found OIL type: " << drgn_type_name(paramType.type);
+    } else {
+      LOG(INFO) << "found OIL type: (no name)";
+    }
     out.push_back({paramType, std::move(weakLinkageName)});
   }
 


### PR DESCRIPTION
## Summary

Checks a call for `drgn_type_name` which was asserted on `drgn_type_has_name`.

## Test plan

- CI