### PR TITLE
std::variant: change to use std::visit

### DIFF
--- a/types/std_variant.toml
+++ b/types/std_variant.toml
@@ -11,32 +11,24 @@ void getSizeType(const %1%<Types...> &container, size_t& returnArg);
 """
 
 func = """
-template <size_t I = 0, class... Types>
-void getSizeVariantContents(const %1%<Types...> &container, size_t& returnArg)
-{
-  if constexpr (I < sizeof...(Types))
-  {
-    if (I == container.index())
-    {
-      // Contents are stored inline - don't double count
-      SAVE_SIZE(-sizeof(std::get<I>(container)));
-
-      getSizeType(std::get<I>(container), returnArg);
-    }
-    else
-    {
-      getSizeVariantContents<I+1>(container, returnArg);
-    }
-  }
-  // else variant is valueless - save no data
-}
-
 template<class... Types>
 void getSizeType(const %1%<Types...> &container, size_t& returnArg)
 {
   SAVE_SIZE(sizeof(%1%<Types...>));
-
   SAVE_DATA(container.index());
-  getSizeVariantContents(container, returnArg);
+
+  // This check should be `container.valueless_by_exception()` but it doesn't
+  // work with the variable sized integers used in `std::variant`. For fewer
+  // than 256 options it uses a `uint8_t` index but checks against -1 of
+  // `uintptr_t`. Manually check for any out of bounds indices as a workaround.
+  if (container.index() >= sizeof...(Types)) {
+    return;
+  }
+
+  std::visit([&returnArg](auto &&arg) {
+    // Account for inline contents
+    SAVE_SIZE(-sizeof(arg));
+    getSizeType(arg, returnArg);
+  }, container);
 }
 """


### PR DESCRIPTION
## Summary

`getSizeType` for `std::variant` previously used a custom templated visitor. Update to use `std::visit`. This is a `.toml` only change as the data written to the data segment is identical.

`if (container.index() >= sizeof...(Types))` is necessary as `container.valueless_by_exception()` does not work correctly for variants whose index is optimised to a type which can't contain `0xffffffffffffffff`. There is already a test that checks the last possible element is handled correctly.

## Test plan

- `make test-devel`
- CI
