### PR TITLE
add test for folly::fbstring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,9 @@ jobs:
               clang-12 \
               libboost-all-dev \
               libgflags-dev \
-              llvm-12-dev
+              llvm-12-dev \
+              libfmt-dev \
+              libjemalloc-dev
       - run:
           name: Test
           environment:

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -5,6 +5,7 @@ set(INTEGRATION_TEST_CONFIGS
   container_enums.toml
   cycles.toml
   enums.toml
+  fbstring.toml
   ignored.toml
   inheritance_access.toml
   inheritance_multiple.toml

--- a/test/integration/fbstring.toml
+++ b/test/integration/fbstring.toml
@@ -1,0 +1,102 @@
+includes = ["folly/FBString.h"]
+[cases]
+  [cases.empty]
+    param_types = ["folly::fbstring&"]
+    setup = "return {};"
+    expect_json = '''
+    [
+      {
+        "typeName": "fbstring",
+        "isTypedef": true,
+        "staticSize": 24,
+        "dynamicSize": 0,
+        "exclusiveSize": 0,
+        "members": [
+          {
+            "staticSize": 24,
+            "dynamicSize": 0,
+            "exclusiveSize": 24,
+            "length": 0,
+            "capacity": 23,
+            "elementStaticSize": 1
+          }
+        ]
+      }
+    ]
+    '''
+
+  [cases.inline]
+    param_types = ["folly::fbstring&"]
+    setup = 'return {"012345"};'
+    expect_json = '''
+    [
+      {
+        "typeName": "fbstring",
+        "isTypedef": true,
+        "staticSize": 24,
+        "dynamicSize": 0,
+        "exclusiveSize": 0,
+        "members": [
+          {
+            "staticSize": 24,
+            "dynamicSize": 0,
+            "exclusiveSize": 24,
+            "length": 6,
+            "capacity": 23,
+            "elementStaticSize": 1
+          }
+        ]
+      }
+    ]
+    '''
+
+  [cases.heap_allocated]
+    param_types = ["folly::fbstring&"]
+    setup = 'return {"abcdefghijklmnopqrstuvwxzy"};'
+    expect_json = '''
+    [
+      {
+        "typeName": "fbstring",
+        "isTypedef": true,
+        "staticSize": 24,
+        "dynamicSize": 26,
+        "exclusiveSize": 0,
+        "members": [
+          {
+            "staticSize": 24,
+            "dynamicSize": 26,
+            "exclusiveSize": 50,
+            "length": 26,
+            "capacity": 26,
+            "elementStaticSize": 1
+          }
+        ]
+      }
+    ]
+    '''
+
+  [cases.string_pooled]
+    skip = "Potentially incorrect dynamic size"
+    param_types = ["folly::fbstring&"]
+    setup = "return folly::fbstring(1024, 'c');"
+    expect_json = '''
+    [
+      {
+        "typeName": "fbstring",
+        "isTypedef": true,
+        "staticSize": 24,
+        "dynamicSize": 1024,
+        "exclusiveSize": 0,
+        "members": [
+          {
+            "staticSize": 24,
+            "dynamicSize": 1024,
+            "exclusiveSize": 1048,
+            "length": 1024,
+            "capacity": 1024,
+            "elementStaticSize": 1
+          }
+        ]
+      }
+    ]
+    '''

--- a/types/fb_string_type.toml
+++ b/types/fb_string_type.toml
@@ -3,7 +3,7 @@ typeName = "folly::basic_fbstring<"
 numTemplateParams = 1
 ctype = "FB_STRING_TYPE"
 header = "folly/FBString.h"
-ns = ["folly::basic_fbstring"]
+ns = ["folly::basic_fbstring", "folly::fbstring_core"]
 replaceTemplateParamIndex = []
 # allocatorIndex = 0
 # underlyingContainerIndex = 0
@@ -18,8 +18,18 @@ func = """
 template <typename E,class T,class A,class Storage>
 void getSizeType(const %1%<E, T, A, Storage> &t, size_t& returnArg)
 {
+    SAVE_SIZE(sizeof(%1%<E, T, A, Storage>));
+
     SAVE_DATA((uintptr_t)(t.data()));
     SAVE_DATA((uintptr_t)t.capacity());
     SAVE_DATA((uintptr_t)t.size());
+
+    // Check if the string is contained within the type (inlined) so as not to double count.
+    SAVE_SIZE(
+      ((uintptr_t)t.data() < (uintptr_t)(&t + sizeof(%1%<E, T, A, Storage>)))
+        &&
+      ((uintptr_t)t.data() >= (uintptr_t)&t)
+        ? 0 : (t.capacity() * sizeof(T))
+    );
 }
 """


### PR DESCRIPTION
## Summary

Adds a test case for `folly::fbstring`. Leaves the shared case skipped as it's not including the string allocation.

## Test plan

- `make configure-devel && make test`
- CI
