### PR TITLE
Avoid following weak_ptrs

### DIFF
--- a/dev.oid.toml
+++ b/dev.oid.toml
@@ -45,4 +45,5 @@ containers = [
     "PWD/types/caffe2_blob_type.toml",
     "PWD/types/std_variant.toml",
     "PWD/types/thrift_isset_type.toml",
+    "PWD/types/weak_ptr_type.toml",
 ]

--- a/src/ContainerInfo.h
+++ b/src/ContainerInfo.h
@@ -62,7 +62,8 @@ namespace fs = std::filesystem;
   X(ENUM_MAP_TYPE)               \
   X(BOOST_BIMAP_TYPE)            \
   X(STD_VARIANT_TYPE)            \
-  X(THRIFT_ISSET_TYPE)
+  X(THRIFT_ISSET_TYPE)           \
+  X(WEAK_PTR_TYPE)
 
 enum ContainerTypeEnum {
 #define X(name) name,

--- a/src/OICodeGen.cpp
+++ b/src/OICodeGen.cpp
@@ -761,10 +761,11 @@ bool OICodeGen::enumerateTemplateParamIdxs(drgn_type *type,
     }
   }
 
-  // Do not add `shared_ptr<void>` or `unique_ptr<void>`
+  // Do not add `shared_ptr<void>`, `unique_ptr<void>`, or `weak_ptr<void>`
   // to `containerTypeMapDrgn`.
   if (containerInfo.ctype == SHRD_PTR_TYPE ||
-      containerInfo.ctype == UNIQ_PTR_TYPE) {
+      containerInfo.ctype == UNIQ_PTR_TYPE ||
+      containerInfo.ctype == WEAK_PTR_TYPE) {
     drgn_qualified_type t{};
     // We checked that this succeeded in the previous loop
     drgn_template_parameter_type(&tParams[0], &t);

--- a/src/TreeBuilder.cpp
+++ b/src/TreeBuilder.cpp
@@ -618,6 +618,9 @@ void TreeBuilder::processContainer(const Variable &variable, Node &node) {
         return;
       }
       break;
+    case WEAK_PTR_TYPE:
+      // Do not handle weak pointers beyond their static size for now.
+      break;
     case SHRD_PTR_TYPE:
     case UNIQ_PTR_TYPE:
       node.pointer = next();

--- a/test/ci.oid.toml
+++ b/test/ci.oid.toml
@@ -41,6 +41,7 @@ containers = [
     "../types/caffe2_blob_type.toml",
     "../types/std_variant.toml",
     "../types/thrift_isset_type.toml",
+    "../types/weak_ptr_type.toml",
 ]
 
 [headers]

--- a/test/integration/std_smart_ptr.toml
+++ b/test/integration/std_smart_ptr.toml
@@ -179,3 +179,97 @@ definitions = '''
       }
     ]
     '''
+  [cases.weak_ptr_int64_empty]
+    param_types = ["std::weak_ptr<std::uint64_t>&"]
+    setup = "return std::weak_ptr<std::uint64_t>();"
+    expect_json = '''
+    [
+      {
+        "staticSize": 16,
+        "exclusiveSize": 16,
+        "dynamicSize": 0,
+        "NOT": "members"
+      }
+    ]
+    '''
+  [cases.weak_ptr_int64_void_empty]
+    param_types = ["std::weak_ptr<void>&"]
+    setup = "return std::weak_ptr<void>();"
+    expect_json = '''
+    [
+      {
+        "staticSize": 16,
+        "exclusiveSize": 16,
+        "dynamicSize": 0,
+        "NOT": "members"
+      }
+    ]
+    '''
+  [cases.weak_ptr_int64_present]
+    param_types = ["std::weak_ptr<std::uint64_t>&"]
+    setup = '''
+    static std::shared_ptr<std::uint64_t> shd = std::make_shared<std::uint64_t>(0xDEADBEEF);
+    std::weak_ptr<std::uint64_t> weak = shd;
+    return weak;
+    '''
+    expect_json = '''
+    [
+      {
+        "staticSize": 16,
+        "exclusiveSize": 16,
+        "dynamicSize": 0,
+        "NOT": "members"
+      }
+    ]
+    '''
+  [cases.weak_ptr_int64_expired]
+    param_types = ["std::weak_ptr<std::uint64_t>&"]
+    setup = '''
+    std::shared_ptr<std::uint64_t> shd = std::make_shared<std::uint64_t>(0xDEADBEEF);
+    std::weak_ptr<std::uint64_t> weak = shd;
+    return weak;
+    '''
+    expect_json = '''
+    [
+      {
+        "staticSize": 16,
+        "exclusiveSize": 16,
+        "dynamicSize": 0,
+        "NOT": "members"
+      }
+    ]
+    '''
+  [cases.weak_ptr_int64_present_chase]
+    param_types = ["std::weak_ptr<std::uint64_t>&"]
+    cli_options = ["--chase-raw-pointers"]
+    setup = '''
+    static std::shared_ptr<std::uint64_t> shd = std::make_shared<std::uint64_t>(0xDEADBEEF);
+    std::weak_ptr<std::uint64_t> weak = shd;
+    return weak;
+    '''
+    expect_json = '''
+    [
+      {
+        "staticSize": 16,
+        "exclusiveSize": 16,
+        "dynamicSize": 0,
+        "NOT": "members"
+      }
+    ]
+    '''
+  [cases.weak_ptr_int64_expired_chase]
+    param_types = ["std::weak_ptr<std::uint64_t>&"]
+    cli_options = ["--chase-raw-pointers"]
+    setup = '''
+    return std::make_shared<std::uint64_t>(0xDEADBEEF);
+    '''
+    expect_json = '''
+    [
+      {
+        "staticSize": 16,
+        "exclusiveSize": 16,
+        "dynamicSize": 0,
+        "NOT": "members"
+      }
+    ]
+    '''

--- a/types/weak_ptr_type.toml
+++ b/types/weak_ptr_type.toml
@@ -1,0 +1,22 @@
+[info]
+typeName = "std::weak_ptr"
+numTemplateParams = 1
+ctype = "WEAK_PTR_TYPE"
+header = "memory"
+ns = ["namespace std"]
+replaceTemplateParamIndex = []
+
+[codegen]
+decl = """
+template<typename T>
+void getSizeType(const %1%<T> &s_ptr, size_t& returnArg);
+"""
+
+# Weak pointers do not have ownership, so let's not follow them (for now)
+func = """
+template<typename T>
+void getSizeType(const %1%<T> &s_ptr, size_t& returnArg)
+{
+    SAVE_SIZE(sizeof(%1%<T>));
+}
+"""


### PR DESCRIPTION
## Summary

Previously, we treated weak_ptrs as normal types and we recursed within them, following the internal data pointer and possibly causing crashes. We really shouldn't be following them, so I added a custom type to simply abort processing. If we want to handle them (ie: check if they are valid, and follow them if so), that should be fairly easy with the work there is here so far.

If people think we should be following weak pointers, I'm happy to add that in.

## Test plan
Added test cases, and manual testing on a couple types (verifying the json output). 