### PR TITLE
set function oi_name to null rather than garbage

### DIFF
--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -1516,6 +1516,7 @@ bool OICodeGen::enumeratePointerType(drgn_type* type) {
   drgn_type* utype = getPtrUnderlyingType(type);
   if (drgn_type_kind(utype) == DRGN_TYPE_FUNCTION) {
     VLOG(2) << "Type " << type << " is a function pointer to " << utype;
+    utype->_private.oi_name = nullptr;
     pointerToTypeMap.emplace(type, utype);
     return ret;
   }


### PR DESCRIPTION
## Summary

Fix a path where `oi_name` is left as a nonsense pointer rather than nullptr.

## Test plan

