### PR TITLE
Add folly shims to avoid linking against folly

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -91,7 +91,9 @@ add_custom_command(
   MAIN_DEPENDENCY gen_tests.py
   DEPENDS ${INTEGRATION_TEST_CONFIGS})
 
-add_executable(integration_test_target ${INTEGRATION_TEST_TARGET_SRC})
+add_executable(integration_test_target
+  ${INTEGRATION_TEST_TARGET_SRC}
+  folly_shims.cpp)
 target_compile_options(integration_test_target PRIVATE -O1)
 target_link_libraries(integration_test_target PRIVATE oil Boost::headers ${Boost_LIBRARIES})
 

--- a/test/integration/folly_shims.cpp
+++ b/test/integration/folly_shims.cpp
@@ -1,0 +1,19 @@
+#include <folly/lang/SafeAssert.h>
+
+namespace folly {
+namespace detail {
+
+// The FOLLY_SAFE_DCHECK macro is peppered throughout the folly headers. When
+// building in release mode this macro does nothing, but in debug builds it
+// requires safe_assert_terminate() to be defined. To avoid building and
+// linking against folly, we define our own no-op version of this function here.
+template <>
+void safe_assert_terminate<false>(safe_assert_arg const* arg, ...) noexcept {
+}
+
+template <>
+void safe_assert_terminate<true>(safe_assert_arg const* arg, ...) noexcept {
+}
+
+}  // namespace detail
+}  // namespace folly


### PR DESCRIPTION
This fixes linker errors in debug builds.

When building in debug mode (-DCMAKE_BUILD_TYPE=Debug), folly requires the function "safe_assert_terminate" to be defined. To avoid building and linking against folly, we define our own no-op version of this function.