### PR TITLE
CodeGen unit tests

### DIFF
--- a/oi/CMakeLists.txt
+++ b/oi/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(codegen
 )
 target_link_libraries(codegen
   container_info
+  resources
   symbol_service
   type_graph
 

--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -21,33 +21,39 @@
 
 #include "ContainerInfo.h"
 #include "OICodeGen.h"
-#include "SymbolService.h"
 
 struct drgn_type;
 
+class SymbolService;
+
 namespace type_graph {
-class Class;
-class Container;
-class Type;
 class TypeGraph;
 }  // namespace type_graph
 
 class CodeGen {
  public:
-  CodeGen(type_graph::TypeGraph& typeGraph,
-          OICodeGen::Config& config,
-          SymbolService& symbols)
-      : typeGraph_(typeGraph), config_(config), symbols_(symbols) {
+  CodeGen(OICodeGen::Config& config, SymbolService& symbols)
+      : config_(config), symbols_(symbols) {
   }
 
-  bool generate(drgn_type* drgnType, std::string& code);
-  void loadConfig(const std::set<std::filesystem::path>& containerConfigPaths);
+  /*
+   * Helper function to perform all the steps required for code generation for a
+   * single drgn_type.
+   */
+  bool codegenFromDrgn(struct drgn_type* drgnType, std::string& code);
+
+  void registerContainer(const std::filesystem::path& path);
+  void addDrgnRoot(struct drgn_type* drgnType,
+                   type_graph::TypeGraph& typeGraph);
+  void transform(type_graph::TypeGraph& typeGraph);
+  void generate(type_graph::TypeGraph& typeGraph,
+                std::string& code,
+                struct drgn_type*
+                    drgnType /* TODO: this argument should not be required */
+  );
 
  private:
-  void registerContainer(const std::filesystem::path& path);
-
-  type_graph::TypeGraph& typeGraph_;
   OICodeGen::Config config_;
-  std::vector<ContainerInfo> containerInfos_;
   SymbolService& symbols_;
+  std::vector<ContainerInfo> containerInfos_;
 };

--- a/oi/ContainerInfo.h
+++ b/oi/ContainerInfo.h
@@ -93,6 +93,13 @@ struct ContainerInfo {
   }
 };
 
+class ContainerInfoError : public std::runtime_error {
+ public:
+  ContainerInfoError(const std::filesystem::path& path, const std::string& msg)
+      : std::runtime_error{std::string{path} + ": " + msg} {
+  }
+};
+
 using ContainerInfoRefSet =
     std::set<std::reference_wrapper<const ContainerInfo>,
              std::less<ContainerInfo>>;

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -52,6 +52,7 @@ extern "C" {
 #include "oi/OIUtils.h"
 #include "oi/PaddingHunter.h"
 #include "oi/Syscall.h"
+#include "oi/type_graph/DrgnParser.h"
 #include "oi/type_graph/TypeGraph.h"
 
 #ifndef OSS_ENABLE
@@ -2928,12 +2929,8 @@ std::optional<std::string> OIDebugger::generateCode(const irequest& req) {
                       codegen->getTypeHierarchy(), codegen->getPaddingInfo()));
 
   if (generatorConfig.features[Feature::TypeGraph]) {
-    type_graph::TypeGraph typeGraph;
-    CodeGen codegen2(typeGraph, generatorConfig, *symbols);
-    codegen2.loadConfig(generatorConfig.containerConfigPaths);
-    if (!codegen2.generate(root->type.type, code)) {
-      return nullopt;
-    }
+    CodeGen codegen2{generatorConfig, *symbols};
+    codegen2.codegenFromDrgn(root->type.type, code);
   }
 
   if (auto sourcePath = cache.getPath(req, OICache::Entity::Source)) {

--- a/oi/SymbolService.h
+++ b/oi/SymbolService.h
@@ -74,4 +74,7 @@ class SymbolService {
 
   std::vector<std::pair<uint64_t, uint64_t>> executableAddrs{};
   bool hardDisableDrgn = false;
+
+ protected:
+  SymbolService() = default;  // For unit tests
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(test_type_graph
   main.cpp
   test_add_padding.cpp
   test_alignment_calc.cpp
+  test_codegen.cpp
   test_drgn_parser.cpp
   test_flattener.cpp
   test_name_gen.cpp
@@ -65,6 +66,7 @@ target_compile_definitions(test_type_graph PRIVATE
   TARGET_EXE_PATH="${CMAKE_CURRENT_BINARY_DIR}/integration/integration_test_target"
 )
 target_link_libraries(test_type_graph
+  codegen
   container_info
   type_graph
 

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "gmock/gmock.h"
+#include "oi/SymbolService.h"
+
+class MockSymbolService : public SymbolService {
+ public:
+  MockSymbolService() {
+  }
+};

--- a/test/type_graph_utils.cpp
+++ b/test/type_graph_utils.cpp
@@ -15,7 +15,6 @@ using type_graph::TypeGraph;
 template <typename T>
 using ref = std::reference_wrapper<T>;
 
-namespace {
 void check(const std::vector<ref<Type>>& types,
            std::string_view expected,
            std::string_view comment) {
@@ -27,16 +26,14 @@ void check(const std::vector<ref<Type>>& types,
   }
 
   expected.remove_prefix(1);  // Remove initial '\n'
-  ASSERT_EQ(expected, out.str())
-      << "Test failure " << comment << " running pass";
+  ASSERT_EQ(expected, out.str()) << "Test failure " << comment;
 }
-}  // namespace
 
 void test(type_graph::Pass pass,
           std::vector<ref<Type>> rootTypes,
           std::string_view expectedBefore,
           std::string_view expectedAfter) {
-  check(rootTypes, expectedBefore, "before");
+  check(rootTypes, expectedBefore, "before running pass");
 
   TypeGraph typeGraph;
   for (const auto& type : rootTypes) {
@@ -45,7 +42,7 @@ void test(type_graph::Pass pass,
 
   pass.run(typeGraph);
 
-  check(rootTypes, expectedAfter, "after");
+  check(rootTypes, expectedAfter, "after running pass");
 }
 
 void test(type_graph::Pass pass,

--- a/test/type_graph_utils.h
+++ b/test/type_graph_utils.h
@@ -10,6 +10,10 @@ class Pass;
 class Type;
 }  // namespace type_graph
 
+void check(const std::vector<std::reference_wrapper<type_graph::Type>>& types,
+           std::string_view expected,
+           std::string_view comment);
+
 void test(type_graph::Pass pass,
           std::vector<std::reference_wrapper<type_graph::Type>> rootTypes,
           std::string_view expectedBefore,


### PR DESCRIPTION
Add a first test for TypeGraph CodeGen.

This required some refactoring of CodeGen to make it unit-testable.