### PR TITLE
codegen: carry decl and func with containerinfo

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -25,7 +25,54 @@ extern "C" {
 
 constexpr int oidMagicId = 0x01DE8;
 
-struct ContainerInfo;
+#define LIST_OF_CONTAINER_TYPES  \
+  X(UNKNOWN_TYPE)                \
+  X(ARRAY_TYPE)                  \
+  X(SMALL_VEC_TYPE)              \
+  X(SET_TYPE)                    \
+  X(UNORDERED_SET_TYPE)          \
+  X(SEQ_TYPE)                    \
+  X(LIST_TYPE)                   \
+  X(STD_MAP_TYPE)                \
+  X(STD_UNORDERED_MAP_TYPE)      \
+  X(MAP_SEQ_TYPE)                \
+  X(BY_MULTI_QRT_TYPE)           \
+  X(F14_MAP)                     \
+  X(F14_SET)                     \
+  X(FEED_QUICK_HASH_SET)         \
+  X(FEED_QUICK_HASH_MAP)         \
+  X(RADIX_TREE_TYPE)             \
+  X(PAIR_TYPE)                   \
+  X(STRING_TYPE)                 \
+  X(FOLLY_IOBUF_TYPE)            \
+  X(FOLLY_IOBUFQUEUE_TYPE)       \
+  X(FB_STRING_TYPE)              \
+  X(UNIQ_PTR_TYPE)               \
+  X(SHRD_PTR_TYPE)               \
+  X(FB_HASH_MAP_TYPE)            \
+  X(FB_HASH_SET_TYPE)            \
+  X(FOLLY_OPTIONAL_TYPE)         \
+  X(OPTIONAL_TYPE)               \
+  X(TRY_TYPE)                    \
+  X(REF_WRAPPER_TYPE)            \
+  X(SORTED_VEC_SET_TYPE)         \
+  X(REPEATED_FIELD_TYPE)         \
+  X(CAFFE2_BLOB_TYPE)            \
+  X(MULTI_MAP_TYPE)              \
+  X(FOLLY_SMALL_HEAP_VECTOR_MAP) \
+  X(CONTAINER_ADAPTER_TYPE)      \
+  X(MICROLIST_TYPE)              \
+  X(ENUM_MAP_TYPE)               \
+  X(BOOST_BIMAP_TYPE)            \
+  X(STD_VARIANT_TYPE)            \
+  X(THRIFT_ISSET_TYPE)           \
+  X(WEAK_PTR_TYPE)
+
+enum ContainerTypeEnum {
+#define X(name) name,
+  LIST_OF_CONTAINER_TYPES
+#undef X
+};
 
 struct RootInfo {
   std::string varName;
@@ -47,8 +94,9 @@ struct DrgnClassMemberInfo {
 
 struct TypeHierarchy {
   std::map<struct drgn_type*, std::vector<DrgnClassMemberInfo>> classMembersMap;
-  std::map<struct drgn_type*,
-           std::pair<ContainerInfo, std::vector<struct drgn_qualified_type>>>
+  std::map<
+      struct drgn_type*,
+      std::pair<ContainerTypeEnum, std::vector<struct drgn_qualified_type>>>
       containerTypeMap;
   std::map<struct drgn_type*, struct drgn_type*> typedefMap;
   std::map<std::string, size_t> sizeMap;

--- a/src/FuncGen.h
+++ b/src/FuncGen.h
@@ -25,8 +25,6 @@ namespace fs = std::filesystem;
 
 class FuncGen {
  public:
-  bool RegisterContainer(ContainerTypeEnum, const fs::path& path);
-
   static void DeclareStoreData(std::string& testCode);
   static void DefineStoreData(std::string& testCode);
 
@@ -40,10 +38,10 @@ class FuncGen {
   static void DefineEncodeDataSize(std::string& testCode);
 
   bool DeclareGetSizeFuncs(std::string& testCode,
-                           const std::set<ContainerInfo>& containerInfo,
+                           const ContainerInfoRefSet& containerInfo,
                            bool chaseRawPointers);
   bool DefineGetSizeFuncs(std::string& testCode,
-                          const std::set<ContainerInfo>& containerInfo,
+                          const ContainerInfoRefSet& containerInfo,
                           bool chaseRawPointers);
 
   static void DeclareGetContainer(std::string& testCode);
@@ -67,8 +65,4 @@ class FuncGen {
 
   static void DefineGetSizeTypedValueFunc(std::string& testCode,
                                           const std::string& ctype);
-
- private:
-  std::map<ContainerTypeEnum, std::string> typeToDeclMap;
-  std::map<ContainerTypeEnum, std::string> typeToFuncMap;
 };

--- a/src/OICodeGen.h
+++ b/src/OICodeGen.h
@@ -114,8 +114,9 @@ class OICodeGen {
   Config config{};
   FuncGen funcGen;
 
-  using ContainerTypeMap =
-      std::pair<ContainerInfo, std::vector<drgn_qualified_type>>;
+  using ContainerTypeMapEntry =
+      std::pair<std::reference_wrapper<const ContainerInfo>,
+                std::vector<drgn_qualified_type>>;
 
   using TemplateParamList =
       std::vector<std::pair<drgn_qualified_type, std::string>>;
@@ -126,7 +127,7 @@ class OICodeGen {
   std::string linkageName;
   std::map<drgn_type*, std::string> unnamedUnion;
   std::map<std::string, size_t> sizeMap;
-  std::map<drgn_type*, ContainerTypeMap> containerTypeMapDrgn;
+  std::map<drgn_type*, ContainerTypeMapEntry> containerTypeMapDrgn;
   std::vector<std::unique_ptr<ContainerInfo>> containerInfoList;
   std::vector<drgn_type*> enumTypes;
   std::vector<std::string> knownTypes;
@@ -155,7 +156,7 @@ class OICodeGen {
   std::set<drgn_type*> thriftIssetStructTypes;
   std::vector<drgn_type*> topoSortedStructTypes;
 
-  std::set<ContainerInfo> containerTypesFuncDef;
+  ContainerInfoRefSet containerTypesFuncDef;
 
   std::map<std::string, PaddingInfo> paddedStructs;
 
@@ -191,7 +192,8 @@ class OICodeGen {
   static SortedTypeDefMap getSortedTypeDefMap(
       const std::map<drgn_type*, drgn_type*>& typedefTypeMap);
 
-  std::optional<ContainerInfo> getContainerInfo(drgn_type* type);
+  std::optional<std::reference_wrapper<const ContainerInfo>> getContainerInfo(
+      drgn_type* type);
   void printAllTypes();
   void printAllTypeNames();
 

--- a/src/Serialize.cpp
+++ b/src/Serialize.cpp
@@ -67,32 +67,6 @@ void serialize(Archive& ar, PaddingInfo& p, const unsigned int version) {
 INSTANCIATE_SERIALIZE(PaddingInfo)
 
 template <class Archive>
-void serialize(Archive& ar, ContainerInfo& info, const unsigned int version) {
-  verify_version<ContainerInfo>(version);
-  ar& info.typeName;
-  // Unfortunately boost serialization doesn't support `std::optional`,
-  // so we have to do this ourselves
-  size_t numTemplateParams = 0;
-  if (Archive::is_saving::value) {
-    numTemplateParams =
-        info.numTemplateParams.value_or(std::numeric_limits<size_t>::max());
-  }
-  ar& numTemplateParams;
-  if (Archive::is_loading::value) {
-    if (numTemplateParams == std::numeric_limits<size_t>::max()) {
-      info.numTemplateParams = std::nullopt;
-    } else {
-      info.numTemplateParams = numTemplateParams;
-    }
-  }
-  ar& info.ctype;
-  ar& info.header;
-  ar& info.ns;
-}
-
-INSTANCIATE_SERIALIZE(ContainerInfo)
-
-template <class Archive>
 void serialize(Archive& ar, struct drgn_location_description& location,
                const unsigned int version) {
   verify_version<struct drgn_location_description>(version);

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -25,7 +25,6 @@
 #include <boost/serialization/vector.hpp>
 
 #include "Common.h"
-#include "ContainerInfo.h"
 #include "PaddingHunter.h"
 #include "SymbolService.h"
 
@@ -39,7 +38,6 @@
   BOOST_CLASS_VERSION(Type, version)
 
 DEFINE_TYPE_VERSION(PaddingInfo, 120, 3)
-DEFINE_TYPE_VERSION(ContainerInfo, 200, 5)
 DEFINE_TYPE_VERSION(struct drgn_location_description, 32, 2)
 DEFINE_TYPE_VERSION(struct drgn_object_locator, 72, 2)
 DEFINE_TYPE_VERSION(FuncDesc::Arg, 128, 2)
@@ -51,7 +49,7 @@ DEFINE_TYPE_VERSION(struct drgn_type, 152, 4)
 DEFINE_TYPE_VERSION(DrgnClassMemberInfo, 64, 3)
 DEFINE_TYPE_VERSION(struct drgn_qualified_type, 16, 2)
 DEFINE_TYPE_VERSION(RootInfo, 48, 2)
-DEFINE_TYPE_VERSION(TypeHierarchy, 384, 6)
+DEFINE_TYPE_VERSION(TypeHierarchy, 384, 7)
 
 #undef DEFINE_TYPE_VERSION
 
@@ -62,7 +60,6 @@ namespace boost::serialization {
   void serialize(Archive&, Type&, const unsigned int)
 
 DECL_SERIALIZE(PaddingInfo);
-DECL_SERIALIZE(ContainerInfo);
 
 DECL_SERIALIZE(FuncDesc::Arg);
 DECL_SERIALIZE(FuncDesc);

--- a/src/TreeBuilder.cpp
+++ b/src/TreeBuilder.cpp
@@ -571,8 +571,8 @@ void TreeBuilder::processContainer(const Variable& variable, Node& node) {
           node.typeName + "'");
     }
 
-    auto& [containerInfo, templateTypes] = entry->second;
-    kind = containerInfo.ctype;
+    auto& [containerKind, templateTypes] = entry->second;
+    kind = containerKind;
     for (const auto& tt : templateTypes) {
       elementTypes.push_back(tt);
     }

--- a/tools/OIP.cpp
+++ b/tools/OIP.cpp
@@ -76,7 +76,7 @@ void printClassMembersMap(
 void printContainerTypeMap(
     const std::map<
         struct drgn_type*,
-        std::pair<ContainerInfo, std::vector<struct drgn_qualified_type>>>&
+        std::pair<ContainerTypeEnum, std::vector<struct drgn_qualified_type>>>&
         containerTypeMap) {
   printf("{");
   bool isFirstItem = true;


### PR DESCRIPTION
## Summary

Code generation of container function declarations and definitions currently runs through two maps, `typeToDeclMap` and `typeToFuncMap`. These are indexed by the `ContainerTypeEnum` which comes from a field in `ContainerInfo`. Rather than having this indirection, we should get the `decl` and `func` directly from the `ContainerInfo` object.

- Delete the `ContainerInfo` copy constructor as it now contains potentially very large strings.
- Change all copies of `ContainerInfo` to a reference to `OICodegen`'s `containerInfoList`.
- Remove `ContainerInfo` from `Serialize.h` as we no longer need to serialize it - only the numeric enum passes between `OICodeGen` and `TreeBuilder`, which makes sense!

Specifically, instead of looking up `typeToDeclMap[cinfo.ctype]` we now use `cInfo.codegen.decl` directly. The `.toml` files and code flow haven't really changed, except to avoid copying the types which are now quite big.

Closes #81

## Test plan

- CI
- `make test-devel`

Removed the serialization of `ContainerInfo` from CPP on `main`. Compilation fails with a tonne of static asserts, so I'm confident this is safe.