### PR TITLE
drgn: refactor, cull dead code, and disable inline

### DIFF
--- a/oi/SymbolService.cpp
+++ b/oi/SymbolService.cpp
@@ -500,6 +500,7 @@ static void parseFormalParam(Dwarf_Die& param,
   VLOG(1) << "Adding function arg address: " << farg;
 }
 
+/*
 static bool handleInlinedFunction(const irequest& request,
                                   std::shared_ptr<FuncDesc> funcDesc,
                                   struct drgn_qualified_type& funcType,
@@ -577,6 +578,7 @@ static bool handleInlinedFunction(const irequest& request,
   module = inlinedInstance->_private.module;
   return true;
 }
+*/
 
 static std::optional<std::shared_ptr<FuncDesc>> createFuncDesc(
     struct drgn_program* prog, const irequest& request) {
@@ -603,9 +605,11 @@ static std::optional<std::shared_ptr<FuncDesc>> createFuncDesc(
   }
 
   if (dwarf_func_inline(&funcDie) == 1) {
-    if (!handleInlinedFunction(request, fd, *ft, funcDie, module)) {
-      return std::nullopt;
-    }
+    // if (!handleInlinedFunction(request, fd, *ft, funcDie, module)) {
+    //   return std::nullopt;
+    // }
+    LOG(ERROR) << "inlined functions are not supported";
+    return std::nullopt;
   }
 
   ptrdiff_t offset = 0;


### PR DESCRIPTION
## Summary

This is a brutal change to the drgn fork, getting it ready for a rebase. Mainly:
- Removes commits of already dead code.
- Squashes fixes to earlier commits into the earlier commit, hopefully making each commit valid in isolation.
- Disables function inlining and the drgn infrastructure. It's not widely used, and we can cherry-pick it back if it becomes of interest in the future.

All in all this gets us down to 26 commits ahead, and the majority are neat and self contained. 2 are already upstreamed and 1 will be worked on soon.

## Test plan

- `make test`
- CI
