### PR TITLE
TypeGraph: Update container TOML format

### DIFF
--- a/oi/ContainerInfo.cpp
+++ b/oi/ContainerInfo.cpp
@@ -172,6 +172,17 @@ const char* containerTypeEnumToStr(ContainerTypeEnum ty) {
   });
 }
 
+namespace {
+/*
+ * Create a regex to match a given type name.
+ *
+ * The type name "name" should match "name" and "name<xxx>".
+ */
+std::regex getMatcher(const std::string& typeName) {
+  return std::regex("^" + typeName + "$|^" + typeName + "<.*>$");
+}
+}  // namespace
+
 ContainerInfo::ContainerInfo(const fs::path& path) {
   toml::table container;
   try {
@@ -196,6 +207,8 @@ ContainerInfo::ContainerInfo(const fs::path& path) {
   } else {
     throw std::runtime_error("`info.type_name` is a required field");
   }
+
+  matcher = getMatcher(typeName);
 
   if (std::optional<std::string> str = info["ctype"].value<std::string>()) {
     ctype = containerTypeEnumFromStr(*str);
@@ -245,4 +258,13 @@ ContainerInfo::ContainerInfo(const fs::path& path) {
   } else {
     throw std::runtime_error("`codegen.decl` is a required field");
   }
+}
+
+ContainerInfo::ContainerInfo(std::string typeName_,
+                             ContainerTypeEnum ctype_,
+                             std::string header_)
+    : typeName(std::move(typeName_)),
+      matcher(getMatcher(typeName)),
+      ctype(ctype_),
+      header(std::move(header_)) {
 }

--- a/oi/ContainerInfo.h
+++ b/oi/ContainerInfo.h
@@ -33,6 +33,11 @@ struct ContainerInfo {
   };
 
   explicit ContainerInfo(const std::filesystem::path& path);  // Throws
+  ContainerInfo(std::string typeName,
+                ContainerTypeEnum ctype,
+                std::string header);
+
+  // Old ctors, remove with OICodeGen:
   ContainerInfo() = default;
   ContainerInfo(std::string typeName_,
                 std::regex matcher_,
@@ -84,10 +89,6 @@ struct ContainerInfo {
 
   bool operator<(const ContainerInfo& rhs) const {
     return (typeName < rhs.typeName);
-  }
-
-  std::regex getMatcher() const {
-    return std::regex("^" + typeName + "<|^" + typeName + "$");
   }
 };
 

--- a/oi/ContainerInfo.h
+++ b/oi/ContainerInfo.h
@@ -32,9 +32,7 @@ struct ContainerInfo {
     std::string func;
   };
 
-  ContainerInfo(const ContainerInfo&) = delete;
-  ContainerInfo& operator=(const ContainerInfo& other) = delete;
-
+  explicit ContainerInfo(const std::filesystem::path& path);  // Throws
   ContainerInfo() = default;
   ContainerInfo(std::string typeName_,
                 std::regex matcher_,
@@ -45,6 +43,7 @@ struct ContainerInfo {
                 std::vector<size_t> replaceTemplateParamIndex_,
                 std::optional<size_t> allocatorIndex_,
                 std::optional<size_t> underlyingContainerIndex_,
+                std::vector<size_t> stubTemplateParams_,
                 ContainerInfo::Codegen codegen_)
       : typeName(std::move(typeName_)),
         matcher(std::move(matcher_)),
@@ -55,8 +54,15 @@ struct ContainerInfo {
         replaceTemplateParamIndex(std::move(replaceTemplateParamIndex_)),
         allocatorIndex(allocatorIndex_),
         underlyingContainerIndex(underlyingContainerIndex_),
+        stubTemplateParams(std::move(stubTemplateParams_)),
         codegen(std::move(codegen_)) {
   }
+
+  ContainerInfo(const ContainerInfo&) = delete;
+  ContainerInfo& operator=(const ContainerInfo& other) = delete;
+
+  ContainerInfo(ContainerInfo&&) = default;
+  ContainerInfo& operator=(ContainerInfo&&) = default;
 
   std::string typeName;
   std::regex matcher;
@@ -69,6 +75,7 @@ struct ContainerInfo {
   // Index of underlying container in template parameters for a container
   // adapter
   std::optional<size_t> underlyingContainerIndex{};
+  std::vector<size_t> stubTemplateParams{};
 
   Codegen codegen;
 
@@ -77,6 +84,10 @@ struct ContainerInfo {
 
   bool operator<(const ContainerInfo& rhs) const {
     return (typeName < rhs.typeName);
+  }
+
+  std::regex getMatcher() const {
+    return std::regex("^" + typeName + "<|^" + typeName + "$");
   }
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,12 @@ cpp_unittest(
   DEPS oicore
 )
 
+cpp_unittest(
+  NAME test_container_info
+  SRCS test_container_info.cpp
+  DEPS oicore
+)
+
 # Integration tests
 if (WITH_FLAKY_TESTS)
   add_test(

--- a/test/test_container_info.cpp
+++ b/test/test_container_info.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+#include "oi/ContainerInfo.h"
+
+TEST(ContainerInfoTest, matcher) {
+  ContainerInfo info{"std::vector", SEQ_TYPE, "vector"};
+
+  EXPECT_TRUE(std::regex_search("std::vector<int>", info.matcher));
+  EXPECT_TRUE(std::regex_search("std::vector<std::list<int>>", info.matcher));
+  EXPECT_TRUE(std::regex_search("std::vector", info.matcher));
+
+  EXPECT_FALSE(std::regex_search("vector", info.matcher));
+  EXPECT_FALSE(std::regex_search("non_std::vector<int>", info.matcher));
+  EXPECT_FALSE(std::regex_search("std::vector_other<int>", info.matcher));
+  EXPECT_FALSE(std::regex_search("std::list<std::vector<int>>", info.matcher));
+  EXPECT_FALSE(std::regex_search("std::vector::value_type", info.matcher));
+  EXPECT_FALSE(std::regex_search("std::vector<int>::value_type", info.matcher));
+  EXPECT_FALSE(std::regex_search("std::vector<std::vector<int>>::value_type",
+                                 info.matcher));
+  // Uh-oh, here's a case that I don't think regexes are powerful enough to
+  // match: EXPECT_FALSE(std::regex_search("std::vector<int>::subtype<bool>",
+  // info.matcher));
+}

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,63 @@
+# Container Type Definition Format
+
+This document describes the format of the container definition files contained in this directory.
+
+### info
+- `type_name`
+
+  The fully-qualified name of the container type. This is used to match against
+  the names of types contained in an executable's debug information.
+
+- `ctype`
+
+  A reference to the enum `ContainerTypeEnum` in OI's source code.
+
+- `header`
+
+  The name of the C++ header file in which this container is defined.
+
+- `stub_template_params`
+
+  The indexes of template parameters which do not represent types stored within
+  this container. These parameters will not be recursed into and measured by OI.
+
+- `underlying_container_index`
+
+  Only used for container adapters. Points OI to the template parameter
+  representing the underlying container to be measured.
+
+### codegen
+- `decl`
+
+  C++ code for the declaration of a `getSizeType` function for this container.
+
+- `func`
+
+  C++ code for the definition of a `getSizeType` function for this container.
+
+
+## Changes introduced with TypeGraph
+- `typeName` and `matcher` fields have been merged into the single field `type_name`.
+- `ns` namespace definition is no longer required.
+- `underlyingContainerIndex` renamed to `underlying_container_index`
+- The options for measuring / stubbing / removing template parameters have been reworked:
+  - By default all parameters are now measured. This includes the tail parameters in a variadic template.
+  - There is one option to specify template parameters which should not be measured: `stub_template_params`. The type graph code will automatically determine what type of stubbing to apply to each parameter in this list.
+
+### Deprecated Options
+- `numTemplateParams`
+
+  The first `numTemplateParams` template parameters for this container represent
+  the types for the data we want to process. If this is not set, use all a
+  container's template parameters. All of a container's parameters will still be
+  enumerated and output in CodeGen, regardless of this setting.
+
+- `allocatorIndex`
+
+  Index of a template parameter representing an allocator. It will be not be
+  used when CodeGenning this container.
+
+- `replaceTemplateParamIndex`
+
+  Indexes of template parameters to be stubbed out, i.e. replaced with dummy
+  structs of a given size. Used for custom hashers and comparers.

--- a/types/array_type.toml
+++ b/types/array_type.toml
@@ -1,12 +1,12 @@
 [info]
-typeName = "std::array<"
-numTemplateParams = 1
+type_name = "std::array"
 ctype = "ARRAY_TYPE"
 header = "array"
+
+# Old:
+numTemplateParams = 1
 ns = ["namespace std"]
-replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
+typeName = "std::array<"
 
 [codegen]
 decl = """

--- a/types/boost_bimap_type.toml
+++ b/types/boost_bimap_type.toml
@@ -1,12 +1,12 @@
 [info]
-typeName = "boost::bimap"
-numTemplateParams = 2
+type_name = "boost::bimap"
 ctype = "BOOST_BIMAP_TYPE"
 header = "boost/bimap.hpp"
+
+# Old:
+numTemplateParams = 2
+typeName = "boost::bimap"
 ns = ["boost::bimap"]
-replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/caffe2_blob_type.toml
+++ b/types/caffe2_blob_type.toml
@@ -1,13 +1,14 @@
 [info]
-typeName = "caffe2::Blob"
-matcher = "^caffe2::Blob$"
-numTemplateParams = 0
+type_name = "caffe2::Blob"
 ctype = "CAFFE2_BLOB_TYPE"
 header = "caffe2/core/blob.h"
+
+# Old:
+typeName = "caffe2::Blob"
+matcher = "^caffe2::Blob$"
 ns = ["caffe2::Blob", "caffe2::Tensor"]
+numTemplateParams = 0
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/cxx11_list_type.toml
+++ b/types/cxx11_list_type.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "std::__cxx11::list"
-numTemplateParams = 1
+type_name = "std::__cxx11::list"
+stub_template_params = [1]
 ctype = "LIST_TYPE"
 header = "list"
+
+# Old:
+typeName = "std::__cxx11::list"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
 allocatorIndex = 1
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -1,35 +1,37 @@
 [info]
-typeName = "std::__cxx11::basic_string<"
-numTemplateParams = 1
+type_name = "std::__cxx11::basic_string"
+stub_template_params = [1,2]
 ctype = "STRING_TYPE"
 header = "string"
+
+# Old:
+typeName = "std::__cxx11::basic_string<"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
 template<typename T>
-void getSizeType(const %1%<T> &t, size_t& returnArg);
+void getSizeType(const %1%<T> &container, size_t& returnArg);
 """
 
 func = """
 template<typename T>
-void getSizeType(const %1%<T> &t, size_t& returnArg)
+void getSizeType(const %1%<T> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T>));
 
-    SAVE_DATA((uintptr_t)t.capacity());
-    SAVE_DATA((uintptr_t)t.size());
+    SAVE_DATA((uintptr_t)container.capacity());
+    SAVE_DATA((uintptr_t)container.size());
 
     // Test for small string optimisation - whether the underlying string is
     // contained within the string object.
     SAVE_SIZE(
-      (((uintptr_t)t.data() < (uintptr_t)(&t + sizeof(%1%<T>)))
+      (((uintptr_t)container.data() < (uintptr_t)(&container + sizeof(%1%<T>)))
         &&
-      ((uintptr_t)t.data() >= (uintptr_t)&t))
-        ? 0 : (t.capacity() * sizeof(T))
+      ((uintptr_t)container.data() >= (uintptr_t)&container))
+        ? 0 : (container.capacity() * sizeof(T))
     );
 }
 """

--- a/types/deque_list_type.toml
+++ b/types/deque_list_type.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "std::deque<"
-numTemplateParams = 1
+type_name = "std::deque"
+stub_template_params = [1]
 ctype = "LIST_TYPE"
 header = "deque"
+
+# Old:
+typeName = "std::deque<"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
 allocatorIndex = 1
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/f14_fast_map.toml
+++ b/types/f14_fast_map.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "folly::F14FastMap<"
-numTemplateParams = 2
+type_name = "folly::F14FastMap"
+stub_template_params = [2,3,4]
 ctype = "F14_MAP"
 header = "folly/container/F14Map.h"
+
+# Old:
+typeName = "folly::F14FastMap<"
 ns = ["folly::F14FastMap"]
+numTemplateParams = 2
 replaceTemplateParamIndex = [2, 3]
 allocatorIndex = 4
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/f14_fast_set.toml
+++ b/types/f14_fast_set.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "folly::F14FastSet<"
-numTemplateParams = 1
+type_name = "folly::F14FastSet"
+stub_template_params = [1,2,3]
 ctype = "F14_SET"
 header = "folly/container/F14Set.h"
+
+# Old:
+typeName = "folly::F14FastSet<"
 ns = ["folly::F14FastSet"]
+numTemplateParams = 1
 replaceTemplateParamIndex = [1, 2]
 allocatorIndex = 3
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/f14_node_map.toml
+++ b/types/f14_node_map.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "folly::F14NodeMap<"
-numTemplateParams = 2
+type_name = "folly::F14NodeMap"
+stub_template_params = [2,3,4]
 ctype = "F14_MAP"
 header = "folly/container/F14Map.h"
+
+# Old:
+typeName = "folly::F14NodeMap<"
 ns = ["folly::F14NodeMap"]
+numTemplateParams = 2
 replaceTemplateParamIndex = [2, 3]
 allocatorIndex = 4
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/f14_node_set.toml
+++ b/types/f14_node_set.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "folly::F14NodeSet<"
-numTemplateParams = 1
+type_name = "folly::F14NodeSet"
+stub_template_params = [1,2,3]
 ctype = "F14_SET"
 header = "folly/container/detail/F14SetFallback.h"
+
+# Old:
+typeName = "folly::F14NodeSet<"
 ns = ["folly::F14NodeSet"]
+numTemplateParams = 1
 replaceTemplateParamIndex = [1, 2]
 allocatorIndex = 3
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/f14_vector_map.toml
+++ b/types/f14_vector_map.toml
@@ -1,12 +1,14 @@
 [info]
-typeName = "folly::F14VectorMap<"
-numTemplateParams = 2
+type_name = "folly::F14VectorMap"
+stub_template_params = [2,3,4]
 ctype = "F14_MAP"
 header = "folly/container/detail/F14MapFallback.h"
+
+# Old:
+typeName = "folly::F14VectorMap<"
 ns = ["folly::F14VectorMap"]
+numTemplateParams = 2
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/f14_vector_set.toml
+++ b/types/f14_vector_set.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "folly::F14VectorSet<"
-numTemplateParams = 1
+type_name = "folly::F14VectorSet"
+stub_template_params = [1,2,3]
 ctype = "F14_SET"
 header = "folly/container/F14Set.h"
+
+# Old:
+typeName = "folly::F14VectorSet<"
 ns = ["folly::F14VectorSet"]
+numTemplateParams = 1
 replaceTemplateParamIndex = [1, 2]
 allocatorIndex = 3
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/fb_string_type.toml
+++ b/types/fb_string_type.toml
@@ -1,35 +1,36 @@
 [info]
-typeName = "folly::basic_fbstring<"
-numTemplateParams = 1
+type_name = "folly::basic_fbstring"
 ctype = "FB_STRING_TYPE"
 header = "folly/FBString.h"
+
+# Old:
+typeName = "folly::basic_fbstring<"
 ns = ["folly::basic_fbstring", "folly::fbstring_core"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
 template <typename E,class T,class A,class Storage>
-void getSizeType(const %1%<E, T, A, Storage> &t, size_t& returnArg);
+void getSizeType(const %1%<E, T, A, Storage> &container, size_t& returnArg);
 """
 
 func = """
 template <typename E,class T,class A,class Storage>
-void getSizeType(const %1%<E, T, A, Storage> &t, size_t& returnArg)
+void getSizeType(const %1%<E, T, A, Storage> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<E, T, A, Storage>));
 
-    SAVE_DATA((uintptr_t)(t.data()));
-    SAVE_DATA((uintptr_t)t.capacity());
-    SAVE_DATA((uintptr_t)t.size());
+    SAVE_DATA((uintptr_t)(container.data()));
+    SAVE_DATA((uintptr_t)container.capacity());
+    SAVE_DATA((uintptr_t)container.size());
 
-    bool inlined = ((uintptr_t)t.data() < (uintptr_t)(&t + sizeof(%1%<E, T, A, Storage>)))
+    bool inlined = ((uintptr_t)container.data() < (uintptr_t)(&container + sizeof(%1%<E, T, A, Storage>)))
         &&
-      ((uintptr_t)t.data() >= (uintptr_t)&t);
+      ((uintptr_t)container.data() >= (uintptr_t)&container);
 
-    if (!inlined && pointers.add((uintptr_t)t.data())) {
-      SAVE_SIZE(t.capacity() * sizeof(T));
+    if (!inlined && pointers.add((uintptr_t)container.data())) {
+      SAVE_SIZE(container.capacity() * sizeof(T));
       SAVE_DATA(1);
     } else {
       SAVE_DATA(0);

--- a/types/folly_iobuf_queue_type.toml
+++ b/types/folly_iobuf_queue_type.toml
@@ -1,25 +1,26 @@
 [info]
-typeName = "folly::IOBufQueue"
-matcher = "^folly::IOBufQueue$"
-numTemplateParams = 0
+type_name = "folly::IOBufQueue"
 ctype = "FOLLY_IOBUFQUEUE_TYPE"
 header = "folly/io/IOBufQueue.h"
+
+# Old:
+typeName = "folly::IOBufQueue"
+matcher = "^folly::IOBufQueue$"
 ns = ["folly::IOBufQueue"]
+numTemplateParams = 0
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
-void getSizeType(const %1% &t, size_t& returnArg);
+void getSizeType(const %1% &container, size_t& returnArg);
 """
 
 func = """
-void getSizeType(const %1% &t, size_t& returnArg)
+void getSizeType(const %1% &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%));
 
-    const IOBuf *head = t.front();
+    const IOBuf *head = container.front();
     SAVE_DATA((uintptr_t)head);
     if (head && pointers.add((uintptr_t)head)) {
         SAVE_DATA(1);

--- a/types/folly_iobuf_type.toml
+++ b/types/folly_iobuf_type.toml
@@ -1,21 +1,22 @@
 [info]
-typeName = "folly::IOBuf"
-matcher = "^folly::IOBuf$"
-numTemplateParams = 0
+type_name = "folly::IOBuf"
 ctype = "FOLLY_IOBUF_TYPE"
 header = "folly/io/IOBuf.h"
+
+# Old:
+typeName = "folly::IOBuf"
+matcher = "^folly::IOBuf$"
 ns = ["folly::IOBuf"]
+numTemplateParams = 0
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
-void getSizeType(const %1% &t, size_t& returnArg);
+void getSizeType(const %1% &container, size_t& returnArg);
 """
 
 func = """
-void getSizeType(const %1% &t, size_t& returnArg)
+void getSizeType(const %1% &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%));
 
@@ -25,9 +26,9 @@ void getSizeType(const %1% &t, size_t& returnArg)
     // caused these functions to be removed which causes relocation
     // errors.
 
-    std::size_t fullLength = t.length();
-    std::size_t fullCapacity = t.capacity();
-    for (const IOBuf* current = t.next(); current != &t;
+    std::size_t fullLength = container.length();
+    std::size_t fullCapacity = container.capacity();
+    for (const IOBuf* current = container.next(); current != &container;
         current = current->next()) {
     fullLength += current->length();
     fullCapacity += current->capacity();

--- a/types/folly_optional_type.toml
+++ b/types/folly_optional_type.toml
@@ -1,27 +1,28 @@
 [info]
-typeName = "folly::Optional<"
-numTemplateParams = 1
+type_name = "folly::Optional"
 ctype = "FOLLY_OPTIONAL_TYPE"
 header = "folly/Optional.h"
+
+# Old:
+typeName = "folly::Optional<"
 ns = ["folly::Optional"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
 template<typename T>
-void getSizeType(const %1%<T> &s_ptr, size_t& returnArg);
+void getSizeType(const %1%<T> &container, size_t& returnArg);
 """
 
 func = """
 template <typename T>
-void getSizeType(const %1%<T>& s_ptr, size_t& returnArg) {
-  if (s_ptr) {
+void getSizeType(const %1%<T>& container, size_t& returnArg) {
+  if (container) {
     SAVE_SIZE(sizeof(%1%<T>) - sizeof(T));
-    SAVE_DATA((uintptr_t)(s_ptr.get_pointer()));
+    SAVE_DATA((uintptr_t)(container.get_pointer()));
 
-    getSizeType(*(s_ptr.get_pointer()), returnArg);
+    getSizeType(*(container.get_pointer()), returnArg);
   } else {
     SAVE_SIZE(sizeof(%1%<T>));
     SAVE_DATA(0);

--- a/types/folly_small_heap_vector_map.toml
+++ b/types/folly_small_heap_vector_map.toml
@@ -1,12 +1,13 @@
 [info]
-typeName = "folly::small_heap_vector_map"
-numTemplateParams = 2
+type_name = "folly::small_heap_vector_map"
 ctype = "FOLLY_SMALL_HEAP_VECTOR_MAP"
 header = "folly/container/heap_vector_types.h"
+
+# Old:
+typeName = "folly::small_heap_vector_map"
 ns = ["folly::small_heap_vector_map"]
+numTemplateParams = 2
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/list_type.toml
+++ b/types/list_type.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "std::list<"
-numTemplateParams = 1
+type_name = "std::list"
+stub_template_params = [1]
 ctype = "LIST_TYPE"
 header = "list"
+
+# Old:
+typeName = "std::list<"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
 allocatorIndex = 1
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/map_seq_type.toml
+++ b/types/map_seq_type.toml
@@ -1,12 +1,13 @@
 [info]
-typeName = "folly::sorted_vector_map<"
-numTemplateParams = 2
+type_name = "folly::sorted_vector_map"
 ctype = "MAP_SEQ_TYPE"
 header = "folly/sorted_vector_types.h"
+
+# Old:
+typeName = "folly::sorted_vector_map<"
 ns = ["namespace std", "folly::sorted_vector_map"]
+numTemplateParams = 2
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/multi_map_type.toml
+++ b/types/multi_map_type.toml
@@ -1,9 +1,13 @@
 [info]
-typeName = "std::multimap"
-numTemplateParams = 2
+type_name = "std::multimap"
+stub_template_params = [2,3]
 ctype = "MULTI_MAP_TYPE"
 header = "map"
+
+# Old:
+typeName = "std::multimap"
 ns = ["namespace std"]
+numTemplateParams = 2
 replaceTemplateParamIndex = [2]
 allocatorIndex = 3
 

--- a/types/optional_type.toml
+++ b/types/optional_type.toml
@@ -1,26 +1,26 @@
 [info]
-typeName = "std::optional<"
-numTemplateParams = 1
+type_name = "std::optional"
 ctype = "OPTIONAL_TYPE"
 header = "optional"
+
+# Old:
+typeName = "std::optional<"
 ns = ["namespace std"]
-replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
+numTemplateParams = 1
 
 [codegen]
 decl = """
 template<typename T>
-void getSizeType(const %1%<T> &s_ptr, size_t& returnArg);
+void getSizeType(const %1%<T> &container, size_t& returnArg);
 """
 
 func = """
 template <typename T>
-void getSizeType(const %1%<T>& s_ptr, size_t& returnArg) {
-  if (s_ptr) {
+void getSizeType(const %1%<T>& container, size_t& returnArg) {
+  if (container) {
     SAVE_SIZE(sizeof(%1%<T>) - sizeof(T));
     SAVE_DATA(true);
-    getSizeType(*s_ptr, returnArg);
+    getSizeType(*container, returnArg);
   } else {
     SAVE_SIZE(sizeof(%1%<T>));
     SAVE_DATA(false);

--- a/types/pair_type.toml
+++ b/types/pair_type.toml
@@ -1,26 +1,27 @@
 [info]
-typeName = "std::pair<"
-numTemplateParams = 2
+type_name = "std::pair"
 ctype = "PAIR_TYPE"
 header = "utility"
+
+# Old:
+typeName = "std::pair<"
 ns = ["namespace std"]
+numTemplateParams = 2
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
 template<typename P, typename Q>
-void getSizeType(const %1%<P,Q> &p, size_t& returnArg);
+void getSizeType(const %1%<P,Q> &container, size_t& returnArg);
 """
 
 func = """
 template<typename P, typename Q>
-void getSizeType(const %1%<P,Q> &p, size_t& returnArg)
+void getSizeType(const %1%<P,Q> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<P,Q>) - sizeof(P) - sizeof(Q));
 
-    getSizeType(p.first, returnArg);
-    getSizeType(p.second, returnArg);
+    getSizeType(container.first, returnArg);
+    getSizeType(container.second, returnArg);
 }
 """

--- a/types/priority_queue_container_adapter_type.toml
+++ b/types/priority_queue_container_adapter_type.toml
@@ -1,22 +1,25 @@
 [info]
-typeName = "std::priority_queue<"
-# numTemplateParams = 1
+type_name = "std::priority_queue"
 ctype = "CONTAINER_ADAPTER_TYPE"
 header = "queue"
+underlying_container_index = 1
+stub_template_params = [2]
+
+# Old:
+typeName = "std::priority_queue<"
 ns = ["namespace std"]
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
 underlyingContainerIndex = 1
 
 [codegen]
 decl = """
-template<class T, class Container>
-void getSizeType(const %1%<T, Container> &container, size_t& returnArg);
+template<class T, class Container, class Cmp>
+void getSizeType(const %1%<T, Container, Cmp> &container, size_t& returnArg);
 """
 
 func = """
-template<class T, class Container>
-void getSizeType(const %1%<T, Container> &containerAdapter, size_t& returnArg)
+template<class T, class Container, class Cmp>
+void getSizeType(const %1%<T, Container, Cmp> &containerAdapter, size_t& returnArg)
 {
     SAVE_DATA((uintptr_t)&containerAdapter);
 

--- a/types/queue_container_adapter_type.toml
+++ b/types/queue_container_adapter_type.toml
@@ -1,11 +1,13 @@
 [info]
-typeName = "std::queue<"
-# numTemplateParams = 1
+type_name = "std::queue"
 ctype = "CONTAINER_ADAPTER_TYPE"
 header = "queue"
+underlying_container_index = 1
+
+# Old:
+typeName = "std::queue<"
 ns = ["namespace std"]
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
 underlyingContainerIndex = 1
 
 [codegen]

--- a/types/ref_wrapper_type.toml
+++ b/types/ref_wrapper_type.toml
@@ -1,17 +1,18 @@
 [info]
-typeName = "std::reference_wrapper<"
-numTemplateParams = 1
+type_name = "std::reference_wrapper"
 ctype = "REF_WRAPPER_TYPE"
 header = "functional"
+
+# Old:
+typeName = "std::reference_wrapper<"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
 template<typename T>
-void getSizeType(const %1%<T> &s_ptr, size_t& returnArg);
+void getSizeType(const %1%<T> &ref, size_t& returnArg);
 """
 
 func = """

--- a/types/repeated_field_type.toml
+++ b/types/repeated_field_type.toml
@@ -1,12 +1,13 @@
 [info]
-typeName = "google::protobuf::RepeatedField<"
-numTemplateParams = 1
+type_name = "google::protobuf::RepeatedField"
 ctype = "REPEATED_FIELD_TYPE"
 header = "google/protobuf/repeated_field.h"
+
+# Old:
+typeName = "google::protobuf::RepeatedField<"
 ns = ["google::protobuf::RepeatedField"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/repeated_ptr_field_type.toml
+++ b/types/repeated_ptr_field_type.toml
@@ -1,12 +1,13 @@
 [info]
-typeName = "google::protobuf::RepeatedPtrField<"
-numTemplateParams = 1
+type_name = "google::protobuf::RepeatedPtrField"
 ctype = "REPEATED_FIELD_TYPE"
 header = "google/protobuf/repeated_field.h"
+
+# Old:
+typeName = "google::protobuf::RepeatedPtrField<"
 ns = ["google::protobuf::RepeatedPtrField"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -1,12 +1,14 @@
 [info]
-typeName = "std::vector<"
-numTemplateParams = 1
+type_name = "std::vector"
+stub_template_params = [1]
 ctype = "SEQ_TYPE"
 header = "vector"
+
+# Old:
+typeName = "std::vector<"
 ns = ["namespace std"]
-replaceTemplateParamIndex = []
+numTemplateParams = 1
 allocatorIndex = 1
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/set_type.toml
+++ b/types/set_type.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "std::set<"
-numTemplateParams = 1
+type_name = "std::set"
+stub_template_params = [1,2]
 ctype = "SET_TYPE"
 header = "set"
+
+# Old:
+typeName = "std::set<"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = [1]
 allocatorIndex = 2
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/shrd_ptr_type.toml
+++ b/types/shrd_ptr_type.toml
@@ -1,12 +1,13 @@
 [info]
-typeName = "std::shared_ptr"
-numTemplateParams = 1
+type_name = "std::shared_ptr"
 ctype = "SHRD_PTR_TYPE"
 header = "memory"
+
+# Old:
+typeName = "std::shared_ptr"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/small_vec_type.toml
+++ b/types/small_vec_type.toml
@@ -1,12 +1,13 @@
 [info]
-typeName = "folly::small_vector<"
-numTemplateParams = 1
+type_name = "folly::small_vector"
 ctype = "SMALL_VEC_TYPE"
 header = "folly/small_vector.h"
+
+# Old:
+typeName = "folly::small_vector<"
 ns = ["folly::small_vector_policy::policy_size_type", "folly::small_vector"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -1,7 +1,12 @@
 [info]
-typeName = "folly::sorted_vector_set<"
+type_name = "folly::sorted_vector_set"
 ctype = "SORTED_VEC_SET_TYPE"
 header = "folly/sorted_vector_types.h"
+stub_template_params = [1,2]
+underlying_container_index = 4
+
+# Old
+typeName = "folly::sorted_vector_set<"
 ns = ["namespace std", "folly::sorted_vector_set"]
 replaceTemplateParamIndex = [1,2]
 underlyingContainerIndex = 4

--- a/types/stack_container_adapter_type.toml
+++ b/types/stack_container_adapter_type.toml
@@ -1,11 +1,13 @@
 [info]
-typeName = "std::stack<"
-# numTemplateParams = 1
+type_name = "std::stack"
 ctype = "CONTAINER_ADAPTER_TYPE"
 header = "stack"
+underlying_container_index = 1
+
+# Old:
+typeName = "std::stack<"
 ns = ["namespace std"]
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
 underlyingContainerIndex = 1
 
 [codegen]

--- a/types/std_map_type.toml
+++ b/types/std_map_type.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "std::map<"
-numTemplateParams = 2
+type_name = "std::map"
+stub_template_params = [2,3]
 ctype = "STD_MAP_TYPE"
 header = "map"
+
+# Old:
+typeName = "std::map<"
 ns = ["namespace std"]
+numTemplateParams = 2
 replaceTemplateParamIndex = [2]
 allocatorIndex = 3
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/std_unordered_map_type.toml
+++ b/types/std_unordered_map_type.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "std::unordered_map<"
-numTemplateParams = 2
+type_name = "std::unordered_map"
+stub_template_params = [2,3,4]
 ctype = "STD_UNORDERED_MAP_TYPE"
 header = "unordered_map"
+
+# Old:
+typeName = "std::unordered_map<"
 ns = ["namespace std"]
+numTemplateParams = 2
 replaceTemplateParamIndex = [2, 3]
 allocatorIndex = 4
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/std_variant.toml
+++ b/types/std_variant.toml
@@ -1,7 +1,10 @@
 [info]
-typeName = "std::variant"
+type_name = "std::variant"
 ctype = "STD_VARIANT_TYPE"
 header = "variant"
+
+# Old:
+typeName = "std::variant"
 ns = ["namespace std"]
 
 [codegen]

--- a/types/string_type.toml
+++ b/types/string_type.toml
@@ -1,35 +1,37 @@
 [info]
-typeName = "std::basic_string<"
-numTemplateParams = 1
+type_name = "std::basic_string"
+stub_template_params = [1,2]
 ctype = "STRING_TYPE"
 header = "string"
+
+# Old:
+typeName = "std::basic_string<"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
 template<typename T>
-void getSizeType(const %1%<T> &t, size_t& returnArg);
+void getSizeType(const %1%<T> &container, size_t& returnArg);
 """
 
 func = """
 template<typename T>
-void getSizeType(const %1%<T> &t, size_t& returnArg)
+void getSizeType(const %1%<T> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T>));
 
-    SAVE_DATA((uintptr_t)t.capacity());
-    SAVE_DATA((uintptr_t)t.size());
+    SAVE_DATA((uintptr_t)container.capacity());
+    SAVE_DATA((uintptr_t)container.size());
 
     // Test for small string optimisation - whether the underlying string is
     // contained within the string object.
     SAVE_SIZE(
-      ((uintptr_t)t.data() < (uintptr_t)(&t + sizeof(%1%<T>)))
+      ((uintptr_t)container.data() < (uintptr_t)(&container + sizeof(%1%<T>)))
         &&
-      ((uintptr_t)t.data() >= (uintptr_t)&t)
-        ? 0 : (t.capacity() * sizeof(T))
+      ((uintptr_t)container.data() >= (uintptr_t)&container)
+        ? 0 : (container.capacity() * sizeof(T))
     );
 }
 """

--- a/types/thrift_isset_type.toml
+++ b/types/thrift_isset_type.toml
@@ -1,12 +1,13 @@
 [info]
-typeName = "apache::thrift::detail::isset_bitset<"
-numTemplateParams = 2
+type_name = "apache::thrift::detail::isset_bitset"
 ctype = "THRIFT_ISSET_TYPE"
 header = "thrift/lib/cpp2/gen/module_types_h.h"
+
+# Old:
+typeName = "apache::thrift::detail::isset_bitset<"
 ns = ["apache::thrift::detail::isset_bitset"]
+numTemplateParams = 2
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/try_type.toml
+++ b/types/try_type.toml
@@ -1,27 +1,28 @@
 [info]
-typeName = "folly::Try<"
-numTemplateParams = 1
+type_name = "folly::Try"
 ctype = "TRY_TYPE"
 header = "folly/Try.h"
+
+# Old:
+typeName = "folly::Try<"
 ns = ["folly::Try"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
 template<typename T>
-void getSizeType(const %1%<T> &s_ptr, size_t& returnArg);
+void getSizeType(const %1%<T> &container, size_t& returnArg);
 """
 
 func = """
 template<typename T>
-void getSizeType(const %1%<T> &s_ptr, size_t& returnArg)
+void getSizeType(const %1%<T> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T>));
-    if (s_ptr.hasValue()) {
-        SAVE_DATA((uintptr_t)(&(s_ptr.value())));
-        getSizeType(s_ptr.value(), returnArg);
+    if (container.hasValue()) {
+        SAVE_DATA((uintptr_t)(&(container.value())));
+        getSizeType(container.value(), returnArg);
     } else {
         SAVE_DATA(0);
     }

--- a/types/uniq_ptr_type.toml
+++ b/types/uniq_ptr_type.toml
@@ -1,31 +1,33 @@
 [info]
-typeName = "std::unique_ptr"
-numTemplateParams = 1
+type_name = "std::unique_ptr"
 ctype = "UNIQ_PTR_TYPE"
 header = "memory"
+stub_template_params = [1]
+
+# Old:
+typeName = "std::unique_ptr"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
-# allocatorIndex = 0
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """
 template<typename T, class Deleter>
-void getSizeType(const %1%<T,Deleter> &s_ptr, size_t& returnArg);
+void getSizeType(const %1%<T,Deleter> &container, size_t& returnArg);
 """
 
 func = """
 template<typename T, class Deleter>
-void getSizeType(const %1%<T,Deleter> &s_ptr, size_t& returnArg)
+void getSizeType(const %1%<T,Deleter> &u_ptr, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T,Deleter>));
 
     if constexpr (!std::is_void<T>::value) {
-        SAVE_DATA((uintptr_t)(s_ptr.get()));
+        SAVE_DATA((uintptr_t)(u_ptr.get()));
 
-        if (s_ptr && pointers.add((uintptr_t)(s_ptr.get()))) {
+        if (u_ptr && pointers.add((uintptr_t)(u_ptr.get()))) {
             SAVE_DATA(1);
-            getSizeType(*(s_ptr.get()), returnArg);
+            getSizeType(*(u_ptr.get()), returnArg);
         } else {
             SAVE_DATA(0);
         }

--- a/types/unordered_set_type.toml
+++ b/types/unordered_set_type.toml
@@ -1,12 +1,15 @@
 [info]
-typeName = "std::unordered_set<"
-numTemplateParams = 1
+type_name = "std::unordered_set"
+stub_template_params = [1,2,3]
 ctype = "UNORDERED_SET_TYPE"
 header = "unordered_set"
+
+# Old:
+typeName = "std::unordered_set<"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = [1, 2]
 allocatorIndex = 3
-# underlyingContainerIndex = 0
 
 [codegen]
 decl = """

--- a/types/weak_ptr_type.toml
+++ b/types/weak_ptr_type.toml
@@ -1,9 +1,12 @@
 [info]
-typeName = "std::weak_ptr"
-numTemplateParams = 1
+type_name = "std::weak_ptr"
 ctype = "WEAK_PTR_TYPE"
 header = "memory"
+
+# Old:
+typeName = "std::weak_ptr"
 ns = ["namespace std"]
+numTemplateParams = 1
 replaceTemplateParamIndex = []
 
 [codegen]


### PR DESCRIPTION
This change is fully backwards compatible with the old ContainerInfo parser, as it is just adding new fields.
    
The old fields will continue to be used by legacy OICodeGen until that is removed.
    
Also add a README describing the format.