### PR TITLE
tomlplusplus: compile header once

### DIFF
--- a/oi/CMakeLists.txt
+++ b/oi/CMakeLists.txt
@@ -1,3 +1,8 @@
+add_library(toml
+  support/Toml.cpp
+)
+target_link_libraries(toml PUBLIC tomlplusplus::tomlplusplus)
+
 add_library(drgn_utils DrgnUtils.cpp)
 target_link_libraries(drgn_utils
   glog::glog
@@ -28,7 +33,7 @@ target_link_libraries(container_info
   drgn_utils # This shouldn't be needed! Clean up Commoh.h!
 
   glog::glog
-  tomlplusplus::tomlplusplus
+  toml
 )
 
 add_library(codegen

--- a/oi/ContainerInfo.cpp
+++ b/oi/ContainerInfo.cpp
@@ -16,9 +16,10 @@
 #include "oi/ContainerInfo.h"
 
 #include <glog/logging.h>
-#include <toml++/toml.h>
 
 #include <map>
+
+#include "oi/support/Toml.h"
 
 namespace fs = std::filesystem;
 

--- a/oi/OIUtils.cpp
+++ b/oi/OIUtils.cpp
@@ -16,13 +16,14 @@
 #include "oi/OIUtils.h"
 
 #include <glog/logging.h>
-#include <toml++/toml.h>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <filesystem>
+
+#include "oi/support/Toml.h"
 
 namespace fs = std::filesystem;
 

--- a/oi/support/Toml.cpp
+++ b/oi/support/Toml.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#define TOML_IMPLEMENTATION
+#include "oi/support/Toml.h"

--- a/oi/support/Toml.h
+++ b/oi/support/Toml.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#define TOML_HEADER_ONLY 0
+#include <toml++/toml.h>

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -104,7 +104,7 @@ target_link_libraries(integration_test_runner PRIVATE
   ${GMOCK_MAIN_LIBS}
   Boost::headers
   ${Boost_LIBRARIES}
-  tomlplusplus::tomlplusplus
+  toml
 )
 target_compile_definitions(integration_test_runner PRIVATE
   TARGET_EXE_PATH="${CMAKE_CURRENT_BINARY_DIR}/integration_test_target"

--- a/test/integration/runner_common.cpp
+++ b/test/integration/runner_common.cpp
@@ -1,7 +1,5 @@
 #include "runner_common.h"
 
-#include <toml++/toml.h>
-
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
@@ -15,6 +13,7 @@
 #include <utility>
 
 #include "oi/OIOpts.h"
+#include "oi/support/Toml.h"
 
 using namespace std::literals;
 


### PR DESCRIPTION
## Summary

`tomlplusplus` defaults to header-only but this is inefficient when you include it in multiple places (which we do). Explicitly compile the header in a single translation unit to improve compilation performance.

## Test plan

- `make test` - an `integration_py` failure because some static size is 16 off. This has to be unrelated.
- CI
- Hoping it's quicker. Testing is hard.
