### PR TITLE
FuncGen: Make functions static where possible

### DIFF
--- a/src/FuncGen.cpp
+++ b/src/FuncGen.cpp
@@ -290,38 +290,6 @@ void FuncGen::DefineTopLevelGetSizeRefRet(std::string& testCode,
   testCode.append(fmt.str());
 }
 
-void FuncGen::DefineTopLevelGetSizePtr(std::string& testCode,
-                                       const std::string& type,
-                                       const std::string& rawType) {
-  std::string func = R"(
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wunknown-attributes"
-    /* Type: %1%, RawType: %2% */
-    void __attribute__((used, retain)) getSize_%3$016x(const %1% * t)
-    #pragma GCC diagnostic pop
-    void getSize(const %1% * t)
-    {
-      pointers.initialize();
-      auto data = reinterpret_cast<uintptr_t*>(dataBase);
-      data[0] = oidMagicId;
-      data[1] = cookieValue;
-      data[2] = 0;
-
-      size_t dataSegOffset = 3 * sizeof(uintptr_t);
-
-      getSizeType(t, dataSegOffset);
-      OIInternal::StoreData((uintptr_t)123456789, dataSegOffset);
-      OIInternal::StoreData((uintptr_t)123456789, dataSegOffset);
-      data[2] = dataSegOffset;
-      dataBase += dataSegOffset;
-    }
-    )";
-
-  boost::format fmt =
-      boost::format(func) % type % rawType % std::hash<std::string>{}(rawType);
-  testCode.append(fmt.str());
-}
-
 void FuncGen::DefineTopLevelGetSizeSmartPtr(std::string& testCode,
                                             const std::string& rawType) {
   std::string func = R"(

--- a/src/FuncGen.h
+++ b/src/FuncGen.h
@@ -27,17 +27,17 @@ class FuncGen {
  public:
   bool RegisterContainer(ContainerTypeEnum, const fs::path& path);
 
-  void DeclareStoreData(std::string& testCode);
-  void DefineStoreData(std::string& testCode);
+  static void DeclareStoreData(std::string& testCode);
+  static void DefineStoreData(std::string& testCode);
 
-  void DeclareAddData(std::string& testCode);
-  void DefineAddData(std::string& testCode);
+  static void DeclareAddData(std::string& testCode);
+  static void DefineAddData(std::string& testCode);
 
-  void DeclareEncodeData(std::string& testCode);
-  void DefineEncodeData(std::string& testCode);
+  static void DeclareEncodeData(std::string& testCode);
+  static void DefineEncodeData(std::string& testCode);
 
-  void DeclareEncodeDataSize(std::string& testCode);
-  void DefineEncodeDataSize(std::string& testCode);
+  static void DeclareEncodeDataSize(std::string& testCode);
+  static void DefineEncodeDataSize(std::string& testCode);
 
   bool DeclareGetSizeFuncs(std::string& testCode,
                            const std::set<ContainerInfo>& containerInfo,
@@ -46,29 +46,31 @@ class FuncGen {
                           const std::set<ContainerInfo>& containerInfo,
                           bool chaseRawPointers);
 
-  void DeclareGetContainer(std::string& testCode);
+  static void DeclareGetContainer(std::string& testCode);
 
-  void DeclareGetSize(std::string& testCode, const std::string& type);
+  static void DeclareGetSize(std::string& testCode, const std::string& type);
 
-  void DeclareTopLevelGetSize(std::string& testCode, const std::string& type);
-  void DefineTopLevelGetObjectSize(std::string& testCode,
-                                   const std::string& type,
-                                   const std::string& linkageName);
+  static void DeclareTopLevelGetSize(std::string& testCode,
+                                     const std::string& type);
+  static void DefineTopLevelGetObjectSize(std::string& testCode,
+                                          const std::string& type,
+                                          const std::string& linkageName);
 
-  void DefineTopLevelGetSizePtr(std::string& testCode, const std::string& type,
-                                const std::string& rawType);
+  static void DefineTopLevelGetSizePtr(std::string& testCode,
+                                       const std::string& type,
+                                       const std::string& rawType);
 
-  void DefineTopLevelGetSizeRef(std::string& testCode,
-                                const std::string& rawType);
+  static void DefineTopLevelGetSizeRef(std::string& testCode,
+                                       const std::string& rawType);
 
-  void DefineTopLevelGetSizeRefRet(std::string& testCode,
-                                   const std::string& type);
+  static void DefineTopLevelGetSizeRefRet(std::string& testCode,
+                                          const std::string& type);
 
-  void DefineTopLevelGetSizeSmartPtr(std::string& testCode,
-                                     const std::string& rawType);
+  static void DefineTopLevelGetSizeSmartPtr(std::string& testCode,
+                                            const std::string& rawType);
 
-  void DefineGetSizeTypedValueFunc(std::string& testCode,
-                                   const std::string& ctype);
+  static void DefineGetSizeTypedValueFunc(std::string& testCode,
+                                          const std::string& ctype);
 
  private:
   std::map<ContainerTypeEnum, std::string> typeToDeclMap;

--- a/src/FuncGen.h
+++ b/src/FuncGen.h
@@ -56,10 +56,6 @@ class FuncGen {
                                           const std::string& type,
                                           const std::string& linkageName);
 
-  static void DefineTopLevelGetSizePtr(std::string& testCode,
-                                       const std::string& type,
-                                       const std::string& rawType);
-
   static void DefineTopLevelGetSizeRef(std::string& testCode,
                                        const std::string& rawType);
 


### PR DESCRIPTION
This will make it easier to share between legacy and TypeGraph codegen.