### PR TITLE
TypeGraph: Allocator improvements

### DIFF
--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -155,3 +155,30 @@ struct alignas(align) DummySizedOperator {
 // DummySizedOperator<0,0> also collapses to this
 template <>
 struct DummySizedOperator<0> {};
+
+template <template <typename, size_t, size_t> typename DerivedT,
+          typename T,
+          size_t N,
+          size_t Align>
+struct DummyAllocatorBase {
+  using value_type = T;
+  T* allocate(std::size_t n) {
+    return nullptr;
+  }
+  void deallocate(T* p, std::size_t n) noexcept {
+  }
+
+  template <typename U>
+  struct rebind {
+    using other = DerivedT<U, N, Align>;
+  };
+};
+
+template <typename T, size_t N, size_t Align = 0>
+struct alignas(Align) DummyAllocator
+    : DummyAllocatorBase<DummyAllocator, T, N, Align> {
+  char c[N];
+};
+
+template <typename T>
+struct DummyAllocator<T, 0> : DummyAllocatorBase<DummyAllocator, T, 0, 0> {};

--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -291,8 +291,12 @@ void DrgnParser::enumerateTemplateParam(drgn_type_template_parameter* tparams,
 
     struct drgn_type* tparamType = tparamQualType.type;
 
+    QualifierSet qualifiers;
+    qualifiers[Qualifier::Const] =
+        (tparamQualType.qualifiers & DRGN_QUALIFIER_CONST);
+
     auto ttype = enumerateType(tparamType);
-    params.emplace_back(ttype);
+    params.emplace_back(ttype, qualifiers);
   } else {
     // This template parameter is a value
     //    TODO why do we need the type of a value?

--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -95,6 +95,9 @@ void NameGen::visit(Container& c) {
     if (param.value) {
       name += *param.value;
     } else {
+      if (param.qualifiers[Qualifier::Const]) {
+        name += "const ";
+      }
       name += param.type->name();
     }
     name += ", ";

--- a/oi/type_graph/Printer.cpp
+++ b/oi/type_graph/Printer.cpp
@@ -115,8 +115,9 @@ void Printer::visit(const Dummy& d) {
 
 void Printer::visit(const DummyAllocator& d) {
   prefix();
-  out_ << "DummyAllocatorTODO (size: " << d.size() << align_str(d.align())
-       << ")" << std::endl;
+  out_ << "DummyAllocator (size: " << d.size() << align_str(d.align()) << ")"
+       << std::endl;
+  print(d.allocType());
 }
 
 bool Printer::prefix(const Type* type) {

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "oi/ContainerInfo.h"
+#include "oi/EnumBitset.h"
 
 #define OI_TYPE_LIST \
   X(Class)           \
@@ -36,6 +37,12 @@
 struct ContainerInfo;
 
 namespace type_graph {
+
+enum class Qualifier {
+  Const,
+  Max,
+};
+using QualifierSet = EnumBitset<Qualifier, static_cast<size_t>(Qualifier::Max)>;
 
 class Visitor;
 class ConstVisitor;
@@ -92,14 +99,18 @@ struct Parent {
 };
 
 struct TemplateParam {
-  // TODO make ctors explicit?
+  // TODO make ctors explicit
   TemplateParam(Type* type) : type(type) {
+  }
+  TemplateParam(Type* type, QualifierSet qualifiers)
+      : type(type), qualifiers(qualifiers) {
   }
   TemplateParam(Type* type, std::string value)
       : type(type), value(std::move(value)) {
   }
 
   Type* type;
+  QualifierSet qualifiers;
   std::optional<std::string>
       value;  // TODO is there any reason not to store all values as strings?
 };

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -410,10 +410,8 @@ class DummyAllocator : public Type {
   DECLARE_ACCEPT
 
   virtual std::string name() const override {
-    return "std::allocator<" + type_.name() + ">";
-    // TODO custom sized allocators:
-    //    return "DummyAllocator<" + type_.name() + ", " + std::to_string(size_)
-    //    + "," + std::to_string(align_) + ">";
+    return "DummyAllocator<" + type_.name() + ", " + std::to_string(size_) +
+           ", " + std::to_string(align_) + ">";
   }
 
   virtual size_t size() const override {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(integration_sleepy folly_headers)
 # Unit tests
 
 add_executable(test_type_graph
+  main.cpp
   test_add_padding.cpp
   test_alignment_calc.cpp
   test_drgn_parser.cpp
@@ -56,6 +57,7 @@ add_executable(test_type_graph
   test_remove_top_level_pointer.cpp
   test_topo_sorter.cpp
   test_type_identifier.cpp
+  type_graph_utils.cpp
 )
 add_dependencies(test_type_graph integration_test_target)
 target_compile_definitions(test_type_graph PRIVATE

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+/*
+ * This listener ensures that test failures (ASSERTs) in helper functions
+ * propagate all the way up and stop the test from continuing.
+ */
+class ThrowListener : public testing::EmptyTestEventListener {
+  void OnTestPartResult(const testing::TestPartResult& result) override {
+    if (result.type() == testing::TestPartResult::kFatalFailure) {
+      throw testing::AssertionException(result);
+    }
+  }
+};
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::UnitTest::GetInstance()->listeners().Append(new ThrowListener);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_add_padding.cpp
+++ b/test/test_add_padding.cpp
@@ -5,29 +5,9 @@
 #include "oi/type_graph/Printer.h"
 #include "oi/type_graph/TypeGraph.h"
 #include "oi/type_graph/Types.h"
+#include "test/type_graph_utils.h"
 
 using namespace type_graph;
-
-void test(Pass pass,
-          std::vector<std::reference_wrapper<Type>> types,
-          std::string_view expected) {
-  TypeGraph typeGraph;
-  for (const auto& type : types) {
-    typeGraph.addRoot(type);
-  }
-
-  pass.run(typeGraph);
-
-  std::stringstream out;
-  Printer printer(out);
-
-  for (const auto& type : types) {
-    printer.print(type);
-  }
-
-  expected.remove_prefix(1);  // Remove initial '\n'
-  EXPECT_EQ(expected, out.str());
-}
 
 TEST(AddPaddingTest, BetweenMembers) {
   auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 16);

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -162,6 +162,24 @@ TEST(NameGenTest, ContainerParamsDuplicatesAcrossContainers) {
   EXPECT_EQ(mycontainer2.name(), "std::vector<MyParam_1, MyParam_2>");
 }
 
+TEST(NameGenTest, ContainerParamsConst) {
+  auto myparam1 =
+      std::make_unique<Class>(Class::Kind::Struct, "MyConstParam", 13);
+  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+
+  auto mycontainer = getVector();
+  mycontainer.templateParams.push_back(
+      TemplateParam{myparam1.get(), {Qualifier::Const}});
+  mycontainer.templateParams.push_back(TemplateParam{myparam2.get()});
+
+  NameGen nameGen;
+  nameGen.generateNames({mycontainer});
+
+  EXPECT_EQ(myparam1->name(), "MyConstParam_0");
+  EXPECT_EQ(myparam2->name(), "MyParam_1");
+  EXPECT_EQ(mycontainer.name(), "std::vector<const MyConstParam_0, MyParam_1>");
+}
+
 TEST(NameGenTest, Array) {
   auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
   auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -242,6 +242,15 @@ TEST(NameGenTest, Pointer) {
   EXPECT_EQ(mypointer->name(), "std::vector<MyParam_0, MyParam_1>*");
 }
 
+TEST(NameGenTest, Dummy) {
+  auto dummy = std::make_unique<Dummy>(12, 34);
+
+  NameGen nameGen;
+  nameGen.generateNames({*dummy});
+
+  EXPECT_EQ(dummy->name(), "DummySizedOperator<12, 34>");
+}
+
 TEST(NameGenTest, DummyAllocator) {
   auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
   auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
@@ -250,7 +259,7 @@ TEST(NameGenTest, DummyAllocator) {
   mycontainer.templateParams.push_back(myparam1.get());
   mycontainer.templateParams.push_back(myparam2.get());
 
-  auto myalloc = std::make_unique<DummyAllocator>(mycontainer, 0, 0);
+  auto myalloc = std::make_unique<DummyAllocator>(mycontainer, 12, 34);
 
   NameGen nameGen;
   nameGen.generateNames({*myalloc});
@@ -259,7 +268,7 @@ TEST(NameGenTest, DummyAllocator) {
   EXPECT_EQ(myparam2->name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
   EXPECT_EQ(myalloc->name(),
-            "std::allocator<std::vector<MyParam_0, MyParam_1>>");
+            "DummyAllocator<std::vector<MyParam_0, MyParam_1>, 12, 34>");
 }
 
 TEST(NameGenTest, Cycle) {

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -1,16 +1,10 @@
 #include <gtest/gtest.h>
 
-#include "oi/ContainerInfo.h"
 #include "oi/type_graph/NameGen.h"
 #include "oi/type_graph/Types.h"
+#include "test/type_graph_utils.h"
 
 using namespace type_graph;
-
-Container getVector() {
-  ContainerInfo info{"std::vector", SEQ_TYPE, "vector"};
-
-  return Container{info, 24};
-}
 
 TEST(NameGenTest, ClassParams) {
   auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);

--- a/test/test_type_identifier.cpp
+++ b/test/test_type_identifier.cpp
@@ -1,7 +1,109 @@
 #include <gtest/gtest.h>
 
+#include "oi/type_graph/Printer.h"
 #include "oi/type_graph/TypeIdentifier.h"
+#include "oi/type_graph/Types.h"
+#include "test/type_graph_utils.h"
 
 using namespace type_graph;
 
-// TODO tests!!!
+TEST(TypeIdentifierTest, StubbedParam) {
+  auto myint = Primitive{Primitive::Kind::Int32};
+
+  auto myparam = Class{Class::Kind::Struct, "MyParam", 4};
+  myparam.members.push_back(Member{&myint, "a", 0});
+
+  auto container = getVector();
+  container.templateParams.push_back(TemplateParam{&myint});
+  container.templateParams.push_back(TemplateParam{&myparam});
+  container.templateParams.push_back(TemplateParam{&myint});
+
+  test(TypeIdentifier::createPass(), {container}, R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+[1]     Struct: MyParam (size: 4)
+          Member: a (offset: 0)
+            Primitive: int32_t
+      Param
+        Primitive: int32_t
+)",
+       R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+        Dummy (size: 4)
+      Param
+        Primitive: int32_t
+)");
+}
+
+TEST(TypeIdentifierTest, Allocator) {
+  auto myint = Primitive{Primitive::Kind::Int32};
+
+  auto myalloc = Class{Class::Kind::Struct, "MyAlloc", 8};
+  myalloc.templateParams.push_back(TemplateParam{&myint});
+  myalloc.functions.push_back(Function{"allocate"});
+  myalloc.functions.push_back(Function{"deallocate"});
+
+  auto container = getVector();
+  container.templateParams.push_back(TemplateParam{&myint});
+  container.templateParams.push_back(TemplateParam{&myalloc});
+  container.templateParams.push_back(TemplateParam{&myint});
+
+  test(TypeIdentifier::createPass(), {container}, R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+[1]     Struct: MyAlloc (size: 8)
+          Param
+            Primitive: int32_t
+          Function: allocate
+          Function: deallocate
+      Param
+        Primitive: int32_t
+)",
+       R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+        DummyAllocator (size: 8)
+          Primitive: int32_t
+      Param
+        Primitive: int32_t
+)");
+}
+
+TEST(TypeIdentifierTest, AllocatorNoParam) {
+  auto myint = Primitive{Primitive::Kind::Int32};
+
+  auto myalloc = Class{Class::Kind::Struct, "MyAlloc", 8};
+  myalloc.functions.push_back(Function{"allocate"});
+  myalloc.functions.push_back(Function{"deallocate"});
+
+  auto container = getVector();
+  container.templateParams.push_back(TemplateParam{&myint});
+  container.templateParams.push_back(TemplateParam{&myalloc});
+
+  test(TypeIdentifier::createPass(), {container}, R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+[1]     Struct: MyAlloc (size: 8)
+          Function: allocate
+          Function: deallocate
+)",
+       R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+        DummyAllocator (size: 8)
+          Primitive: int32_t
+)");
+}

--- a/test/type_graph_utils.cpp
+++ b/test/type_graph_utils.cpp
@@ -1,0 +1,68 @@
+#include "test/type_graph_utils.h"
+
+#include <gtest/gtest.h>
+
+#include "oi/ContainerInfo.h"
+#include "oi/type_graph/PassManager.h"
+#include "oi/type_graph/Printer.h"
+#include "oi/type_graph/TypeGraph.h"
+
+using type_graph::Container;
+using type_graph::Pass;
+using type_graph::Type;
+using type_graph::TypeGraph;
+
+template <typename T>
+using ref = std::reference_wrapper<T>;
+
+namespace {
+void check(const std::vector<ref<Type>>& types,
+           std::string_view expected,
+           std::string_view comment) {
+  std::stringstream out;
+  type_graph::Printer printer(out);
+
+  for (const auto& type : types) {
+    printer.print(type);
+  }
+
+  expected.remove_prefix(1);  // Remove initial '\n'
+  ASSERT_EQ(expected, out.str())
+      << "Test failure " << comment << " running pass";
+}
+}  // namespace
+
+void test(type_graph::Pass pass,
+          std::vector<ref<Type>> rootTypes,
+          std::string_view expectedBefore,
+          std::string_view expectedAfter) {
+  check(rootTypes, expectedBefore, "before");
+
+  TypeGraph typeGraph;
+  for (const auto& type : rootTypes) {
+    typeGraph.addRoot(type);
+  }
+
+  pass.run(typeGraph);
+
+  check(rootTypes, expectedAfter, "after");
+}
+
+void test(type_graph::Pass pass,
+          std::vector<ref<Type>> rootTypes,
+          std::string_view expectedAfter) {
+  TypeGraph typeGraph;
+  for (const auto& type : rootTypes) {
+    typeGraph.addRoot(type);
+  }
+
+  pass.run(typeGraph);
+
+  check(rootTypes, expectedAfter, "after");
+}
+
+Container getVector() {
+  static ContainerInfo info{"std::vector", SEQ_TYPE, "vector"};
+  info.stubTemplateParams = {1};
+  return Container{info, 24};
+}

--- a/test/type_graph_utils.h
+++ b/test/type_graph_utils.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <functional>
+#include <string_view>
+#include <vector>
+
+namespace type_graph {
+class Container;
+class Pass;
+class Type;
+}  // namespace type_graph
+
+void test(type_graph::Pass pass,
+          std::vector<std::reference_wrapper<type_graph::Type>> rootTypes,
+          std::string_view expectedBefore,
+          std::string_view expectedAfter);
+
+void test(type_graph::Pass pass,
+          std::vector<std::reference_wrapper<type_graph::Type>> rootTypes,
+          std::string_view expectedAfter);
+
+type_graph::Container getVector();

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -12,13 +12,13 @@ replaceTemplateParamIndex = []
 
 [codegen]
 decl = """
-template<typename T>
-void getSizeType(const %1%<T> &container, size_t& returnArg);
+template<typename T, typename Traits, typename Allocator>
+void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg);
 """
 
 func = """
-template<typename T>
-void getSizeType(const %1%<T> &container, size_t& returnArg)
+template<typename T, typename Traits, typename Allocator>
+void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T>));
 

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -12,13 +12,13 @@ allocatorIndex = 1
 
 [codegen]
 decl = """
-template<typename T>
-void getSizeType(const %1%<T> &container, size_t& returnArg);
+template<typename T, typename Allocator>
+void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg);
 """
 
 func = """
-template<typename T>
-void getSizeType(const %1%<T> &container, size_t& returnArg)
+template<typename T, typename Allocator>
+void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T>));
 

--- a/types/string_type.toml
+++ b/types/string_type.toml
@@ -12,13 +12,13 @@ replaceTemplateParamIndex = []
 
 [codegen]
 decl = """
-template<typename T>
-void getSizeType(const %1%<T> &container, size_t& returnArg);
+template<typename T, typename Traits, typename Allocator>
+void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg);
 """
 
 func = """
-template<typename T>
-void getSizeType(const %1%<T> &container, size_t& returnArg)
+template<typename T, typename Traits, typename Allocator>
+void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T>));
 


### PR DESCRIPTION
## Summary
### Replace allocators with DummyAllocator
When we were previously removing allocators, we were only able to work with containers whose allocators appeared as their last template parameter.

Now we can replace allocators in the middle of a parameter list.

### Apply qualifiers to template params
This is necessary when replacing the allocator of a map type, for example.

`std::map<int, int>` will need an allocator which allocates elements of type `std::pair<const int, int>>`

## Test plan
100% of tests pass with legacy OICodeGen.
84% of tests pass with TypeGraph CodeGen.

New test successes with this change:
```
OidIntegration.sorted_vector_set_no_ints
OidIntegration.sorted_vector_set_some_ints
```