### PR TITLE
TypeGraph: Fix std::string container

### DIFF
--- a/dev.oid.toml
+++ b/dev.oid.toml
@@ -46,4 +46,5 @@ containers = [
     "PWD/types/std_variant.toml",
     "PWD/types/thrift_isset_type.toml",
     "PWD/types/weak_ptr_type.toml",
+    "PWD/types/std_char_traits.toml",
 ]

--- a/oi/Common.h
+++ b/oi/Common.h
@@ -65,7 +65,7 @@ constexpr int oidMagicId = 0x01DE8;
   X(ENUM_MAP_TYPE)               \
   X(BOOST_BIMAP_TYPE)            \
   X(STD_VARIANT_TYPE)            \
-  X(THRIFT_ISSET_TYPE)           \
+  X(DUMMY_TYPE)                  \
   X(WEAK_PTR_TYPE)
 
 enum ContainerTypeEnum {

--- a/oi/TreeBuilder.cpp
+++ b/oi/TreeBuilder.cpp
@@ -830,7 +830,7 @@ void TreeBuilder::processContainer(const Variable& variable, Node& node) {
     case BY_MULTI_QRT_TYPE:
       containerStats.length = containerStats.capacity = next();
       break;
-    case THRIFT_ISSET_TYPE:
+    case DUMMY_TYPE:
       // Dummy container
       containerStats.elementStaticSize = 0;
       break;

--- a/test/ci.oid.toml
+++ b/test/ci.oid.toml
@@ -42,6 +42,7 @@ containers = [
     "../types/std_variant.toml",
     "../types/thrift_isset_type.toml",
     "../types/weak_ptr_type.toml",
+    "../types/std_char_traits.toml",
 ]
 
 [headers]

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -1,6 +1,6 @@
 [info]
 type_name = "std::__cxx11::basic_string"
-stub_template_params = [1,2]
+stub_template_params = [2]
 ctype = "STRING_TYPE"
 header = "string"
 

--- a/types/std_char_traits.toml
+++ b/types/std_char_traits.toml
@@ -1,0 +1,17 @@
+[info]
+type_name = "std::char_traits"
+ctype = "DUMMY_TYPE"
+header = "string"
+
+# Old:
+typeName = "std::char_traits<"
+ns = ["namespace std"]
+numTemplateParams = 1
+
+[codegen]
+decl = """
+// DummyDecl %1%
+"""
+func = """
+// DummyFunc %1%
+"""

--- a/types/string_type.toml
+++ b/types/string_type.toml
@@ -1,6 +1,6 @@
 [info]
 type_name = "std::basic_string"
-stub_template_params = [1,2]
+stub_template_params = [2]
 ctype = "STRING_TYPE"
 header = "string"
 

--- a/types/thrift_isset_type.toml
+++ b/types/thrift_isset_type.toml
@@ -1,6 +1,6 @@
 [info]
 type_name = "apache::thrift::detail::isset_bitset"
-ctype = "THRIFT_ISSET_TYPE"
+ctype = "DUMMY_TYPE"
 header = "thrift/lib/cpp2/gen/module_types_h.h"
 
 # Old:


### PR DESCRIPTION
std::basic_string takes three template parameters:
1. CharT
2. Traits
3. Allocator

The Traits parameter was causing issues, as it requires a type which exposes certain things, e.g. `Traits::value_type`.

We have a few options to resolve this:
1. Remove this parameter, as we do for allocators
    Cons: removing a template parameter doesn't work if other parameters appear after it

2. Stub this parameter, as we do for hashers/comparators
    Cons: we need to hardcode an implementation that satisfies the `Traits::value_type` requirements

3. Leave the parameter as-is
    Cons: will not work if a non-standard Traits is used

    By using the real implementation of this Traits parameter
    (normally `std::char_traits<CharT>`), we get one that we know will
    work as long as it is defined in a stdlib header.

Option 3 is what we use in this patch. Instead of adding more configuration options to the container TOML file format (e.g. `params_to_keep = [1]`), we add `std::char_traits` as a dummy container type. Now, whenever `std::char_traits` appears, it will be left as-is, i.e. not removed, replaced or reverse-engineered.

This is the same approach previously used for Thrift's isset_bitset.

## Test plan
The following tests now pass with and without TypeGraph:
```
OidIntegration.std_string_empty
OidIntegration.std_string_sso
OidIntegration.std_string_heap_allocated
```