### PR TITLE
Faster locateSymbol by re-using dwfl across calls

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -105,3 +105,14 @@ struct TypeHierarchy {
   std::set<struct drgn_type*> thriftIssetStructTypes;
   std::map<struct drgn_type*, std::vector<struct drgn_type*>> descendantClasses;
 };
+
+// Helper for std::variant and std::visit
+// https://en.cppreference.com/w/cpp/utility/variant/visit
+template <class... Ts>
+struct visitor : Ts... {
+  using Ts::operator()...;
+};
+
+// Type deduction for the helper above
+template <class... Ts>
+visitor(Ts...) -> visitor<Ts...>;

--- a/src/SymbolService.h
+++ b/src/SymbolService.h
@@ -28,6 +28,7 @@
 
 namespace fs = std::filesystem;
 
+struct Dwfl;
 struct drgn_program;
 struct irequest;
 
@@ -38,7 +39,10 @@ struct SymbolInfo {
 
 class SymbolService {
  public:
-  SymbolService(std::variant<pid_t, fs::path>);
+  SymbolService(pid_t);
+  SymbolService(fs::path);
+  SymbolService(const SymbolService&) = delete;
+  SymbolService& operator=(const SymbolService&) = delete;
   ~SymbolService();
 
   struct drgn_program* getDrgnProgram();
@@ -60,8 +64,13 @@ class SymbolService {
   }
 
  private:
-  std::variant<pid_t, fs::path> target{0};
+  std::variant<pid_t, fs::path> target;
+  struct Dwfl* dwfl{nullptr};
   struct drgn_program* prog{nullptr};
+
+  bool loadModules();
+  bool loadModulesFromPid(pid_t);
+  bool loadModulesFromPath(const fs::path&);
 
   std::vector<std::pair<uint64_t, uint64_t>> executableAddrs{};
   bool hardDisableDrgn = false;


### PR DESCRIPTION
## Summary
SymbolService is used to locate symbols when the JIT code is being relocated in the target process. Our previous implementation was inefficient, as a new `Dwfl` instance was created, initialised with the target's modules, then destroyed, for each call to `locateSymbol`.

This PR modifies SymbolService to keep the same `Dwfl` instance across multiple calls to `locateSymbol`. Dwfl is initialised once, during the SymbolService construction.

## Test plan
This PR doesn't change `oid`'s behaviour. The tests should be enough to validate the changes.
```
$ make test
[...]
100% tests passed, 0 tests failed out of 420

Total Test time (real) =  66.51 sec
```