### PR TITLE
clean up common.h

### DIFF
--- a/oi/CMakeLists.txt
+++ b/oi/CMakeLists.txt
@@ -30,8 +30,6 @@ add_library(container_info
   ContainerInfo.cpp
 )
 target_link_libraries(container_info
-  drgn_utils # This shouldn't be needed! Clean up Commoh.h!
-
   glog::glog
   toml
 )

--- a/oi/ContainerInfo.h
+++ b/oi/ContainerInfo.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "oi/Common.h"
+#include "oi/ContainerTypeEnum.h"
 
 ContainerTypeEnum containerTypeEnumFromStr(std::string& str);
 const char* containerTypeEnumToStr(ContainerTypeEnum ty);

--- a/oi/ContainerTypeEnum.h
+++ b/oi/ContainerTypeEnum.h
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <map>
-#include <set>
-#include <string>
-#include <vector>
-
-extern "C" {
-#include <drgn.h>
-}
-
-constexpr int oidMagicId = 0x01DE8;
 
 #define LIST_OF_CONTAINER_TYPES  \
   X(UNKNOWN_TYPE)                \
@@ -73,46 +63,3 @@ enum ContainerTypeEnum {
   LIST_OF_CONTAINER_TYPES
 #undef X
 };
-
-struct RootInfo {
-  std::string varName;
-  struct drgn_qualified_type type;
-};
-
-struct ClassMember {
-  std::string typeName;
-  std::string varName;
-};
-
-struct DrgnClassMemberInfo {
-  struct drgn_type* type;
-  std::string member_name;
-  uint64_t bit_offset;
-  uint64_t bit_field_size;
-  bool isStubbed;
-};
-
-struct TypeHierarchy {
-  std::map<struct drgn_type*, std::vector<DrgnClassMemberInfo>> classMembersMap;
-  std::map<
-      struct drgn_type*,
-      std::pair<ContainerTypeEnum, std::vector<struct drgn_qualified_type>>>
-      containerTypeMap;
-  std::map<struct drgn_type*, struct drgn_type*> typedefMap;
-  std::map<std::string, size_t> sizeMap;
-  std::set<struct drgn_type*> knownDummyTypeList;
-  std::map<struct drgn_type*, struct drgn_type*> pointerToTypeMap;
-  std::set<struct drgn_type*> thriftIssetStructTypes;
-  std::map<struct drgn_type*, std::vector<struct drgn_type*>> descendantClasses;
-};
-
-// Helper for std::variant and std::visit
-// https://en.cppreference.com/w/cpp/utility/variant/visit
-template <class... Ts>
-struct visitor : Ts... {
-  using Ts::operator()...;
-};
-
-// Type deduction for the helper above
-template <class... Ts>
-visitor(Ts...) -> visitor<Ts...>;

--- a/oi/OICodeGen.h
+++ b/oi/OICodeGen.h
@@ -26,11 +26,11 @@
 class SymbolService;
 struct irequest;
 
-#include "oi/Common.h"
 #include "oi/ContainerInfo.h"
 #include "oi/Features.h"
 #include "oi/FuncGen.h"
 #include "oi/PaddingHunter.h"
