### PR TITLE
Add support for exclusive size reporting

### DIFF
--- a/src/TreeBuilder.h
+++ b/src/TreeBuilder.h
@@ -111,4 +111,7 @@ class TreeBuilder {
   template <class T>
   std::string_view serialize(const T &);
   void JSON(NodeID id, std::ofstream &output);
+
+  static void setSize(TreeBuilder::Node &node, uint64_t dynamicSize,
+                      uint64_t memberSizes);
 };

--- a/test/integration/anonymous.toml
+++ b/test/integration/anonymous.toml
@@ -162,24 +162,28 @@ definitions = '''
         "isTypedef": true,
         "staticSize": 8,
         "dynamicSize": 12,
+        "exclusiveSize": 0,
         "members": [{
           "name": "",
           "typeName": "__anon_struct_0",
           "isTypedef": false,
           "staticSize": 8,
           "dynamicSize": 12,
+          "exclusiveSize": 0,
           "members": [{
             "name": "node",
             "typeName": "struct Node *",
             "staticSize": 8,
             "dynamicSize": 12,
+            "exclusiveSize": 8,
             "members": [{
               "typeName": "Node",
               "staticSize": 12,
+              "exclusiveSize": 0,
               "members": [
-                { "name": "a", "staticSize": 4, "dynamicSize": 0 },
-                { "name": "b", "staticSize": 4, "dynamicSize": 0 },
-                { "name": "c", "staticSize": 4, "dynamicSize": 0 }
+                { "name": "a", "staticSize": 4, "exclusiveSize": 4, "dynamicSize": 0 },
+                { "name": "b", "staticSize": 4, "exclusiveSize": 4, "dynamicSize": 0 },
+                { "name": "c", "staticSize": 4, "exclusiveSize": 4, "dynamicSize": 0 }
               ]
             }]
           }]

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -144,10 +144,11 @@ definitions = '''
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":4,
+      "exclusiveSize":4,
       "members":[
-        {"name":"a", "staticSize":4, "dynamicSize":0},
-        {"name":"b", "staticSize":8, "dynamicSize":4},
-        {"name":"c", "staticSize":8, "dynamicSize":0}
+        {"name":"a", "staticSize":4, "exclusiveSize":4, "dynamicSize":0},
+        {"name":"b", "staticSize":8, "exclusiveSize":8, "dynamicSize":4},
+        {"name":"c", "staticSize":8, "exclusiveSize":8, "dynamicSize":0}
       ]}]'''
   [cases.struct_primitive_ptrs_no_follow]
     param_types = ["const PrimitivePtrs&"]

--- a/test/integration/sorted_vector_set.toml
+++ b/test/integration/sorted_vector_set.toml
@@ -34,12 +34,14 @@ definitions = '''
     expect_json = '''[{
       "staticSize": 24,
       "dynamicSize": 16,
+      "exclusiveSize": 0,
       "length":3,
       "capacity":4,
       "elementStaticSize":4,
       "members": [{
         "staticSize": 24,
         "dynamicSize": 16,
+        "exclusiveSize": 40,
         "length": 3,
         "capacity": 4,
         "elementStaticSize": 4

--- a/test/integration/std_array.toml
+++ b/test/integration/std_array.toml
@@ -8,6 +8,7 @@ includes = ["array", "cstdint", "vector"]
       {
         "staticSize": 1,
         "dynamicSize": 0,
+        "exclusiveSize": 1,
         "length": 0,
         "capacity": 0,
         "elementStaticSize": 8
@@ -22,6 +23,7 @@ includes = ["array", "cstdint", "vector"]
       {
         "staticSize": 8,
         "dynamicSize": 0,
+        "exclusiveSize": 8,
         "length": 1,
         "capacity": 1,
         "elementStaticSize": 8
@@ -70,17 +72,20 @@ includes = ["array", "cstdint", "vector"]
       {
         "staticSize": 48,
         "dynamicSize": 72,
+        "exclusiveSize": 0,
         "length": 2,
         "capacity": 2,
         "elementStaticSize": 24,
         "members": [
           {
             "staticSize": 24,
-            "dynamicSize": 40
+            "dynamicSize": 40,
+            "exclusiveSize": 64
           },
           {
             "staticSize": 24,
-            "dynamicSize": 32
+            "dynamicSize": 32,
+            "exclusiveSize": 56
           }
         ]
       }

--- a/test/integration/std_optional.toml
+++ b/test/integration/std_optional.toml
@@ -8,6 +8,7 @@ includes = ["optional", "cstdint", "vector"]
       {
         "staticSize": 16,
         "dynamicSize": 0,
+        "exclusiveSize": 16,
         "length": 0,
         "capacity": 1,
         "elementStaticSize": 8
@@ -22,6 +23,7 @@ includes = ["optional", "cstdint", "vector"]
       {
         "staticSize": 16,
         "dynamicSize": 0,
+        "exclusiveSize": 16,
         "length": 1,
         "capacity": 1,
         "elementStaticSize": 8
@@ -36,6 +38,7 @@ includes = ["optional", "cstdint", "vector"]
       {
         "staticSize": 32,
         "dynamicSize": 0,
+        "exclusiveSize": 32,
         "length": 0,
         "capacity": 1,
         "elementStaticSize": 24
@@ -50,6 +53,7 @@ includes = ["optional", "cstdint", "vector"]
       {
         "staticSize": 32,
         "dynamicSize": 40,
+        "exclusiveSize": 8,
         "length": 1,
         "capacity": 1,
         "elementStaticSize": 24,
@@ -57,6 +61,7 @@ includes = ["optional", "cstdint", "vector"]
           {
             "staticSize": 24,
             "dynamicSize": 40,
+            "exclusiveSize": 64,
             "length": 5
           }
         ]

--- a/test/integration/std_smart_ptr.toml
+++ b/test/integration/std_smart_ptr.toml
@@ -14,6 +14,7 @@ definitions = '''
       {
         "staticSize": 8,
         "dynamicSize": 0,
+        "exclusiveSize": 8,
         "length": 0,
         "capacity": 1,
         "elementStaticSize": 8
@@ -56,13 +57,15 @@ definitions = '''
       {
         "staticSize": 8,
         "dynamicSize": 64,
+        "exclusiveSize": 8,
         "length": 1,
         "capacity": 1,
         "elementStaticSize": 24,
         "members": [
           {
             "staticSize": 24,
-            "dynamicSize": 40
+            "dynamicSize": 40,
+            "exclusiveSize": 64
           }
         ]
       }
@@ -159,7 +162,8 @@ definitions = '''
     [
       {
         "staticSize": 16,
-        "dynamicSize": 0
+        "dynamicSize": 0,
+        "exclusiveSize": 16
       }
     ]
     '''
@@ -170,7 +174,8 @@ definitions = '''
     [
       {
         "staticSize": 16,
-        "dynamicSize": 0
+        "dynamicSize": 0,
+        "exclusiveSize": 16
       }
     ]
     '''

--- a/test/integration/std_string.toml
+++ b/test/integration/std_string.toml
@@ -10,10 +10,12 @@ includes = ["string"]
         "isTypedef": true,
         "staticSize": 32,
         "dynamicSize": 0,
+        "exclusiveSize": 0,
         "members": [
           {
             "staticSize": 32,
             "dynamicSize": 0,
+            "exclusiveSize": 32,
             "length": 0,
             "capacity": 15,
             "elementStaticSize": 1
@@ -32,10 +34,12 @@ includes = ["string"]
         "isTypedef": true,
         "staticSize": 32,
         "dynamicSize": 0,
+        "exclusiveSize": 0,
         "members": [
           {
             "staticSize": 32,
             "dynamicSize": 0,
+            "exclusiveSize": 32,
             "length": 6,
             "capacity": 15,
             "elementStaticSize": 1
@@ -54,10 +58,12 @@ includes = ["string"]
         "isTypedef": true,
         "staticSize": 32,
         "dynamicSize": 26,
+        "exclusiveSize": 0,
         "members": [
           {
             "staticSize": 32,
             "dynamicSize": 26,
+            "exclusiveSize": 58,
             "length": 26,
             "capacity": 26,
             "elementStaticSize": 1

--- a/test/integration/std_variant.toml
+++ b/test/integration/std_variant.toml
@@ -14,11 +14,12 @@ definitions = '''
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
+      "exclusiveSize":15,
       "length":1,
       "capacity":1,
       "elementStaticSize":8,
       "members":[
-        {"typeName":"char", "staticSize":1, "dynamicSize":0}
+        {"typeName":"char", "staticSize":1, "exclusiveSize":1, "dynamicSize":0}
       ]}]'''
   [cases.char_int64_2]
     param_types = ["const std::variant<char, int64_t>&"]
@@ -26,11 +27,12 @@ definitions = '''
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
+      "exclusiveSize":8,
       "length":1,
       "capacity":1,
       "elementStaticSize":8,
       "members":[
-        {"typeName":"long", "staticSize":8, "dynamicSize":0}
+        {"typeName":"long", "staticSize":8, "exclusiveSize":8, "dynamicSize":0}
       ]}]'''
 
   [cases.vector_int_1]
@@ -39,6 +41,7 @@ definitions = '''
     expect_json = '''[{
       "staticSize":32,
       "dynamicSize":12,
+      "exclusiveSize":8,
       "length":1,
       "capacity":1,
       "elementStaticSize":24,
@@ -47,6 +50,7 @@ definitions = '''
           "typeName":"vector<int, std::allocator<int> >",
           "staticSize":24,
           "dynamicSize":12,
