### PR TITLE
Add copyright header to all source files

### DIFF
--- a/oi/Headers.h
+++ b/oi/Headers.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include <string_view>
 
 namespace ObjectIntrospection {

--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #define NDEBUG 1
 // Required for compatibility with new glibc headers
 #define __malloc__(x, y) __malloc__


### PR DESCRIPTION
Meta's Open Source Team's automated checks highlighted the missing copyright headers on Headers.cpp.
We had a manual exclusion rule on OITraceCode.cpp, but seeing as how we have core code in this file, I added the header to it and removed the exclusion rule.
