### PR TITLE
features: switch to bitset

### DIFF
--- a/oi/Features.cpp
+++ b/oi/Features.cpp
@@ -45,4 +45,10 @@ const char* featureToStr(Feature f) {
   }
 }
 
+FeatureSet::FeatureSet(std::initializer_list<Feature> features) {
+  for (auto f : features) {
+    (*this)[f] = true;
+  }
+}
+
 }  // namespace ObjectIntrospection

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <array>
+#include <bitset>
 #include <string_view>
 
 #define OI_FEATURE_LIST                         \
@@ -41,6 +42,25 @@ constexpr std::array allFeatures = {
 #define X(name, _) Feature::name,
     OI_FEATURE_LIST
 #undef X
+};
+
+class FeatureSet {
+ private:
+  using BitsetType = std::bitset<allFeatures.size() + 1>;
+
+ public:
+  FeatureSet() = default;
+  FeatureSet(std::initializer_list<Feature>);
+
+  constexpr bool operator[](Feature f) const {
+    return bitset[(size_t)f];
+  }
+  BitsetType::reference operator[](Feature f) {
+    return bitset[(size_t)f];
+  }
+
+ private:
+  BitsetType bitset;
 };
 
 }  // namespace ObjectIntrospection

--- a/oi/OICodeGen.h
+++ b/oi/OICodeGen.h
@@ -57,7 +57,7 @@ class OICodeGen {
      */
     bool useDataSegment;
 
-    std::set<Feature> features{};
+    FeatureSet features{};
 
     std::set<fs::path> containerConfigPaths{};
     std::set<std::string> defaultHeaders{};
@@ -112,12 +112,6 @@ class OICodeGen {
  private:
   Config config{};
   FuncGen funcGen;
-
-  bool chaseRawPointers;
-  bool packStructs;
-  bool genPaddingStats;
-  bool captureThriftIsset;
-  bool polymorphicInheritance;
 
   using ContainerTypeMapEntry =
       std::pair<std::reference_wrapper<const ContainerInfo>,
@@ -185,6 +179,9 @@ class OICodeGen {
     std::unique_ptr<char, FreeDeleter> _data;
   };
 
+  bool feature(Feature f) const {
+    return config.features[f];
+  }
   static void prependQualifiers(enum drgn_qualifiers, std::string& sb);
   static std::string stripFullyQualifiedName(
       const std::string& fullyQualifiedName);

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -2852,7 +2852,7 @@ bool OIDebugger::processTargetData() {
     const auto& [rootType, typeHierarchy, paddingInfos] = typeInfo->second;
     VLOG(1) << "Root type addr: " << (void*)rootType.type.type;
 
-    if (treeBuilderConfig.features.contains(Feature::GenPaddingStats)) {
+    if (treeBuilderConfig.features[Feature::GenPaddingStats]) {
       paddingHunter.localPaddedStructs = paddingInfos;
       typeTree.setPaddedStructs(&paddingHunter.localPaddedStructs);
     }
@@ -2876,7 +2876,7 @@ bool OIDebugger::processTargetData() {
       continue;
     }
 
-    if (treeBuilderConfig.features.contains(Feature::GenPaddingStats)) {
+    if (treeBuilderConfig.features[Feature::GenPaddingStats]) {
       paddingHunter.processLocalPaddingInfo();
     }
   }
@@ -2890,7 +2890,7 @@ bool OIDebugger::processTargetData() {
     typeTree.dumpJson();
   }
 
-  if (treeBuilderConfig.features.contains(Feature::GenPaddingStats)) {
+  if (treeBuilderConfig.features[Feature::GenPaddingStats]) {
     paddingHunter.outputPaddingInfo();
   }
 

--- a/oi/OIUtils.cpp
+++ b/oi/OIUtils.cpp
@@ -31,7 +31,7 @@ namespace OIUtils {
 using namespace ObjectIntrospection;
 using namespace std::literals;
 
-std::optional<std::set<Feature>> processConfigFile(
+std::optional<ObjectIntrospection::FeatureSet> processConfigFile(
     const std::string& configFilePath,
     std::map<Feature, bool> featureMap,
     OICompiler::Config& compilerConfig,
@@ -153,10 +153,10 @@ std::optional<std::set<Feature>> processConfigFile(
     }
   }
 
-  std::set<Feature> featuresSet;
+  ObjectIntrospection::FeatureSet featuresSet;
   for (auto [k, v] : featureMap) {
     if (v) {
-      featuresSet.insert(k);
+      featuresSet[k] = true;
     }
   }
   return featuresSet;

--- a/oi/OIUtils.h
+++ b/oi/OIUtils.h
@@ -24,7 +24,7 @@
 
 namespace OIUtils {
 
-std::optional<std::set<Feature>> processConfigFile(
+std::optional<ObjectIntrospection::FeatureSet> processConfigFile(
     const std::string& configFilePath,
     std::map<Feature, bool> featureMap,
     OICompiler::Config& compilerConfig,

--- a/oi/TreeBuilder.h
+++ b/oi/TreeBuilder.h
@@ -41,7 +41,7 @@ class TreeBuilder {
   struct Config {
     // Don't set default values for the config so the user gets
     // an "unitialized field" warning if he missed any.
-    std::set<ObjectIntrospection::Feature> features;
+    ObjectIntrospection::FeatureSet features;
     bool logAllStructs;
     bool dumpDataSegment;
     std::optional<std::string> jsonPath;
@@ -68,9 +68,6 @@ class TreeBuilder {
   const TypeHierarchy* th = nullptr;
   const std::vector<uint64_t>* oidData = nullptr;
   std::map<std::string, PaddingInfo>* paddedStructs = nullptr;
-
-  bool genPaddingStats;
-  bool chaseRawPointers;
 
   /*
    * The RocksDB output needs versioning so they are imported correctly in

--- a/tools/OITB.cpp
+++ b/tools/OITB.cpp
@@ -120,10 +120,8 @@ static std::ostream&
 operator<<(std::ostream& out, TreeBuilder::Config tbc) {
   out << "TreeBuilde::Config = [";
   out << "\n  logAllStructs = " << tbc.logAllStructs;
-  out << "\n  chaseRawPointers = "
-      << tbc.features.contains(Feature::ChaseRawPointers);
-  out << "\n  genPaddingStats = "
-      << tbc.features.contains(Feature::GenPaddingStats);
+  out << "\n  chaseRawPointers = " << tbc.features[Feature::ChaseRawPointers];
+  out << "\n  genPaddingStats = " << tbc.features[Feature::GenPaddingStats];
   out << "\n  dumpDataSegment = " << tbc.dumpDataSegment;
   out << "\n  jsonPath = " << (tbc.jsonPath ? *tbc.jsonPath : "NONE");
   out << "\n]\n";
@@ -157,10 +155,10 @@ int main(int argc, char* argv[]) {
             true;  // Weird that we're setting it to true, again...
         break;
       case 'n':
-        tbConfig.features.insert(Feature::ChaseRawPointers);
+        tbConfig.features[Feature::ChaseRawPointers] = true;
         break;
       case 'w':
-        tbConfig.features.erase(Feature::GenPaddingStats);
+        tbConfig.features[Feature::GenPaddingStats] = false;
         break;
       case 'J':
         tbConfig.jsonPath = optarg ? optarg : "oid_out.json";
@@ -189,7 +187,7 @@ int main(int argc, char* argv[]) {
 
   TreeBuilder typeTree(tbConfig);
 
-  if (tbConfig.features.contains(Feature::GenPaddingStats)) {
+  if (tbConfig.features[Feature::GenPaddingStats]) {
     LOG(INFO) << "Setting-up PaddingHunter...";
     typeTree.setPaddedStructs(&paddingInfos);
   }


### PR DESCRIPTION
## Summary

Features were implemented as a `std::set` and cached as bits. Make this more efficient by storing them in a `bitset` (wrapped to have enum accessor).

## Test plan

- `make test`
- CI
