### PR TITLE
TypeGraph: Handle alias templates

### DIFF
--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -106,4 +106,24 @@ void NameGen::visit(Container& c) {
   c.setName(name);
 }
 
+void NameGen::visit(Typedef& td) {
+  /*
+   * Treat like class names.
+   *
+   * We must remove template parameters from typedef names because, although
+   * they won't have real (in DWARF) template parameters themselves, their names
+   * may still contain other type names surrounded by angle brackets.
+   *
+   * An alias template, e.g. std::conditional_t, will have this behaviour:
+   *     conditional_t<B,T,F> is a typedef for conditional<B,T,F>::type
+   */
+  std::string name = td.name();
+  removeTemplateParams(name);
+
+  // Append an incrementing number to ensure we don't get duplicates
+  td.setName(name + "_" + std::to_string(n++));
+
+  visit(*td.underlyingType());
+}
+
 }  // namespace type_graph

--- a/oi/type_graph/NameGen.h
+++ b/oi/type_graph/NameGen.h
@@ -34,6 +34,7 @@ class NameGen final : public RecursiveVisitor {
 
   void visit(Class& c) override;
   void visit(Container& c) override;
+  void visit(Typedef& td) override;
 
  private:
   void visit(Type& type) override;

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -317,6 +317,10 @@ class Typedef : public Type {
     return name_;
   }
 
+  void setName(std::string name) {
+    name_ = std::move(name);
+  }
+
   virtual size_t size() const override {
     return underlyingType_->size();
   }

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -194,10 +194,21 @@ TEST(NameGenTest, Typedef) {
   NameGen nameGen;
   nameGen.generateNames({*mytypedef});
 
-  EXPECT_EQ(myparam1->name(), "MyParam_0");
-  EXPECT_EQ(myparam2->name(), "MyParam_1");
-  EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
-  EXPECT_EQ(mytypedef->name(), "MyTypedef");
+  EXPECT_EQ(myparam1->name(), "MyParam_1");
+  EXPECT_EQ(myparam2->name(), "MyParam_2");
+  EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_1, MyParam_2>");
+  EXPECT_EQ(mytypedef->name(), "MyTypedef_0");
+}
+
+TEST(NameGenTest, TypedefAliasTemplate) {
+  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
+  auto mytypedef =
+      std::make_unique<Typedef>("MyTypedef<ParamA, ParamB>", myint.get());
+
+  NameGen nameGen;
+  nameGen.generateNames({*mytypedef});
+
+  EXPECT_EQ(mytypedef->name(), "MyTypedef_0");
 }
 
 TEST(NameGenTest, Pointer) {


### PR DESCRIPTION
This fixes the test failure for std::conditional_t

## Test plan
The following test now passes with and without type graph:
```
OidIntegration.std_conditional_a
```