### PR TITLE
ensure oi_name is never a nullptr

### DIFF
--- a/oi/DrgnUtils.cpp
+++ b/oi/DrgnUtils.cpp
@@ -122,8 +122,10 @@ std::string typeToName(drgn_type* type) {
     const char* typeTag = drgn_type_tag(type);
     if (typeTag != nullptr) {
       typeName = typeTag;
-    } else {
+    } else if (type->_private.oi_name != nullptr) {
       typeName = type->_private.oi_name;
+    } else {
+      typeName = "";
     }
     // TODO: Lookup unnamed union in type->string flag
   } else if (drgn_type_has_name(type)) {


### PR DESCRIPTION
## Summary
Ensure type->_private->oi_name is never a null pointer. We just assign it an empty string if the type has no tag or if the tag is null.

## Test plan
A `make test` was clean.
