### PR TITLE
Fix warning in drgn pure name changes

### DIFF
--- a/src/OIGenerator.cpp
+++ b/src/OIGenerator.cpp
@@ -85,7 +85,7 @@ OIGenerator::findOilTypesAndNames(drgnplusplus::program& prog) {
   for (auto& func : drgnplusplus::func_iterator(prog)) {
     std::string strongLinkageName;
     {
-      char* linkageNameCstr;
+      const char* linkageNameCstr;
       if (auto err = drgnplusplus::error(
               drgn_type_linkage_name(func.type, &linkageNameCstr))) {
         // throw err;


### PR DESCRIPTION
## Summary
Fix a warning in the pure changes I added last week. Whoops, butterfingers :)

All this should be is a missing declaration in `libdrgn/dwarf_info.h`

## Test plan
These are now the warnings left in the drgn codebase on our fork
```
../../libdrgn/dwarf_info.c: In function ‘drgn_func_iterator_create’:
../../libdrgn/dwarf_info.c:9434:7: warning: assignment to ‘struct drgn_func_iterator *’ from incompatible pointer type ‘struct drgn_type_iterator *’ [-Wincompatible-pointer-types]
  *ret = iter;
       ^
../../libdrgn/dwarf_info.c: In function ‘drgn_type_linkage_name’:
../../libdrgn/dwarf_info.c:9585:11: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  *str_ret = dwarf_formstring(&linkage_name);
```

Which should be fixed probably, but not right now.