### PR TITLE
oilgen: change interface to support multiple calls in one cu

### DIFF
--- a/examples/compile-time-oil/.gitignore
+++ b/examples/compile-time-oil/.gitignore
@@ -2,5 +2,5 @@ oilgen
 OilVectorOfStrings
 OilVectorOfStrings.o
 jit.cpp
-JitCompiled.o
+JitCompiled.*.o
 

--- a/examples/compile-time-oil/Makefile
+++ b/examples/compile-time-oil/Makefile
@@ -15,14 +15,11 @@ oilgen:
 	(cd ../../ && make oid-devel)
 	ln -s ../../build/oilgen oilgen
 
-JitCompiled.o: oilgen OilVectorOfStrings.o
-	./oilgen --exit-code -o JitCompiled.o -c ../../build/sample.oid.toml -d OilVectorOfStrings.o
-
-OilVectorOfStrings: OilVectorOfStrings.o JitCompiled.o
-	${CXX} ${CXXFLAGS} OilVectorOfStrings.o JitCompiled.o -o OilVectorOfStrings
+OilVectorOfStrings: oilgen OilVectorOfStrings.o
+	${CXX} ${CXXFLAGS} OilVectorOfStrings.o $$(./oilgen --exit-code -o JitCompiled.o -c ../../build/sample.oid.toml -d OilVectorOfStrings.o) -o OilVectorOfStrings
 
 all: OilVectorOfStrings
 
 clean:
-	rm -f oilgen OilVectorOfStrings{,.o,.o.dwarf} JitCompiled.o jit.cpp
+	rm -f oilgen OilVectorOfStrings{,.o,.o.dwarf} JitCompiled.*.o jit.cpp
 

--- a/src/OIGenerator.h
+++ b/src/OIGenerator.h
@@ -22,8 +22,6 @@
 #include "OICodeGen.h"
 #include "OICompiler.h"
 
-namespace fs = std::filesystem;
-
 namespace ObjectIntrospection {
 
 class OIGenerator {
@@ -44,9 +42,9 @@ class OIGenerator {
   }
 
  private:
-  fs::path outputPath;
-  fs::path configFilePath;
-  fs::path sourceFileDumpPath;
+  std::filesystem::path outputPath;
+  std::filesystem::path configFilePath;
+  std::filesystem::path sourceFileDumpPath;
   bool failIfNothingGenerated;
 
   std::unordered_map<std::string, std::string> oilStrongToWeakSymbolsMap(
@@ -55,10 +53,10 @@ class OIGenerator {
   std::vector<std::tuple<drgn_qualified_type, std::string>>
   findOilTypesAndNames(drgnplusplus::program& prog);
 
-  bool generateForType(const OICodeGen::Config& generatorConfig,
-                       const OICompiler::Config& compilerConfig,
-                       const drgn_qualified_type& type,
-                       const std::string& linkageName, SymbolService& symbols);
+  std::filesystem::path generateForType(
+      const OICodeGen::Config& generatorConfig,
+      const OICompiler::Config& compilerConfig, const drgn_qualified_type& type,
+      const std::string& linkageName, SymbolService& symbols);
 };
 
 }  // namespace ObjectIntrospection

--- a/tools/OILGen.cpp
+++ b/tools/OILGen.cpp
@@ -29,7 +29,8 @@ using namespace ObjectIntrospection;
 
 constexpr static OIOpts opts{
     OIOpt{'h', "help", no_argument, nullptr, "Print this message and exit."},
-    OIOpt{'o', "output", required_argument, "<file>", "Write output to file."},
+    OIOpt{'o', "output", required_argument, "<file>",
+          "Write output(s) to file(s) with this prefix."},
     OIOpt{'c', "config-file", required_argument, "<oid.toml>",
           "Path to OI configuration file."},
     OIOpt{'d', "dump-jit", optional_argument, "<jit.cpp>",
@@ -63,6 +64,9 @@ int main(int argc, char* argv[]) {
   while ((c = getopt_long(argc, argv, opts.shortOpts(), opts.longOpts(),
                           nullptr)) != -1) {
     switch (c) {
+      case 'h':
+        usage();
+        return EXIT_SUCCESS;
       case 'o':
         outputPath = optarg;
         break;
@@ -85,7 +89,7 @@ int main(int argc, char* argv[]) {
   fs::path primaryObject = argv[optind];
 
   if ((setenv("DRGN_ENABLE_TYPE_ITERATOR", "1", 1)) < 0) {
-    std::cerr << "Failed to set environment variable\
+    LOG(ERROR) << "Failed to set environment variable\
        DRGN_ENABLE_TYPE_ITERATOR\n";
     exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
## Summary

Puts some temporary rubbish in the OILgen path to generate multiple output `.o` files from a single `.o` file. This occurs when there are multiple OIL calls in a single compilation unit.

Eventually (classic) this will be replaced with a single `.o` file containing both calls. This is more optimal as we can share the anonymous namespace between them, e.g. if we have `struct A {}; struct B { A a; };` and have OIL calls for both we can reuse the logic for traversing `A` when traversing `B`. Although this would be possible to implement now, it should be significantly easier after Type Graph is implemented, so I'm using this simple solution for now.

## Test plan

- `cd examples/compile-time-oil && make && ./OilVectorOfStrings` - works
- D43875626
- `make test-devel`
- CI
