### PR TITLE
Update rocksdb to 7.9.2

### DIFF
--- a/src/TreeBuilder.cpp
+++ b/src/TreeBuilder.cpp
@@ -31,6 +31,7 @@
 #include "PaddingHunter.h"
 #include "rocksdb/db.h"
 #include "rocksdb/options.h"
+#include "rocksdb/statistics.h"
 
 extern "C" {
 #include <drgn.h>


### PR DESCRIPTION
## Summary

- Update rocksdb to [v7.9.2](https://github.com/facebook/rocksdb/releases/tag/v7.9.2).
- Add an additional header dependency on `"rocksdb/statistics.h" for upcoming rocksdb 8.

## Test plan

- `make test-devel`
- CI
