### PR TITLE
Integration test: Add "target_function" option

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -180,6 +180,21 @@ definitions = '''
     args = "arg0,arg1"
     ```
 
+  - `target_function`
+
+    Symbol of the target function to be traced, when the auto-generated target
+    function is not sufficient.
+
+    The fields `param_types` and `setup` are no longer required if
+    `target_function` is defined.
+
+    Example:
+    ```
+    target_function = "my_function"
+    ```
+
+    Implies `oil_disable`.
+
   - `cli_options`
 
     Additional command line arguments passed to oid.


### PR DESCRIPTION
This new option will allow us to build our own target executables against which we can run the standard integration test framework, with JSON comparisons of expected results.

This will be useful for testing Split-DWARF support.