### PR TITLE
Add drgn function for looking up by "pure name"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "extern/drgn"]
   path = extern/drgn
-  url = https://github.com/ajor/drgn.git
+  url = https://github.com/jgkamat/drgn.git


### PR DESCRIPTION
## Summary
Add drgn function for looking up by "pure name"

Normally we really shouldn't need to go from string name to type, but in theory it is possible and quick with drgn to do so. Unfortunately doing so properly would require making a parser which can consume C++ types and return "normalized" versions of that. In lieu of doing that, I'm just doing a simple string split. 

Therefore this API should work for the simple case (no spaces, types matching dwarf exactly, etc). But if anything is wrong, we will return not found.

## Test plan
Add call to this function and verify build succeeds (to make sure we can actually call this function). Verify function works with a hacky python wrapper on a larger binary. Also tested by Jon as part of volume testing.
