### PR TITLE
oil: remove fields in options

### DIFF
--- a/include/ObjectIntrospection.h
+++ b/include/ObjectIntrospection.h
@@ -84,7 +84,6 @@ enum Response : int {
 struct options {
   std::string configFilePath{};
   std::string debugFilePath{};
-  std::string cacheDirPath{};
 
   int debugLevel = 0;
   std::string sourceFileDumpPath{};
@@ -92,11 +91,6 @@ struct options {
   bool layout = false;
   bool chaseRawPointers = false;
   bool generateJitDebugInfo = false;
-
-  bool enableUpload = false;
-  bool enableDownload = false;
-  bool abortOnLoadFail = false;
-  bool forceJIT = true;
 
   friend bool operator==(const options &lhs, const options &rhs);
   friend bool operator!=(const options &lhs, const options &rhs);

--- a/src/OILibrary.cpp
+++ b/src/OILibrary.cpp
@@ -21,7 +21,6 @@ namespace ObjectIntrospection {
 
 bool operator==(const options& lhs, const options& rhs) {
   return lhs.configFilePath == rhs.configFilePath &&
-         lhs.cacheDirPath == rhs.cacheDirPath &&
          lhs.debugFilePath == rhs.debugFilePath &&
          lhs.debugLevel == rhs.debugLevel &&
          lhs.chaseRawPointers == rhs.chaseRawPointers;

--- a/src/OILibraryImpl.h
+++ b/src/OILibraryImpl.h
@@ -22,8 +22,6 @@
 
 namespace ObjectIntrospection {
 
-const std::string function_identifier(uintptr_t);
-
 class OILibraryImpl {
  public:
   OILibraryImpl(OILibrary *, void *);

--- a/test/integration/gen_tests.py
+++ b/test/integration/gen_tests.py
@@ -131,7 +131,6 @@ def add_test_setup(f, config):
             f'  .configFilePath = std::getenv("CONFIG_FILE_PATH"),\n'
             f"  .debugLevel = 3,\n"
             f'  .sourceFileDumpPath = "oil_jit_code.cpp",\n'
-            f"  .forceJIT = true,\n"
             f"}};"
         )
 


### PR DESCRIPTION
## Summary

5 of the fields in the OIL options relate to caching and JIT compilation. Remove these as they don't make sense anymore - you should use compile time OIL if you want caching and to disable JIT. These options are not used under compile time OIL.

## Test plan

- `make test-devel`
- CI
- D44216203
