### PR TITLE
Add a feature system to OI to make it easier to add optional features in the future

### DIFF
--- a/examples/compile-time-oil/Makefile
+++ b/examples/compile-time-oil/Makefile
@@ -12,7 +12,7 @@ OilVectorOfStrings.o: OilVectorOfStrings.cpp
 
 oilgen:
 	rm -f oilgen
-	(cd ../../ && make oid-devel)
+	(cd ../../ && make oid)
 	ln -s ../../build/oilgen oilgen
 
 OilVectorOfStrings: oilgen OilVectorOfStrings.o

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(symbol_service
 
 add_library(codegen
   ContainerInfo.cpp
+  Features.cpp
   FuncGen.cpp
   OICodeGen.cpp
 )

--- a/src/Features.cpp
+++ b/src/Features.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "Features.h"
+
+#include <map>
+
+namespace ObjectIntrospection {
+
+Feature featureFromStr(std::string_view str) {
+  static const std::map<std::string_view, Feature> nameMap = {
+#define X(name, str) {str, Feature::name},
+      OI_FEATURE_LIST
+#undef X
+  };
+
+  if (auto search = nameMap.find(str); search != nameMap.end()) {
+    return search->second;
+  }
+  return Feature::UnknownFeature;
+}
+
+const char* featureToStr(Feature f) {
+  switch (f) {
+#define X(name, str)  \
+  case Feature::name: \
+    return str;
+    OI_FEATURE_LIST
+#undef X
+
+    default:
+      return "UnknownFeature";
+  }
+}
+
+}  // namespace ObjectIntrospection

--- a/src/Features.h
+++ b/src/Features.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+#include <string_view>
+
+#define OI_FEATURE_LIST                         \
+  X(ChaseRawPointers, "chase-raw-pointers")     \
+  X(PackStructs, "pack-structs")                \
+  X(GenPaddingStats, "gen-padding-stats")       \
+  X(CaptureThriftIsset, "capture-thrift-isset") \
+  X(PolymorphicInheritance, "polymorphic-inheritance")
+
+namespace ObjectIntrospection {
+
+enum class Feature {
+  UnknownFeature,
+#define X(name, _) name,
+  OI_FEATURE_LIST
+#undef X
+};
+
+Feature featureFromStr(std::string_view);
+const char* featureToStr(Feature);
+
+constexpr std::array allFeatures = {
+#define X(name, _) Feature::name,
+    OI_FEATURE_LIST
+#undef X
+};
+
+}  // namespace ObjectIntrospection

--- a/src/OICodeGen.h
+++ b/src/OICodeGen.h
@@ -28,6 +28,7 @@ struct irequest;
 
 #include "Common.h"
 #include "ContainerInfo.h"
+#include "Features.h"
 #include "FuncGen.h"
 #include "PaddingHunter.h"
 
@@ -35,6 +36,7 @@ extern "C" {
 #include <drgn.h>
 }
 
+using namespace ObjectIntrospection;
 namespace fs = std::filesystem;
 
 struct ParentMember {
@@ -54,11 +56,8 @@ class OICodeGen {
      * uninitialized field" warning if they missed any.
      */
     bool useDataSegment;
-    bool chaseRawPointers;
-    bool packStructs;
-    bool genPaddingStats;
-    bool captureThriftIsset;
-    bool polymorphicInheritance;
+
+    std::set<Feature> features{};
 
     std::set<fs::path> containerConfigPaths{};
     std::set<std::string> defaultHeaders{};
@@ -113,6 +112,12 @@ class OICodeGen {
  private:
   Config config{};
   FuncGen funcGen;
+
+  bool chaseRawPointers;
+  bool packStructs;
+  bool genPaddingStats;
+  bool captureThriftIsset;
+  bool polymorphicInheritance;
 
   using ContainerTypeMapEntry =
       std::pair<std::reference_wrapper<const ContainerInfo>,

--- a/src/OIDebugger.h
+++ b/src/OIDebugger.h
@@ -32,11 +32,13 @@
 namespace fs = std::filesystem;
 
 class OIDebugger {
-  OIDebugger(std::string, OICodeGen::Config, TreeBuilder::Config);
+  OIDebugger(OICodeGen::Config, OICompiler::Config, TreeBuilder::Config);
 
  public:
-  OIDebugger(pid_t, std::string, OICodeGen::Config, TreeBuilder::Config);
-  OIDebugger(fs::path, std::string, OICodeGen::Config, TreeBuilder::Config);
+  OIDebugger(pid_t, OICodeGen::Config, OICompiler::Config, TreeBuilder::Config);
+  OIDebugger(fs::path, OICodeGen::Config, OICompiler::Config,
+             TreeBuilder::Config);
+
   bool segmentInit(void);
   bool stopTarget(void);
   bool interruptTarget(void);
@@ -142,7 +144,6 @@ class OIDebugger {
   }
 
  private:
-  std::string configFilePath;
   bool debug = false;
   bool enableJitLogging = false;
   pid_t traceePid{};

--- a/src/OIGenerator.cpp
+++ b/src/OIGenerator.cpp
@@ -184,13 +184,20 @@ int OIGenerator::generate(fs::path& primaryObject, SymbolService& symbols) {
   std::vector<std::tuple<drgn_qualified_type, std::string>> oilTypes =
       findOilTypesAndNames(prog);
 
+  std::map<Feature, bool> featuresMap = {
+      {Feature::PackStructs, true},
+  };
+
   OICodeGen::Config generatorConfig{};
   OICompiler::Config compilerConfig{};
-  if (!OIUtils::processConfigFile(configFilePath, compilerConfig,
-                                  generatorConfig)) {
+
+  auto features = OIUtils::processConfigFile(configFilePath, featuresMap,
+                                             compilerConfig, generatorConfig);
+  if (!features) {
     LOG(ERROR) << "failed to process config file";
     return -1;
   }
+  generatorConfig.features = *features;
   generatorConfig.useDataSegment = false;
 
   size_t failures = 0;

--- a/src/OILibraryImpl.cpp
+++ b/src/OILibraryImpl.cpp
@@ -80,16 +80,22 @@ void OILibraryImpl::initCompiler() {
   symbols = std::make_shared<SymbolService>(getpid());
 
   compilerConfig.generateJitDebugInfo = _self->opts.generateJitDebugInfo;
-
   generatorConfig.useDataSegment = false;
-  generatorConfig.chaseRawPointers = _self->opts.chaseRawPointers;
-  generatorConfig.packStructs = true;
-  generatorConfig.genPaddingStats = false;
 }
 
 bool OILibraryImpl::processConfigFile() {
-  return OIUtils::processConfigFile(_self->opts.configFilePath, compilerConfig,
-                                    generatorConfig);
+  auto features = OIUtils::processConfigFile(
+      _self->opts.configFilePath,
+      {
+          {Feature::ChaseRawPointers, _self->opts.chaseRawPointers},
+          {Feature::PackStructs, true},
+      },
+      compilerConfig, generatorConfig);
+  if (!features) {
+    return false;
+  }
+  generatorConfig.features = *features;
+  return true;
 }
 
 template <class T, class F>

--- a/src/OIUtils.h
+++ b/src/OIUtils.h
@@ -15,13 +15,17 @@
  */
 #pragma once
 
+#include <optional>
+#include <set>
+
+#include "Features.h"
 #include "OICodeGen.h"
 #include "OICompiler.h"
 
 namespace OIUtils {
 
-bool processConfigFile(const std::string& configFilePath,
-                       OICompiler::Config& compilerConfig,
-                       OICodeGen::Config& generatorConfig);
+std::optional<std::set<Feature>> processConfigFile(
+    const std::string& configFilePath, std::map<Feature, bool> featureMap,
+    OICompiler::Config& compilerConfig, OICodeGen::Config& generatorConfig);
 
 }  // namespace OIUtils

--- a/src/TreeBuilder.cpp
+++ b/src/TreeBuilder.cpp
@@ -53,6 +53,9 @@ enum class TrackPointerTag : uint64_t {
 TreeBuilder::TreeBuilder(Config c) : config{std::move(c)} {
   buffer = std::make_unique<msgpack::sbuffer>();
 
+  chaseRawPointers = config.features.contains(Feature::ChaseRawPointers);
+  genPaddingStats = config.features.contains(Feature::GenPaddingStats);
+
   auto testdbPath = "/tmp/testdb_" + std::to_string(getpid());
   if (auto status = rocksdb::DestroyDB(testdbPath, {}); !status.ok()) {
     LOG(FATAL) << "RocksDB error while destroying database: "
@@ -414,7 +417,7 @@ TreeBuilder::Node TreeBuilder::process(NodeID id, Variable variable) {
   if (!variable.isStubbed) {
     switch (drgn_type_kind(variable.type)) {
       case DRGN_TYPE_POINTER:
-        if (config.chaseRawPointers) {
+        if (chaseRawPointers) {
           // Pointers to incomplete types are stubbed out
           // See OICodeGen::enumeratePointerType
           if (th->knownDummyTypeList.contains(variable.type)) {
@@ -529,7 +532,7 @@ TreeBuilder::Node TreeBuilder::process(NodeID id, Variable variable) {
         break;
     }
 
-    if (config.genPaddingStats) {
+    if (genPaddingStats) {
       auto entry = paddedStructs->find(node.typeName);
       if (entry != paddedStructs->end()) {
         entry->second.instancesCnt++;

--- a/src/TreeBuilder.h
+++ b/src/TreeBuilder.h
@@ -18,11 +18,13 @@
 #include <memory>
 #include <msgpack/sbuffer_decl.hpp>
 #include <optional>
+#include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
 #include "Common.h"
+#include "Features.h"
 
 // The rocksdb includes are extremely heavy and bloat compile times,
 // so we just forward-declare `DB` to avoid making other compile units
@@ -39,9 +41,8 @@ class TreeBuilder {
   struct Config {
     // Don't set default values for the config so the user gets
     // an "unitialized field" warning if he missed any.
+    std::set<ObjectIntrospection::Feature> features;
     bool logAllStructs;
-    bool chaseRawPointers;
-    bool genPaddingStats;
     bool dumpDataSegment;
     std::optional<std::string> jsonPath;
   };
@@ -65,6 +66,9 @@ class TreeBuilder {
   const TypeHierarchy* th = nullptr;
   const std::vector<uint64_t>* oidData = nullptr;
   std::map<std::string, PaddingInfo>* paddedStructs = nullptr;
+
+  bool genPaddingStats;
+  bool chaseRawPointers;
 
   /*
    * The RocksDB output needs versioning so they are imported correctly in

--- a/test/integration/gen_tests.py
+++ b/test/integration/gen_tests.py
@@ -270,13 +270,16 @@ def add_oid_integration_test(f, config, case_name, case):
     cli_options = (
         "{" + ", ".join(f'"{option}"' for option in case.get("cli_options", ())) + "}"
     )
-    config_extra = case.get("config", "")
+
+    config_prefix = case.get("config_prefix", "")
+    config_suffix = case.get("config_suffix", "")
 
     f.write(
         f"\n"
         f"TEST_F(OidIntegration, {case_str}) {{\n"
         f"{generate_skip(case, 'oid')}"
-        f'  std::string configOptions = R"--({config_extra})--";\n'
+        f'  std::string configPrefix = R"--({config_prefix})--";\n'
+        f'  std::string configSuffix = R"--({config_suffix})--";\n'
         f"  ba::io_context ctx;\n"
         f"  auto [target, oid] = runOidOnProcess(\n"
         f"        {{\n"
@@ -285,7 +288,7 @@ def add_oid_integration_test(f, config, case_name, case):
         f'          .scriptSource = "{probe_str}",\n'
         f"        }},\n"
         f"        {cli_options},\n"
-        f"        std::move(configOptions));\n"
+        f"        std::move(configPrefix), std::move(configSuffix));\n"
         f"  ASSERT_EQ(exit_code(oid), {exit_code});\n"
         f"  EXPECT_EQ(target.proc.running(), true);\n"
     )
@@ -341,18 +344,20 @@ def add_oil_integration_test(f, config, case_name, case):
     if case.get("oil_disable", False):
         return
 
-    config_extra = case.get("config", "")
+    config_prefix = case.get("config_prefix", "")
+    config_suffix = case.get("config_suffix", "")
 
     f.write(
         f"\n"
         f"TEST_F(OilIntegration, {case_str}) {{\n"
         f"{generate_skip(case, 'oil')}"
-        f'  std::string configOptions = R"--({config_extra})--";\n'
+        f'  std::string configPrefix = R"--({config_prefix})--";\n'
+        f'  std::string configSuffix = R"--({config_suffix})--";\n'
         f"  ba::io_context ctx;\n"
         f"  auto target = runOilTarget({{\n"
         f"    .ctx = ctx,\n"
         f'    .targetArgs = "oil {case_str}",\n'
-        f"  }}, std::move(configOptions));\n\n"
+        f"  }}, std::move(configPrefix), std::move(configSuffix));\n\n"
         f"  ASSERT_EQ(exit_code(target), {exit_code});\n"
         f"\n"
         f"  bpt::ptree result_json;\n"

--- a/test/integration/ignored.toml
+++ b/test/integration/ignored.toml
@@ -18,7 +18,7 @@ definitions = '''
         "The 3rd member of the struct Bar"
       };
     """
-    config = """
+    config_suffix = """
     [[codegen.ignore]]
     type = "Foo"
     members = ["a"]

--- a/test/integration/inheritance_polymorphic.toml
+++ b/test/integration/inheritance_polymorphic.toml
@@ -136,3 +136,23 @@ definitions = '''
         {"name":"vec_b", "staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4},
         {"name":"int_c", "staticSize":4, "dynamicSize":0}
       ]}]'''
+  [cases.feature_flag]
+    oil_skip = "Polymorphic inheritance disabled in OIL"
+    cli_options = ["-fpolymorphic-inheritance"]
+    param_types = ["const B&"]
+    arg_types = ["C"]
+    setup = '''
+      C c;
+      c.vec_b = {1,2,3};
+      return c;
+    '''
+    expect_json = '''[{
+      "typeName":"C",
+      "staticSize":48,
+      "dynamicSize":12,
+      "members":[
+        {"staticSize":8, "dynamicSize":0},
+        {"name":"int_a", "staticSize":4, "dynamicSize":0},
+        {"name":"vec_b", "staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4},
+        {"name":"int_c", "staticSize":4, "dynamicSize":0}
+      ]}]'''

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -238,3 +238,47 @@ definitions = '''
         {"staticSize":8, "dynamicSize":0, "pointer":0},
         {"staticSize":8, "dynamicSize":0, "NOT": {"pointer":0}}
       ]}]'''
+  [cases.feature_flag]
+    oil_disable = "oil can't chase raw pointers safely"
+    param_types = ["const std::vector<int*>&"]
+    setup = "return {{new int(1), nullptr, new int(3)}};"
+    cli_options = ["-fchase-raw-pointers"]
+    expect_json = '''[{
+      "staticSize":24,
+      "dynamicSize":32,
+      "length":3,
+      "capacity":3,
+      "elementStaticSize":8,
+      "members":[
+        {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}},
+        {"staticSize":8, "dynamicSize":0, "pointer":0},
+        {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}}
+      ]}]'''
+  [cases.feature_flag_disabled]
+    param_types = ["const PrimitivePtrs&"]
+    setup = "return PrimitivePtrs{0, new int(0), new int(0)};"
+    cli_options = ["-fchase-raw-pointers", "-Fchase-raw-pointers"]
+    expect_json = '''[{
+      "staticSize":24,
+      "dynamicSize":0,
+      "members":[
+        {"name":"a", "staticSize":4, "dynamicSize":0},
+        {"name":"b", "staticSize":8, "dynamicSize":0},
+        {"name":"c", "staticSize":8, "dynamicSize":0}
+      ]}]'''
+  [cases.feature_config]
+    oil_disable = "oil can't chase raw pointers safely"
+    param_types = ["const std::vector<int*>&"]
+    setup = "return {{new int(1), nullptr, new int(3)}};"
+    config_prefix = 'features = ["chase-raw-pointers"]'
+    expect_json = '''[{
+      "staticSize":24,
+      "dynamicSize":32,
+      "length":3,
+      "capacity":3,
+      "elementStaticSize":8,
+      "members":[
+        {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}},
+        {"staticSize":8, "dynamicSize":0, "pointer":0},
+        {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}}
+      ]}]'''

--- a/test/integration/runner_common.cpp
+++ b/test/integration/runner_common.cpp
@@ -122,9 +122,10 @@ int IntegrationBase::exit_code(Proc& proc) {
   return proc.proc.exit_code();
 }
 
-fs::path IntegrationBase::createCustomConfig(const std::string& extraConfig) {
+fs::path IntegrationBase::createCustomConfig(const std::string& prefix,
+                                             const std::string& suffix) {
   // If no extra config provided, return the config path unaltered.
-  if (extraConfig.empty()) {
+  if (prefix.empty() && suffix.empty()) {
     return configFile;
   }
 
@@ -157,9 +158,17 @@ fs::path IntegrationBase::createCustomConfig(const std::string& extraConfig) {
   }
 
   std::ofstream customConfig(customConfigFile, std::ios_base::app);
+  if (!prefix.empty()) {
+    customConfig << "\n\n# Test custom config start\n\n";
+    customConfig << prefix;
+    customConfig << "\n\n# Test custom config end\n\n";
+  }
   customConfig << config;
-  customConfig << "\n\n# Test custom config\n\n";
-  customConfig << extraConfig;
+  if (!suffix.empty()) {
+    customConfig << "\n\n# Test custom config start\n\n";
+    customConfig << suffix;
+    customConfig << "\n\n# Test custom config end\n\n";
+  }
 
   return customConfigFile;
 }
@@ -170,7 +179,8 @@ std::string OidIntegration::TmpDirStr() {
 
 OidProc OidIntegration::runOidOnProcess(OidOpts opts,
                                         std::vector<std::string> extra_args,
-                                        std::string extra_config) {
+                                        std::string configPrefix,
+                                        std::string configSuffix) {
   // Binary paths are populated by CMake
   std::string targetExe =
       std::string(TARGET_EXE_PATH) + " " + opts.targetArgs + " 1000";
@@ -195,7 +205,7 @@ OidProc OidIntegration::runOidOnProcess(OidOpts opts,
     std::ofstream touch(segconfigPath);
   }
 
-  fs::path thisConfig = createCustomConfig(extra_config);
+  fs::path thisConfig = createCustomConfig(configPrefix, configSuffix);
 
   // Keep PID as the last argument to make it easier for users to directly copy
   // and modify the command from the verbose mode output.
@@ -337,8 +347,9 @@ std::string OilIntegration::TmpDirStr() {
   return std::string("/tmp/oil-integration-XXXXXX");
 }
 
-Proc OilIntegration::runOilTarget(OidOpts opts, std::string extra_config) {
-  fs::path thisConfig = createCustomConfig(extra_config);
+Proc OilIntegration::runOilTarget(OidOpts opts, std::string configPrefix,
+                                  std::string configSuffix) {
+  fs::path thisConfig = createCustomConfig(configPrefix, configSuffix);
 
   std::string targetExe = std::string(TARGET_EXE_PATH) + " " + opts.targetArgs +
                           " " + thisConfig.string();

--- a/test/integration/runner_common.h
+++ b/test/integration/runner_common.h
@@ -38,7 +38,8 @@ class IntegrationBase : public ::testing::Test {
   void TearDown() override;
   void SetUp() override;
   int exit_code(Proc& proc);
-  std::filesystem::path createCustomConfig(const std::string& extra);
+  std::filesystem::path createCustomConfig(const std::string& prefix,
+                                           const std::string& suffix);
 
   std::filesystem::path workingDir;
 
@@ -51,7 +52,7 @@ class OidIntegration : public IntegrationBase {
   std::string TmpDirStr() override;
 
   OidProc runOidOnProcess(OidOpts opts, std::vector<std::string> extra_args,
-                          std::string extra_config);
+                          std::string configPrefix, std::string configSuffix);
 
   /*
    * compare_json
@@ -69,5 +70,6 @@ class OilIntegration : public IntegrationBase {
  protected:
   std::string TmpDirStr() override;
 
-  Proc runOilTarget(OidOpts opts, std::string extra_config);
+  Proc runOilTarget(OidOpts opts, std::string configPrefix,
+                    std::string configSuffix);
 };

--- a/test/integration/thrift_isset.toml
+++ b/test/integration/thrift_isset.toml
@@ -225,3 +225,24 @@ namespace cpp2 {
         {"name":"__fbthrift_field_e", "staticSize":4, "NOT":"isset"},
         {"name":"__isset", "staticSize":3}
       ]}]'''
+
+  [cases.feature_flag]
+    param_types = ["const cpp2::MyThriftStructBoxed&"]
+    setup = '''
+      cpp2::MyThriftStructBoxed ret;
+      ret.d_ref() = 1;
+      ret.e_ref() = 1;
+      return ret;
+    '''
+    cli_options = ["-fcapture-thrift-isset"]
+    expect_json = '''[{
+      "staticSize":32,
+      "dynamicSize":0,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":8, "NOT":"isset"},
+        {"name":"__fbthrift_field_b", "staticSize":8, "NOT":"isset"},
+        {"name":"__fbthrift_field_c", "staticSize":4, "isset":false},
+        {"name":"__fbthrift_field_d", "staticSize":4, "isset":true},
+        {"name":"__fbthrift_field_e", "staticSize":4, "isset":true},
+        {"name":"__isset", "staticSize":3}
+      ]}]'''


### PR DESCRIPTION
## Summary

Adds features which are specified either on the command line or the config.

- Enable a feature with e.g. `-fchase-raw-pointers`.
- Disable a feature with e.g. `-Fchase-raw-pointers`, last on the command line is always preferred.
- Add a base set of features in the config using: `features = ["chase-raw-pointers"]`.
- Messed around with the test extra config option as sometimes with `.toml` things need to be at the top or at the bottom of the file.

## Test plan

- New tests for each case.
- Checked `oilgen` still functions on its limited test case (really should write proper external tests for that...).
- `make test`
- CI
