### PR TITLE
Flattener: Attempt to take params from parent allocator in case of bad DWARF

### DIFF
--- a/oi/EnumBitset.h
+++ b/oi/EnumBitset.h
@@ -37,6 +37,16 @@ class EnumBitset {
     return bitset[static_cast<size_t>(v)];
   }
 
+  bool all() const noexcept {
+    return bitset.all();
+  }
+  bool any() const noexcept {
+    return bitset.any();
+  }
+  bool none() const noexcept {
+    return bitset.none();
+  }
+
  private:
   BitsetType bitset;
 };

--- a/oi/type_graph/Printer.cpp
+++ b/oi/type_graph/Printer.cpp
@@ -159,6 +159,7 @@ void Printer::print_param(const TemplateParam& param) {
   } else {
     print(*param.type);
   }
+  print_qualifiers(param.qualifiers);
   depth_--;
 }
 
@@ -201,6 +202,20 @@ void Printer::print_value(const std::string& value) {
   depth_++;
   prefix();
   out_ << "Value: " << value << std::endl;
+  depth_--;
+}
+
+void Printer::print_qualifiers(const QualifierSet& qualifiers) {
+  if (qualifiers.none()) {
+    return;
+  }
+  depth_++;
+  prefix();
+  out_ << "Qualifiers:";
+  if (qualifiers[Qualifier::Const]) {
+    out_ << " const";
+  }
+  out_ << std::endl;
   depth_--;
 }
 

--- a/oi/type_graph/Printer.h
+++ b/oi/type_graph/Printer.h
@@ -50,6 +50,7 @@ class Printer : public ConstVisitor {
   void print_function(const Function& function);
   void print_child(const Type& child);
   void print_value(const std::string& value);
+  void print_qualifiers(const QualifierSet& qualifiers);
   static std::string align_str(uint64_t align);
 
   std::ostream& out_;

--- a/oi/type_graph/TypeIdentifier.h
+++ b/oi/type_graph/TypeIdentifier.h
@@ -33,6 +33,7 @@ class TypeGraph;
 class TypeIdentifier : public RecursiveVisitor {
  public:
   static Pass createPass();
+  static bool isAllocator(Type& t);
 
   TypeIdentifier(TypeGraph& typeGraph) : typeGraph_(typeGraph) {
   }

--- a/test/test_type_identifier.cpp
+++ b/test/test_type_identifier.cpp
@@ -77,32 +77,40 @@ TEST(TypeIdentifierTest, Allocator) {
 )");
 }
 
-TEST(TypeIdentifierTest, AllocatorNoParam) {
+TEST(TypeIdentifierTest, AllocatorSize1) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myalloc = Class{Class::Kind::Struct, "MyAlloc", 8};
+  auto myalloc = Class{Class::Kind::Struct, "MyAlloc", 1};
+  myalloc.templateParams.push_back(TemplateParam{&myint});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
 
   auto container = getVector();
   container.templateParams.push_back(TemplateParam{&myint});
   container.templateParams.push_back(TemplateParam{&myalloc});
+  container.templateParams.push_back(TemplateParam{&myint});
 
   test(TypeIdentifier::createPass(), {container}, R"(
 [0] Container: std::vector (size: 24)
       Param
         Primitive: int32_t
       Param
-[1]     Struct: MyAlloc (size: 8)
+[1]     Struct: MyAlloc (size: 1)
+          Param
+            Primitive: int32_t
           Function: allocate
           Function: deallocate
+      Param
+        Primitive: int32_t
 )",
        R"(
 [0] Container: std::vector (size: 24)
       Param
         Primitive: int32_t
       Param
-        DummyAllocator (size: 8)
+        DummyAllocator (size: 0)
           Primitive: int32_t
+      Param
+        Primitive: int32_t
 )");
 }


### PR DESCRIPTION
This is needed for running tests in CI, as the older compilers we have there generate bad DWARF with missing template parameters for allocators.