### PR TITLE
add std::conditional test

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -19,6 +19,7 @@ set(INTEGRATION_TEST_CONFIGS
   references.toml
   simple_struct.toml
   std_array.toml
+  std_conditional.toml
   std_deque_del_allocator.toml
   std_list_del_allocator.toml
   std_deque.toml

--- a/test/integration/std_conditional.toml
+++ b/test/integration/std_conditional.toml
@@ -1,0 +1,80 @@
+definitions = '''
+class A {
+  int f;
+  int g;
+};
+
+class B {
+  int h;
+};
+
+class C {
+public:
+//  using T = std::conditional_t<alignof(int*) >= sizeof(char), A, B>;
+  std::conditional_t<alignof(int*) >= sizeof(char), A, B> foo;
+};
+'''
+[cases]
+  [cases.a]
+    param_types = ["const C&"]
+    setup = '''
+      C foo;
+      return {foo};
+    '''
+    expect_json = '''
+[
+  {
+    "typeName": "C",
+    "isTypedef": false,
+    "staticSize": 8,
+    "dynamicSize": 0,
+    "members": [
+      {
+        "name": "foo",
+        "typePath": "foo",
+        "isTypedef": true,
+        "staticSize": 8,
+        "dynamicSize": 0,
+        "members": [
+          {
+            "name": "",
+            "typePath": "",
+            "typeName": "type",
+            "isTypedef": true,
+            "staticSize": 8,
+            "dynamicSize": 0,
+            "members": [
+              {
+                "name": "",
+                "typePath": "",
+                "typeName": "A",
+                "isTypedef": false,
+                "staticSize": 8,
+                "dynamicSize": 0,
+                "members": [
+                  {
+                    "name": "f",
+                    "typePath": "f",
+                    "typeName": "int",
+                    "isTypedef": false,
+                    "staticSize": 4,
+                    "dynamicSize": 0
+                  },
+                  {
+                    "name": "g",
+                    "typePath": "g",
+                    "typeName": "int",
+                    "isTypedef": false,
+                    "staticSize": 4,
+                    "dynamicSize": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]
+'''


### PR DESCRIPTION
## Summary
Add a test for verifying OI processes a `std::conditional_t` type. This addresses issue #76 .

## Test plan

Test passes in test suite:

```
 61/379 Test  #99: OidIntegration.std_conditional_a .......................................   Passed    5.01 sec
```