+          "exclusiveSize":36,
           "length":3,
           "capacity":3,
           "elementStaticSize":4
@@ -77,6 +81,7 @@ definitions = '''
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":0,
+      "exclusiveSize":8,
       "length":1,
       "capacity":1,
       "elementStaticSize":16,
@@ -84,11 +89,12 @@ definitions = '''
         {
           "staticSize":16,
           "dynamicSize":0,
+          "exclusiveSize":8,
           "length":1,
           "capacity":1,
           "elementStaticSize":8,
           "members":[
-            {"typeName":"long", "staticSize":8, "dynamicSize":0}
+            {"typeName":"long", "staticSize":8, "exclusiveSize":8, "dynamicSize":0}
           ]
         }
       ]}]'''
@@ -109,6 +115,7 @@ definitions = '''
     expect_json = '''[{
       "staticSize":8,
       "dynamicSize":0,
+      "exclusiveSize":8,
       "length":1,
       "capacity":1,
       "elementStaticSize":4,
@@ -125,11 +132,12 @@ definitions = '''
     expect_json = '''[{
       "staticSize":8,
       "dynamicSize":0,
+      "exclusiveSize":7,
       "length":1,
       "capacity":1,
       "elementStaticSize":4,
       "members":[
-        {"typeName":"char", "staticSize":1, "dynamicSize":0}
+        {"typeName":"char", "staticSize":1, "exclusiveSize":1, "dynamicSize":0}
       ]}]'''
   [cases.256_params_empty]
     param_types = ["const std::variant<Thrower,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,char>&"]

