### PR TITLE
Pass in CodeCov.io token through CI env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,4 +204,4 @@ jobs:
             # forever. Delete it for a speedup.
             rm -rf extern
 
-            ./codecov -Z -f coverage.info
+            ./codecov -Z -f coverage.info -t $CODECOV_TOKEN


### PR DESCRIPTION
CodeCov's docs say that a token isn't required for a public repository, but our uploads have been broken for a few weeks at this point and passing in the token fixes them...