### PR TITLE
reduce race window for breakpoint trap in prologue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,9 +149,9 @@ jobs:
             OMP_NUM_THREADS: 1
           command: |
             echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-            ctest --test-dir build/test/ --test-action Test -j 4 \
+            ctest --test-dir build/test/ --test-action Test -j 16 \
               --no-compress-output --output-on-failure \
-              --schedule-random --timeout 30 --repeat until-pass:4 \
+              --schedule-random --timeout 60 \
               --output-junit results.xml
       - store_test_results:
           path: build/test/results.xml


### PR DESCRIPTION
## Summary
The CI has been experiencing failed tests owing to targets dying with SIGILL delivery and as far as I know we've never seen this in production which always seemed odd. The reason is that we have a race condition in processTraps() that becomes more reproducible as the JIT code get smaller (quicker to execute).

The race is between when we continue a target thread to execute the JIT code (the ptrace(PTRACE_CONT) at the bottom of processTraps()) and waiting for that thread to finish JIT code execution - to execute the int3 instruction and the subsequent SIGTRAP that is raised to oid which we receive by the waitpid() call at the start of processTrap().

The VLOG() calls being executed at the start of processTraps() and the ptrace(PTRACE_CONT) give a window where we are not waiting for signals delivered to the target thread. Now, in theory, this shouldn't matter as when a thread is controlled by ptrace (any previously seized threads in our case) any and all signals delivered to it should be redirected to the tracer (i.e., oid). The oid process should therefore receive a SIGTRAP for the int3 instruction in the prologue code when it next executes a waitpid() call. However, the symptoms were that we received a SIGILL from executing junk after the prologue section - it appeared as though we never executed the int3 instruction! However, if I replaced the int3 with ud2 then we do execute it and subsequent bpftrace'ing shows that the int3 is dispatched in the kernel. Why oid never appears to receive it is a mystery to me at the minute and it's either a bug in a ptrace related area, how we pick signals up or in ptrace itself. Further investigation needs to be done.

What this change does is to remove the ptrace(PTRACE_CONT) at the start of processTrap() as I don't think we actually need it (see below). All this does is remove the cycles that exist between oid continuing the target and waiting for a signal. I think we have much work to do to close this race and it's still pretty wide open but we get away with it even with these changes because our JIT code is so large! In my tests it appears that the simplest possible case of an class with a single integer member still generates ~800 instructions. more work to be done there also.

I also introduced a new VLOG() level of 4 which is intended now for al logging calls that are executed while a thread is stopped (i.e., really, really don't execute these logs unless we absolutely need to).


## Test plan

The CI now passes all tests without any repeated tests being needed so I have changed that in the config. The thing I'm most concerned about is not the second call to processTraps() when we are cleaning threads up and releasing any that have received/generated signals or extended wait events while other things were happening. I've done some mental gymnastics and convinced myself that we are OK . I've also been experimenting with some pretty aggressive multithreaded test cases which have been OK. However, the real test comes with very aggressive hugely threaded applications and I have yet to do that testing.
