### PR TITLE
resources: manage headers properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ target_link_libraries(oid_parser glog::glog)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(oi)
+add_subdirectory(resources)
 add_library(oicore
   oi/Descs.cpp
   oi/Metrics.cpp
@@ -261,6 +262,7 @@ target_link_libraries(oicore
   ${Boost_LIBRARIES}
   Boost::headers
   glog::glog
+  resources
 )
 if (FORCE_LLVM_STATIC)
   target_link_libraries(oicore

--- a/oi/Headers.h
+++ b/oi/Headers.h
@@ -1,0 +1,10 @@
+#include <string_view>
+
+namespace ObjectIntrospection {
+namespace headers {
+
+// These externs are provided by our build system. See resources/CMakeLists.txt
+extern const std::string_view OITraceCode_cpp;
+
+}  // namespace headers
+}  // namespace ObjectIntrospection

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -45,6 +45,7 @@ extern "C" {
 #include <glog/logging.h>
 
 #include "oi/ContainerInfo.h"
+#include "oi/Headers.h"
 #include "oi/Metrics.h"
 #include "oi/OILexer.h"
 #include "oi/OIUtils.h"
@@ -2902,9 +2903,7 @@ std::optional<std::string> OIDebugger::generateCode(const irequest& req) {
     return std::nullopt;
   }
 
-  std::string code =
-#include "OITraceCode.cpp"
-      ;
+  std::string code(headers::OITraceCode_cpp);
 
   auto codegen = OICodeGen::buildFromConfig(generatorConfig, *symbols);
   if (!codegen) {

--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -25,6 +25,7 @@
 #include <variant>
 
 #include "oi/DrgnUtils.h"
+#include "oi/Headers.h"
 #include "oi/OIUtils.h"
 
 namespace ObjectIntrospection {
@@ -134,9 +135,7 @@ fs::path OIGenerator::generateForType(const OICodeGen::Config& generatorConfig,
     return {};
   }
 
-  std::string code =
-#include "OITraceCode.cpp"
-      ;
+  std::string code(headers::OITraceCode_cpp);
 
   codegen->setRootType(type);
   codegen->setLinkageName(linkageName);

--- a/oi/OILibraryImpl.cpp
+++ b/oi/OILibraryImpl.cpp
@@ -25,6 +25,7 @@
 #include <boost/format.hpp>
 #include <fstream>
 
+#include "oi/Headers.h"
 #include "oi/OIParser.h"
 #include "oi/OIUtils.h"
 
@@ -159,9 +160,7 @@ int OILibraryImpl::compileCode() {
     return Response::OIL_COMPILATION_FAILURE;
   }
 
-  std::string code =
-#include "OITraceCode.cpp"
-      ;
+  std::string code(headers::OITraceCode_cpp);
 
   auto codegen = OICodeGen::buildFromConfig(generatorConfig, *symbols);
   if (!codegen) {

--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -1,9 +1,8 @@
-R"(
 #define NDEBUG 1
 // Required for compatibility with new glibc headers
 #define __malloc__(x, y) __malloc__
 #if !__has_builtin(__builtin_free)
-  #define __builtin_free(x) free(x)
+#define __builtin_free(x) free(x)
 #endif
 #pragma clang diagnostic ignored "-Wunknown-attributes"
 
@@ -51,7 +50,9 @@ class {
   }
 
  public:
-  void initialize() noexcept { data.fill(0); }
+  void initialize() noexcept {
+    data.fill(0);
+  }
 
   // Adds the pointer to the set.
   // Returns `true` if the value was newly added,
@@ -74,21 +75,21 @@ class {
 } static pointers;
 
 void __jlogptr(uintptr_t ptr) {
-    static constexpr char hexdigits[] = "0123456789abcdef";
-    static constexpr size_t ptrlen = 2 * sizeof(ptr);
+  static constexpr char hexdigits[] = "0123456789abcdef";
+  static constexpr size_t ptrlen = 2 * sizeof(ptr);
 
-    static char hexstr[ptrlen + 1] = {};
+  static char hexstr[ptrlen + 1] = {};
 
-    size_t i = ptrlen;
-    while (i--) {
-        hexstr[i] = hexdigits[ptr & 0xf];
-        ptr = ptr >> 4;
-    }
-    hexstr[ptrlen] = '\n';
-    write(logFile, hexstr, sizeof(hexstr));
+  size_t i = ptrlen;
+  while (i--) {
+    hexstr[i] = hexdigits[ptr & 0xf];
+    ptr = ptr >> 4;
+  }
+  hexstr[ptrlen] = '\n';
+  write(logFile, hexstr, sizeof(hexstr));
 }
 
-} // namespace
+}  // namespace
 
 // Unforunately, this is a hack for AdFilterData.
 class PredictorInterface;
@@ -134,7 +135,9 @@ struct AllocAligned {
 // Deleter object for unique_ptr for an aligned object
 template <typename T>
 struct AlignedDeleter {
-  void operator()(T* p) const { AllocAligned<T>::release(p); }
+  void operator()(T* p) const {
+    AllocAligned<T>::release(p);
+  }
 };
 
 // alignas(0) is ignored according to docs so can be default
@@ -143,15 +146,12 @@ struct alignas(align) DummySizedOperator {
   char c[N];
 };
 
-// The empty class specialization is, unfortunately, necessary. When this operator
-// is passed as a template parameter to something like unordered_map, even though
-// an empty class and a class with a single character have size one, there is some
-// empty class optimization that changes the static size of the container if an
-// empty class is passed.
+// The empty class specialization is, unfortunately, necessary. When this
+// operator is passed as a template parameter to something like unordered_map,
+// even though an empty class and a class with a single character have size one,
+// there is some empty class optimization that changes the static size of the
+// container if an empty class is passed.
 
 // DummySizedOperator<0,0> also collapses to this
 template <>
-struct DummySizedOperator<0> {
-};
-
-)"
+struct DummySizedOperator<0> {};

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(resources headers.cpp)
+
+target_include_directories(resources PRIVATE ../)
+
+function(embed_headers output)
+  file(WRITE ${output} "#include \"oi/Headers.h\"\n\n")
+  file(APPEND ${output} "namespace ObjectIntrospection {\n")
+  file(APPEND ${output} "namespace headers {\n\n")
+
+  set(HEADERS
+    ../oi/OITraceCode.cpp
+  )
+  foreach(header ${HEADERS})
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${header})
+    get_filename_component(filename ${header} NAME)
+    string(MAKE_C_IDENTIFIER ${filename} varname)
+    file(READ ${header} contents)
+    file(APPEND ${output} "const std::string_view ${varname} = R\"CONTENTS(${contents})CONTENTS\";\n\n")
+  endforeach()
+
+  file(APPEND ${output} "} // namespace headers\n")
+  file(APPEND ${output} "} // namespace ObjectIntrospection\n")
+endfunction()
+
+embed_headers(${CMAKE_BINARY_DIR}/resources/headers.cpp)


### PR DESCRIPTION
## Summary

Previously we had an `R"(` string in `OITraceCode.cpp` which allowed us to include the file as a string. Instead, keep `OITraceCode.cpp` a fully formed C++ file and utilise the build system to turn it into a string. This will be used for more header files that are needed both as valid headers and as strings for JIT compilation in the Typed TreeBuilder work.

## Test plan

- `make test`
- CI