+#include "oi/TypeHierarchy.h"
 
 extern "C" {
 #include <drgn.h>

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -61,6 +61,8 @@ extern "C" {
 using namespace std;
 using namespace ObjectIntrospection;
 
+constexpr int oidMagicId = 0x01DE8;
+
 bool OIDebugger::isGlobalDataProbeEnabled(void) const {
   return std::any_of(cbegin(pdata), cend(pdata),
                      [](const auto& r) { return r.type == "global"; });

--- a/oi/Serialize.h
+++ b/oi/Serialize.h
@@ -24,9 +24,9 @@
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/vector.hpp>
 
-#include "oi/Common.h"
 #include "oi/PaddingHunter.h"
 #include "oi/SymbolService.h"
+#include "oi/TypeHierarchy.h"
 
 #define DEFINE_TYPE_VERSION(Type, size, version)                             \
   static_assert(                                                             \

--- a/oi/SymbolService.cpp
+++ b/oi/SymbolService.cpp
@@ -34,6 +34,15 @@ extern "C" {
 #include "dwarf.h"
 }
 
+template <typename... Ts>
+struct visitor : Ts... {
+  using Ts::operator()...;
+};
+
+// Type deduction for the helper above
+template <typename... Ts>
+visitor(Ts...) -> visitor<Ts...>;
+
 static bool LoadExecutableAddressRange(
     pid_t pid, std::vector<std::pair<uint64_t, uint64_t>>& exeAddrs) {
   std::ifstream f("/proc/" + std::to_string(pid) + "/maps");

--- a/oi/SymbolService.h
+++ b/oi/SymbolService.h
@@ -23,8 +23,8 @@
 #include <variant>
 #include <vector>
 
-#include "oi/Common.h"
 #include "oi/Descs.h"
+#include "oi/TypeHierarchy.h"
 
 namespace fs = std::filesystem;
 

--- a/oi/TreeBuilder.h
+++ b/oi/TreeBuilder.h
@@ -23,8 +23,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include "oi/Common.h"
 #include "oi/Features.h"
+#include "oi/TypeHierarchy.h"
 
 // The rocksdb includes are extremely heavy and bloat compile times,
 // so we just forward-declare `DB` to avoid making other compile units

--- a/oi/TypeHierarchy.h
+++ b/oi/TypeHierarchy.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "oi/ContainerTypeEnum.h"
+
+extern "C" {
+#include <drgn.h>
+}
+
+struct RootInfo {
+  std::string varName;
+  struct drgn_qualified_type type;
+};
+
+struct ClassMember {
+  std::string typeName;
+  std::string varName;
+};
+
+struct DrgnClassMemberInfo {
+  struct drgn_type* type;
+  std::string member_name;
+  uint64_t bit_offset;
+  uint64_t bit_field_size;
+  bool isStubbed;
+};
+
+struct TypeHierarchy {
+  std::map<struct drgn_type*, std::vector<DrgnClassMemberInfo>> classMembersMap;
+  std::map<
+      struct drgn_type*,
+      std::pair<ContainerTypeEnum, std::vector<struct drgn_qualified_type>>>
+      containerTypeMap;
+  std::map<struct drgn_type*, struct drgn_type*> typedefMap;
+  std::map<std::string, size_t> sizeMap;
+  std::set<struct drgn_type*> knownDummyTypeList;
+  std::map<struct drgn_type*, struct drgn_type*> pointerToTypeMap;
+  std::set<struct drgn_type*> thriftIssetStructTypes;
+  std::map<struct drgn_type*, std::vector<struct drgn_type*>> descendantClasses;
+};

--- a/oi/type_graph/AddChildren.cpp
+++ b/oi/type_graph/AddChildren.cpp
@@ -22,6 +22,10 @@
 #include "oi/DrgnUtils.h"
 #include "oi/SymbolService.h"
 
+extern "C" {
+#include <drgn.h>
+}
+
 template <typename T>
 using ref = std::reference_wrapper<T>;
 

--- a/oi/type_graph/AddChildren.h
+++ b/oi/type_graph/AddChildren.h
@@ -24,6 +24,7 @@
 #include "Visitor.h"
 
 class SymbolService;
+struct drgn_type;
 
 namespace type_graph {
 

--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -439,6 +439,12 @@ bool DrgnParser::chasePointer() const {
   return chaseRawPointers_;
 }
 
+DrgnParserError::DrgnParserError(const std::string& msg, struct drgn_error* err)
+    : std::runtime_error{msg + ": " + std::to_string(err->code) + " " +
+                         err->message},
+      err_(err) {
+}
+
 DrgnParserError::~DrgnParserError() {
   drgn_error_destroy(err_);
 }

--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -23,6 +23,8 @@
 
 struct drgn_type;
 struct drgn_type_template_parameter;
+struct drgn_error;
+
 struct ContainerInfo;
 
 namespace type_graph {
@@ -84,11 +86,7 @@ class DrgnParserError : public std::runtime_error {
  public:
   DrgnParserError(const std::string& msg) : std::runtime_error{msg} {
   }
-  DrgnParserError(const std::string& msg, struct drgn_error* err)
-      : std::runtime_error{msg + ": " + std::to_string(err->code) + " " +
-                           err->message},
-        err_(err) {
-  }
+  DrgnParserError(const std::string& msg, struct drgn_error* err);
 
   ~DrgnParserError();
 

--- a/tools/OITB.cpp
+++ b/tools/OITB.cpp
@@ -24,11 +24,11 @@
 #include <span>
 
 #include "glog/vlog_is_on.h"
-#include "oi/Common.h"
 #include "oi/OIOpts.h"
 #include "oi/PaddingHunter.h"
 #include "oi/Serialize.h"
 #include "oi/TreeBuilder.h"
+#include "oi/TypeHierarchy.h"
 
 namespace fs = std::filesystem;
 


### PR DESCRIPTION
## Summary

`Common.h` is used in several places and includes the massive `drgn` header. Split it up for better dependencies.

## Test plan

- `make clobber; make configure-devel && make test'
- CI