--- a/test/integration/std_vector.toml
+++ b/test/integration/std_vector.toml
@@ -17,7 +17,7 @@ includes = ["vector"]
     skip = true # https://github.com/facebookexperimental/object-introspection/issues/14
     param_types = ["const std::vector<bool>&"]
     setup = "return {{true, false, true}};"
-    expect_json = '[{"staticSize":40,"dynamicSize":8, "length":3, "capacity":64, "elementStaticSize":0.125}]'
+    expect_json = '[{"staticSize":40,"dynamicSize":8, "exclusiveSize":40, "length":3, "capacity":64, "elementStaticSize":0.125}]'
   [cases.vector_int_empty]
     param_types = ["const std::vector<std::vector<int>>&"]
     setup = "return {};"
@@ -28,13 +28,14 @@ includes = ["vector"]
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":96,
+      "exclusiveSize":24,
       "length":3,
       "capacity":3,
       "elementStaticSize":24,
       "members":[
-        {"staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4},
-        {"staticSize":24, "dynamicSize":4, "length":1, "capacity":1, "elementStaticSize":4},
-        {"staticSize":24, "dynamicSize":8, "length":2, "capacity":2, "elementStaticSize":4}
+        {"staticSize":24, "dynamicSize":12, "exclusiveSize":36, "length":3, "capacity":3, "elementStaticSize":4},
+        {"staticSize":24, "dynamicSize":4, "exclusiveSize":28, "length":1, "capacity":1, "elementStaticSize":4},
+        {"staticSize":24, "dynamicSize":8, "exclusiveSize":32, "length":2, "capacity":2, "elementStaticSize":4}
       ]}]'''
   [cases.reserve]
     param_types = ["const std::vector<int>&"]
@@ -43,4 +44,4 @@ includes = ["vector"]
       ret.reserve(10);
       return ret;
     '''
-    expect_json = '[{"staticSize":24, "dynamicSize":40, "length":3, "capacity":10, "elementStaticSize":4}]'
+    expect_json = '[{"staticSize":24, "dynamicSize":40, "exclusiveSize":64, "length":3, "capacity":10, "elementStaticSize":4}]'


### PR DESCRIPTION
## Summary
Add initial pass for exclusive size

Unfortunately this became a lot more complex than I was hoping - I was trying to avoid making additional calls into rocksdb, so I couldn't just query for members. That said, it's not that bad considering I had to touch a lot of places.

## Test plan
Writing tests to hopefully cover all the edge cases I can think of. 