### PR TITLE
tests:  make relative config paths absolute when copying

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -3,6 +3,7 @@ set(INTEGRATION_TEST_CONFIGS
   anonymous.toml
   container_enums.toml
   cycles.toml
+  ignored.toml
   inheritance_access.toml
   inheritance_multiple.toml
   inheritance_polymorphic.toml
@@ -95,7 +96,9 @@ target_include_directories(integration_test_runner PRIVATE ${CMAKE_CURRENT_SOURC
 target_link_libraries(integration_test_runner PRIVATE
   ${GMOCK_MAIN_LIBS}
   Boost::headers
-  ${Boost_LIBRARIES})
+  ${Boost_LIBRARIES}
+  tomlplusplus::tomlplusplus
+)
 target_compile_definitions(integration_test_runner PRIVATE
   TARGET_EXE_PATH="${CMAKE_CURRENT_BINARY_DIR}/integration_test_target"
   OID_EXE_PATH="$<TARGET_FILE:oid>"

--- a/test/integration/gen_tests.py
+++ b/test/integration/gen_tests.py
@@ -240,9 +240,7 @@ def add_oid_integration_test(f, config, case_name, case):
         f"\n"
         f"TEST_F(OidIntegration, {case_str}) {{\n"
         f"{generate_skip(case, 'oid')}"
-        f'  std::string configOptions = R"--(\n'
-        f"{config_extra}\n"
-        f'  )--";\n'
+        f'  std::string configOptions = R"--({config_extra})--";\n'
         f"  ba::io_context ctx;\n"
         f"  auto [target, oid] = runOidOnProcess(\n"
         f"        {{\n"
@@ -307,15 +305,18 @@ def add_oil_integration_test(f, config, case_name, case):
     if case.get("oil_disable", False):
         return
 
+    config_extra = case.get("config", "")
+
     f.write(
         f"\n"
         f"TEST_F(OilIntegration, {case_str}) {{\n"
         f"{generate_skip(case, 'oil')}"
+        f'  std::string configOptions = R"--({config_extra})--";\n'
         f"  ba::io_context ctx;\n"
         f"  auto target = runOilTarget({{\n"
         f"    .ctx = ctx,\n"
         f'    .targetArgs = "oil {case_str} 1",\n'
-        f"  }});\n\n"
+        f"  }}, std::move(configOptions));\n\n"
         f"  ASSERT_EQ(exit_code(target), {exit_code});\n"
         f"\n"
         f"  bpt::ptree result_json;\n"

--- a/test/integration/runner_common.h
+++ b/test/integration/runner_common.h
@@ -38,6 +38,7 @@ class IntegrationBase : public ::testing::Test {
   void TearDown() override;
   void SetUp() override;
   int exit_code(Proc &proc);
+  std::filesystem::path createCustomConfig(const std::string &extra);
 
   std::filesystem::path workingDir;
 
@@ -68,5 +69,5 @@ class OilIntegration : public IntegrationBase {
  protected:
   std::string TmpDirStr() override;
 
-  Proc runOilTarget(OidOpts opts);
+  Proc runOilTarget(OidOpts opts, std::string extra_config);
 };


### PR DESCRIPTION
## Summary

As config files may contain paths relative to them, copying them into an arbitrary location (tmp path) won't succeed. Due to the directory layout this works in OSS & CI, but it failed when the tests were brought over internally. Canonicalise the paths while copying the config file to prevent this issue.

It became clear while testing this that the tests in `ignored.toml` weren't being run. Added them to the `test/integration/CMakeLists.txt` test cases and fixed them working with OIL.

Closes #55 

## Test plan

- D43647536
- `make test-devel`
- CI
