### PR TITLE
Warnings cleanup

### DIFF
--- a/src/Metrics.h
+++ b/src/Metrics.h
@@ -36,8 +36,8 @@ constexpr auto outputEnvKey = "OID_METRICS_OUTPUT";
  * "oid_metrics.json".
  */
 struct TraceFlags {
-  bool time : 1 = false;
-  bool rss : 1 = false;
+  bool time = false;
+  bool rss = false;
 
   operator bool() const {
     return time || rss;

--- a/test/integration/arrays.toml
+++ b/test/integration/arrays.toml
@@ -2,9 +2,16 @@ definitions = '''
   struct Foo10 {
     int arr[10];
   };
+
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wzero-length-array"
   struct Foo0 {
     int arr[0];
   };
+
+  using ZeroLengthIntArray = int[0];
+  #pragma clang diagnostic pop
+
   struct MultiDim {
     int arr[2][3];
   };
@@ -59,7 +66,7 @@ definitions = '''
     # WARNING: zero-length arrays are handled differently to non-empty arrays.
     # They end up not being treated as containers. This should probably change
     # in the future.
-    param_types = ["int[0]"]
+    param_types = ["ZeroLengthIntArray"]
     setup = "return {};"
     expect_json = '[{"staticSize":0, "dynamicSize":0}]'
   [cases.ref_int10]
@@ -72,6 +79,6 @@ definitions = '''
     # WARNING: zero-length arrays are handled differently to non-empty arrays.
     # They end up not being treated as containers. This should probably change
     # in the future.
-    param_types = ["const int(&)[0]"]
+    param_types = ["const ZeroLengthIntArray&"]
     setup = "return {};"
     expect_json = '[{"staticSize":0, "dynamicSize":0}]'

--- a/test/integration/gen_tests.py
+++ b/test/integration/gen_tests.py
@@ -56,7 +56,10 @@ def add_test_setup(f, config):
         f"\n"
         f'{config.get("raw_definitions", "")}\n'
         f"namespace {ns} {{\n"
+        f"#pragma clang diagnostic push\n"
+        f"#pragma clang diagnostic ignored \"-Wunused-private-field\"\n"
         f'{config.get("definitions", "")}\n'
+        f"#pragma clang diagnostic pop\n"
     )
 
     # fmt: on


### PR DESCRIPTION
## Summary

- Disables warnings for test code where they're reasonable.
- Changed something which used bitfields with a default initialiser in our single C++17 file to using whole bools with a default initialiser.

I gave up on turning on `-Werror` because I am weak. Before we turn this on we need to build a consistent set of warnings in all the different build environments, otherwise it's very annoying.

## Test plan

- `make test-devel` - there are fewer warnings.
- CI
