### PR TITLE
Replace nop instructions with ud2

### DIFF
--- a/src/OIDebugger.h
+++ b/src/OIDebugger.h
@@ -160,6 +160,7 @@ class OIDebugger {
   uint64_t count{};
   bool sigIntHandlerActive{false};
   const int sizeofInt3 = 1;
+  const int sizeofUd2 = 2;
   const int replayInstSize = 512;
   bool trapsRemoved{false};
   std::shared_ptr<SymbolService> symbols;

--- a/src/X86InstDefs.h
+++ b/src/X86InstDefs.h
@@ -24,3 +24,5 @@ static constexpr uint8_t movabsrax1Inst = 0xb8;
 static constexpr uint8_t callRaxInst0Inst = 0xff;
 static constexpr uint8_t callRaxInst1Inst = 0xd0;
 static constexpr long syscallInsts = 0x9090909090050fcc;
+static constexpr uint8_t ud2Inst0 = 0x0f;
+static constexpr uint8_t ud2Inst1 = 0x0b;


### PR DESCRIPTION
## Summary
The OI code prologue is a 64 byte area used to setup a call into JIT code and a subsequent return back to OI via an `int3`. Currently we have 23 bytes of useful instructions and we pad the rest with `nop` instructions (single byte `0x90` opcode) which, in hindsight, turns out to be suboptimal. If, for some reason, we end up executing instructions past the `int3` then the thread will execute the nops and run into some variables that we have just after the prologue (starting with the `dataBase` variable which is a pointer to the current byte of data being written by JIT code ). Depending on it's current value this will either be a random sequence of junk instructions or an illegal instruction.

A much better approach is to replace the `nop` instructions with `ud2` instructions (a `ud2` is the official x86 instruction for an undefined instruction). This means we will generate a SIGILL when we hit the first ud2 and this is better for debugging strange prologue related issues. The new instructions sequence on a local test case looks like:

```
(gdb) disas/r 0x7f7990400000,+0t66
Dump of assembler code from 0x7f7990400000 to 0x7f7990400042:
   0x00007f7990400000:  48 bf 78 65 74 33 ff 7f 00 00   movabs $0x7fff33746578,%rdi
   0x00007f799040000a:  48 b8 c0 00 40 90 79 7f 00 00   movabs $0x7f79904000c0,%rax
   0x00007f7990400014:  ff d0   callq  *%rax
   0x00007f7990400016:  cc      int3
=> 0x00007f7990400017:  0f 0b   ud2
   0x00007f7990400019:  0f 0b   ud2
   0x00007f799040001b:  0f 0b   ud2
   0x00007f799040001d:  0f 0b   ud2
   0x00007f799040001f:  0f 0b   ud2
   0x00007f7990400021:  0f 0b   ud2
   0x00007f7990400023:  0f 0b   ud2
   0x00007f7990400025:  0f 0b   ud2
   0x00007f7990400027:  0f 0b   ud2
   0x00007f7990400029:  0f 0b   ud2
   0x00007f799040002b:  0f 0b   ud2
   0x00007f799040002d:  0f 0b   ud2
   0x00007f799040002f:  0f 0b   ud2
   0x00007f7990400031:  0f 0b   ud2
   0x00007f7990400033:  0f 0b   ud2
   0x00007f7990400035:  0f 0b   ud2
   0x00007f7990400037:  0f 0b   ud2
   0x00007f7990400039:  0f 0b   ud2
   0x00007f799040003b:  0f 0b   ud2
   0x00007f799040003d:  0f 0b   ud2
   0x00007f799040003f:  00 27   add    %ah,(%rdi)
   0x00007f7990400041:  e0 c5   loopne 0x7f7990400008
End of assembler dump.
```

The main issue is to ensure that we don't overwrite past the end of the prologue as a `ud2` is two bytes long.  I've verified  this just by manual inspection. In the above we can see that the `dataBase` variable at 0x00007f7990400040 is intact and valid:

```
(gdb) x/xg 0x00007f7990400040
0x7f7990400040: 0x00007f7991c5e027
```

We had captured 39 bytes (0x27) at the time of inspection.

## Test plan
Manual and `make oid-devel`.
