### PR TITLE
Generate a shared library linked to integration_test_target

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -68,6 +68,7 @@ list(TRANSFORM INTEGRATION_TEST_CONFIGS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -no-pie")
 
 set(INTEGRATION_TEST_TARGET_SRC integration_test_target.cpp)
+set(INTEGRATION_TEST_TARGET_SHLIB_SRC integration_test_target_shlib.cpp)
 set(INTEGRATION_TEST_RUNNER_SRC integration_test_runner.cpp)
 
 find_program(PYTHON_CMD NAMES python3.6 python3)
@@ -81,19 +82,25 @@ list(TRANSFORM INTEGRATION_TEST_THRIFT_SRCS APPEND ".thrift")
 add_custom_command(
   OUTPUT
     ${INTEGRATION_TEST_TARGET_SRC}
+    ${INTEGRATION_TEST_TARGET_SHLIB_SRC}
     ${INTEGRATION_TEST_RUNNER_SRC}
     ${INTEGRATION_TEST_THRIFT_SRCS}
   COMMAND ${PYTHON_CMD}
     ${CMAKE_CURRENT_SOURCE_DIR}/gen_tests.py
     ${INTEGRATION_TEST_TARGET_SRC}
+    ${INTEGRATION_TEST_TARGET_SHLIB_SRC}
     ${INTEGRATION_TEST_RUNNER_SRC}
     ${INTEGRATION_TEST_CONFIGS}
   MAIN_DEPENDENCY gen_tests.py
   DEPENDS ${INTEGRATION_TEST_CONFIGS})
 
+add_library(integration_test_target_shlib SHARED ${INTEGRATION_TEST_TARGET_SHLIB_SRC})
+target_compile_options(integration_test_target_shlib PRIVATE -O1)
+target_link_libraries(integration_test_target_shlib PRIVATE oil Boost::headers ${Boost_LIBRARIES})
+
 add_executable(integration_test_target ${INTEGRATION_TEST_TARGET_SRC})
 target_compile_options(integration_test_target PRIVATE -O1)
-target_link_libraries(integration_test_target PRIVATE oil Boost::headers ${Boost_LIBRARIES})
+target_link_libraries(integration_test_target PRIVATE oil integration_test_target_shlib Boost::headers ${Boost_LIBRARIES})
 
 add_executable(integration_test_runner ${INTEGRATION_TEST_RUNNER_SRC} runner_common.cpp)
 target_include_directories(integration_test_runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -112,6 +112,13 @@ definitions = '''
   required for a specific test to compile, avoiding the need to add new
   dependencies to the build system for one-off tests.
 
+- `definitions_shlib`, `raw_definitions_shlib`
+
+  Same as above, but the definitions are put into a shared library linked with the target program.
+  It enables testing how Object Introspection handles shared libraries.
+
+  **WARNING:** The shared library doesn't handle Thrift definitions.
+
 - `cases` **Required**
 
   A list of individual test cases, each with their own setup, OI probe


### PR DESCRIPTION
## Summary
Extend our integration test suite by linking a generated shared library to the integration_test_target. This enable us testing and validating that `oid` handles shared libraries. We can add definitions in the shared library using the keys `definitions_shlib` and `raw_definitions_shlib`.

## Test plan
There are no tests using the new shlib definitions, yet. However, we can see this PR is not affecting our existing tests:
```
$ make configure-devel
[...]

$ make test
[...]
100% tests passed, 0 tests failed out of 420

Total Test time (real) =  75.04 sec
```