### PR TITLE
Quit oid when upload/download is requested but cache is disabled

### DIFF
--- a/src/OID.cpp
+++ b/src/OID.cpp
@@ -293,6 +293,9 @@ static ExitStatus::ExitStatus runScript(const std::string &fileName,
 
   oid->setCacheRemoteEnabled(oidConfig.cacheRemoteUpload,
                              oidConfig.cacheRemoteDownload);
+  if (!oid->validateCache()) {
+    return ExitStatus::UsageError;
+  }
   oid->setCustomCodeFile(oidConfig.customCodeFile);
   oid->setEnableJitLogging(oidConfig.enableJitLogging);
   oid->setGenerateJitDebugInfo(oidConfig.generateJitDebug);

--- a/src/OIDebugger.h
+++ b/src/OIDebugger.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <glog/logging.h>
+
 #include <filesystem>
 #include <fstream>
 
@@ -84,6 +86,15 @@ class OIDebugger {
     cache.enableUpload = upload;
     cache.enableDownload = download;
     cache.abortOnLoadFail = download && !upload;
+  }
+
+  bool validateCache() {
+    if ((cache.enableUpload || cache.enableDownload) && !cache.isEnabled()) {
+      LOG(ERROR) << "Cache download/upload option specified when cache is "
+                    "disabled - aborting!";
+      return false;
+    }
+    return true;
   }
 
   void setHardDisableDrgn(bool val) {


### PR DESCRIPTION
## Summary
Quit oid if cache is not fully configured. I've tested both sides of this if statement manually internally, and with --mode prod, to make sure other cases are not affected.
