### PR TITLE
Cycles

### DIFF
--- a/src/FuncGen.cpp
+++ b/src/FuncGen.cpp
@@ -251,7 +251,6 @@ void FuncGen::DefineTopLevelGetSizeRef(std::string& testCode,
       data[2] = 0;
 
       size_t dataSegOffset = 3 * sizeof(uintptr_t);
-      OIInternal::StoreData((uintptr_t)(&t), dataSegOffset);
       JLOG("%1% @");
       JLOGPTR(&t);
       OIInternal::getSizeType(t, dataSegOffset);
@@ -279,7 +278,6 @@ void FuncGen::DefineTopLevelGetSizeRefRet(std::string& testCode,
       pointers.initialize();
       size_t ret = 0;
       pointers.add((uintptr_t)&t);
-      SAVE_DATA((uintptr_t)t);
       OIInternal::getSizeType(t, ret);
       return ret;
     }
@@ -305,7 +303,6 @@ void FuncGen::DefineTopLevelGetSizeSmartPtr(std::string& testCode,
       data[2] = 0;
 
       size_t dataSegOffset = 3 * sizeof(uintptr_t);
-      OIInternal::StoreData((uintptr_t)(&t), dataSegOffset);
 
       OIInternal::getSizeType(t, dataSegOffset);
       OIInternal::StoreData((uintptr_t)123456789, dataSegOffset);

--- a/src/OICodeGen.cpp
+++ b/src/OICodeGen.cpp
@@ -3284,7 +3284,10 @@ bool OICodeGen::generateJitCode(std::string& code) {
       JLOGPTR(s_ptr);
       StoreData((uintptr_t)(s_ptr), returnArg);
       if (s_ptr && pointers.add((uintptr_t)s_ptr)) {
-          getSizeType(*(s_ptr), returnArg);
+        StoreData(1, returnArg);
+        getSizeType(*(s_ptr), returnArg);
+      } else {
+        StoreData(0, returnArg);
       }
     }
 

--- a/src/TreeBuilder.cpp
+++ b/src/TreeBuilder.cpp
@@ -40,7 +40,7 @@ extern "C" {
 }
 
 /* Tag indicating if the pointer has  been followed or skipped */
-enum class TrackPointerTag: uint64_t {
+enum class TrackPointerTag : uint64_t {
   /* The content has been skipped.
    * It prevents double counting the footprint of a node the JIT code has seen
    * before, double counting content being stored inline, or getting stuck in an
@@ -225,9 +225,6 @@ void TreeBuilder::build(const std::vector<uint64_t>& data,
     auto& rootID = rootIDs.emplace_back(nextNodeID++);
 
     try {
-      // The first value is the address of the root object. Drop it as we don't
-      // need to manage pointer deduplication anymore.
-      next();
       process(rootID, {.type = type, .name = argName, .typePath = argName});
     } catch (...) {
       // Mark the failure using the error node ID

--- a/src/TreeBuilder.h
+++ b/src/TreeBuilder.h
@@ -99,13 +99,11 @@ class TreeBuilder {
    */
   std::unique_ptr<msgpack::sbuffer> buffer;
   rocksdb::DB* db = nullptr;
-  std::unordered_set<uintptr_t> pointers{};
 
   uint64_t getDrgnTypeSize(struct drgn_type* type);
   uint64_t next();
   bool isContainer(const Variable& variable);
   bool isPrimitive(struct drgn_type* type);
-  bool shouldProcess(uintptr_t pointer);
   Node process(NodeID id, Variable variable);
   void processContainer(const Variable& variable, Node& node);
   template <class T>

--- a/test/integration.py
+++ b/test/integration.py
@@ -261,7 +261,7 @@ class OIDebuggerTestCase(unittest.TestCase):
             beforeSegs = int(numsegs.stdout.decode("ascii"))
 
             proc = subprocess.run(
-                f"{self.oid} --script {self.script()} -t 1 --pid {pid}",
+                f"{self.oid} --config-file {self.oid_conf} --script {self.script()} -t 1 --pid {pid} -d 3",
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -279,7 +279,7 @@ class OIDebuggerTestCase(unittest.TestCase):
 
             # remove both the text and data segments
             proc = subprocess.run(
-                f"{self.oid} -r --pid {pid}",
+                f"{self.oid} --config-file {self.oid_conf} -r --pid {pid}",
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/test/integration/cycles.toml
+++ b/test/integration/cycles.toml
@@ -90,7 +90,6 @@ definitions = '''
     '''
 
   [cases.unique_ptr]
-    oil_skip = "OIL processes one node in the cycle twice" # https://github.com/facebookexperimental/object-introspection/issues/104
     param_types = ["std::reference_wrapper<UniqueNode>&"]
     setup = '''
       auto first = std::make_unique<UniqueNode>();
@@ -168,7 +167,6 @@ definitions = '''
     '''
 
   [cases.shared_ptr]
-    oil_skip = "OIL processes one node in the cycle twice" # https://github.com/facebookexperimental/object-introspection/issues/104
     param_types = ["std::reference_wrapper<SharedNode>&"]
     setup = '''
       auto first = std::make_shared<SharedNode>();

--- a/test/integration/fbstring.toml
+++ b/test/integration/fbstring.toml
@@ -76,7 +76,6 @@ includes = ["folly/FBString.h"]
     '''
 
   [cases.string_pooled]
-    skip = "Potentially incorrect dynamic size"
     param_types = ["folly::fbstring&"]
     setup = "return folly::fbstring(1024, 'c');"
     expect_json = '''

--- a/types/fb_string_type.toml
+++ b/types/fb_string_type.toml
@@ -24,12 +24,15 @@ void getSizeType(const %1%<E, T, A, Storage> &t, size_t& returnArg)
     SAVE_DATA((uintptr_t)t.capacity());
     SAVE_DATA((uintptr_t)t.size());
 
-    // Check if the string is contained within the type (inlined) so as not to double count.
-    SAVE_SIZE(
-      ((uintptr_t)t.data() < (uintptr_t)(&t + sizeof(%1%<E, T, A, Storage>)))
+    bool inlined = ((uintptr_t)t.data() < (uintptr_t)(&t + sizeof(%1%<E, T, A, Storage>)))
         &&
-      ((uintptr_t)t.data() >= (uintptr_t)&t)
-        ? 0 : (t.capacity() * sizeof(T))
-    );
+      ((uintptr_t)t.data() >= (uintptr_t)&t);
+
+    if (!inlined && pointers.add((uintptr_t)t.data())) {
+      SAVE_SIZE(t.capacity() * sizeof(T));
+      SAVE_DATA(1);
+    } else {
+      SAVE_DATA(0);
+    }
 }
 """

--- a/types/folly_iobuf_queue_type.toml
+++ b/types/folly_iobuf_queue_type.toml
@@ -21,7 +21,11 @@ void getSizeType(const %1% &t, size_t& returnArg)
 
     const IOBuf *head = t.front();
     SAVE_DATA((uintptr_t)head);
-    if (head)
-    getSizeType(*head, returnArg);
+    if (head && pointers.add((uintptr_t)head)) {
+        SAVE_DATA(1);
+        getSizeType(*head, returnArg);
+    } else {
+        SAVE_DATA(0);
+    }
 }
 """

--- a/types/ref_wrapper_type.toml
+++ b/types/ref_wrapper_type.toml
@@ -20,6 +20,11 @@ void getSizeType(const %1%<T> &ref, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T>));
     SAVE_DATA((uintptr_t)&(ref.get()));
-    getSizeType(ref.get(), returnArg);
+    if (pointers.add((uintptr_t)&ref.get())) {
+        SAVE_DATA(1);
+        getSizeType(ref.get(), returnArg);
+    } else {
+        SAVE_DATA(0);
+    }
 }
 """

--- a/types/shrd_ptr_type.toml
+++ b/types/shrd_ptr_type.toml
@@ -21,11 +21,14 @@ void getSizeType(const %1%<T> &s_ptr, size_t& returnArg)
     SAVE_SIZE(sizeof(%1%<T>));
 
     if constexpr (!std::is_void<T>::value) {
-    SAVE_DATA((uintptr_t)(s_ptr.get()));
+        SAVE_DATA((uintptr_t)(s_ptr.get()));
 
-    if (s_ptr && pointers.add((uintptr_t)(s_ptr.get()))) {
-        getSizeType(*(s_ptr.get()), returnArg);
-    }
+        if (s_ptr && pointers.add((uintptr_t)(s_ptr.get()))) {
+            SAVE_DATA(1);
+            getSizeType(*(s_ptr.get()), returnArg);
+        } else {
+            SAVE_DATA(0);
+        }
     }
 }
 """

--- a/types/uniq_ptr_type.toml
+++ b/types/uniq_ptr_type.toml
@@ -21,11 +21,14 @@ void getSizeType(const %1%<T,Deleter> &s_ptr, size_t& returnArg)
     SAVE_SIZE(sizeof(%1%<T,Deleter>));
 
     if constexpr (!std::is_void<T>::value) {
-    SAVE_DATA((uintptr_t)(s_ptr.get()));
+        SAVE_DATA((uintptr_t)(s_ptr.get()));
 
-    if (s_ptr && pointers.add((uintptr_t)(s_ptr.get()))) {
-        getSizeType(*(s_ptr.get()), returnArg);
-    }
+        if (s_ptr && pointers.add((uintptr_t)(s_ptr.get()))) {
+            SAVE_DATA(1);
+            getSizeType(*(s_ptr.get()), returnArg);
+        } else {
+            SAVE_DATA(0);
+        }
     }
 }
 """


### PR DESCRIPTION
## Summary

Moves all of the pointer detection logic out of TreeBuilder and into the data segment. Closes #104 as there is now no opportunity for OIL to have a different issue in pointer detection logic to OID. This makes it easier to type the datasegment as part of #95. There is room for improvement as null pointer implies the following will be a zero, meaning we could save a byte, but this is easier to implement for an MVP of the typed data segment.

Also fixes a bug in the `integration.py` tests where the config wasn't passed to OID, causing it to use the default. This took a lot of head scratching to debug.

## Test plan

- `make test-devel`
- CI
- Tried adding a test for `folly::IOBufQueue`. Unfortunately it's completely broken, because of #123 and not including the logic for traversing the `folly::IOBuf`, at minimum.
