### PR TITLE
features: clean up old flags

### DIFF
--- a/oi/OID.cpp
+++ b/oi/OID.cpp
@@ -145,18 +145,7 @@ constexpr static OIOpts opts{
         "Each argument gets its own dump file: 'dataseg.<oid-pid>.<arg>.dump'"},
     OIOpt{'j', "generate-jit-debug", no_argument, nullptr,
           "Output debug info for the generated JIT code"},
-    OIOpt{'n', "chase-raw-pointers", no_argument, nullptr,
-          "Generate probe for raw pointers"},
     OIOpt{'a', "log-all-structs", no_argument, nullptr, "Log all structures"},
-    OIOpt{'z', "disable-packed-structs", no_argument, nullptr,
-          "Disable appending packed attributes to the definition of structs"},
-    OIOpt{'w', "disable-padding-hunter", no_argument, nullptr,
-          "Disable Padding Hunter\n"
-          "Padded structs will be written to file called PADDING"},
-    OIOpt{'T', "capture-thrift-isset", no_argument, nullptr,
-          "Capture the isset value for Thrift fields"},
-    OIOpt{'P', "polymorphic-inheritance", no_argument, nullptr,
-          "Follow runtime polymorphic inheritance hierarchies"},
     OIOpt{'m', "mode", required_argument, "[prod]",
           "Allows to specify a mode of operation/group of settings"},
     OIOpt{'f', "enable-feature", required_argument, nullptr,
@@ -620,14 +609,8 @@ int main(int argc, char* argv[]) {
       case 'r':
         oidConfig.removeMappings = true;
         break;
-      case 'n':
-        features[Feature::ChaseRawPointers] = true;
-        break;
       case 'a':
         logAllStructs = true;
-        break;
-      case 'z':
-        features[Feature::PackStructs] = false;
         break;
       case 'B':
         dumpDataSegment = true;
@@ -641,17 +624,8 @@ int main(int argc, char* argv[]) {
       case 't':
         oidConfig.timeout_s = atoi(optarg);
         break;
-      case 'w':
-        features[Feature::GenPaddingStats] = false;
-        break;
       case 'J':
         jsonPath = optarg != nullptr ? optarg : "oid_out.json";
-        break;
-      case 'T':
-        features[Feature::CaptureThriftIsset] = true;
-        break;
-      case 'P':
-        features[Feature::PolymorphicInheritance] = true;
         break;
       case 'h':
       default:

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -201,7 +201,7 @@ definitions = '''
 
     Example:
     ```
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     ```
 
   - `skip`, `oid_skip`, `oil_skip`

--- a/test/integration/anonymous.toml
+++ b/test/integration/anonymous.toml
@@ -84,7 +84,7 @@ definitions = '''
   [cases.regular_struct]
     param_types = ["const Node&"]
     setup = "return Node{1, 2, 3};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize":12,
       "dynamicSize":0,
@@ -104,7 +104,7 @@ definitions = '''
         }
       };
     '''
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 8,
       "dynamicSize": 12,
@@ -141,7 +141,7 @@ definitions = '''
           new Node{1, 2, 3}
         }
       };'''
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
 
   [cases.anon_typedef]
     oil_disable = "oil can't chase raw pointers safely"
@@ -152,7 +152,7 @@ definitions = '''
           .node = new Node{1, 2, 3}
         }
       };'''
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 8,
       "dynamicSize": 12,
@@ -194,7 +194,7 @@ definitions = '''
   [cases.anon_union]
     param_types = ["const AnonUnionContainer&"]
     setup = 'return AnonUnionContainer{ .a = 3 };'
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 24,
       "dynamicSize": 0,
@@ -209,7 +209,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const NestedAnonContainer&"]
     setup = 'return NestedAnonContainer{.m = { .v = {.as = {new Node{1, 2, 3}}}}};'
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 80,
       "dynamicSize": 12,
@@ -279,7 +279,7 @@ definitions = '''
   #     result.ns[3].nodes.resize(22);
   #     return result;
   #   '''
-  #   cli_options = ["--chase-raw-pointers"]
+  #   cli_options = ["-fchase-raw-pointers"]
   #   expect_json = '''[{
   #     "staticSize": 104,
   #     "dynamicSize": 556,

--- a/test/integration/cycles.toml
+++ b/test/integration/cycles.toml
@@ -28,7 +28,7 @@ definitions = '''
       third->next = first;
       return first;
     '''
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''
     [
       {

--- a/test/integration/inheritance_polymorphic.toml
+++ b/test/integration/inheritance_polymorphic.toml
@@ -24,7 +24,7 @@ definitions = '''
 [cases]
   [cases.a_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["A"]
     setup = "return {};"
@@ -39,7 +39,7 @@ definitions = '''
 
   [cases.b_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["B"]
     setup = '''
@@ -58,7 +58,7 @@ definitions = '''
       ]}]'''
   [cases.b_as_b]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const B&"]
     arg_types = ["B"]
     setup = '''
@@ -78,7 +78,7 @@ definitions = '''
 
   [cases.c_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["C"]
     setup = '''
@@ -98,7 +98,7 @@ definitions = '''
       ]}]'''
   [cases.c_as_b]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const B&"]
     arg_types = ["C"]
     setup = '''
@@ -118,28 +118,8 @@ definitions = '''
       ]}]'''
   [cases.c_as_c]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
-    param_types = ["const C&"]
-    arg_types = ["C"]
-    setup = '''
-      C c;
-      c.vec_b = {1,2,3};
-      return c;
-    '''
-    expect_json = '''[{
-      "typeName":"C",
-      "staticSize":48,
-      "dynamicSize":12,
-      "members":[
-        {"staticSize":8, "dynamicSize":0},
-        {"name":"int_a", "staticSize":4, "dynamicSize":0},
-        {"name":"vec_b", "staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4},
-        {"name":"int_c", "staticSize":4, "dynamicSize":0}
-      ]}]'''
-  [cases.feature_flag]
-    oil_skip = "Polymorphic inheritance disabled in OIL"
     cli_options = ["-fpolymorphic-inheritance"]
-    param_types = ["const B&"]
+    param_types = ["const C&"]
     arg_types = ["C"]
     setup = '''
       C c;

--- a/test/integration/inheritance_polymorphic_diamond.toml
+++ b/test/integration/inheritance_polymorphic_diamond.toml
@@ -31,7 +31,7 @@ definitions = '''
 [cases]
   [cases.root_as_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Root&"]
     arg_types = ["Root"]
     setup = "return {};"
@@ -46,7 +46,7 @@ definitions = '''
 
   [cases.middle1_as_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Root&"]
     arg_types = ["Middle1"]
     setup = '''
@@ -65,7 +65,7 @@ definitions = '''
       ]}]'''
   [cases.middle1_as_middle1]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Middle1&"]
     arg_types = ["Middle1"]
     setup = '''
@@ -85,7 +85,7 @@ definitions = '''
 
   [cases.middle2_as_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Root&"]
     arg_types = ["Middle2"]
     setup = '''
@@ -104,7 +104,7 @@ definitions = '''
       ]}]'''
   [cases.middle2_as_middle2]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Middle2&"]
     arg_types = ["Middle2"]
     setup = '''
@@ -124,7 +124,7 @@ definitions = '''
 
   [cases.child_as_middle1_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     # We need to explicitly cast from Child to Middle1 before going to root to
     # resolve the diamond problem
     param_types = ["const Root&"]
@@ -150,7 +150,7 @@ definitions = '''
       ]}]'''
   [cases.child_as_middle2_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     # We need to explicitly cast from Child to Middle2 before going to root to
     # resolve the diamond problem
     param_types = ["const Root&"]
@@ -176,7 +176,7 @@ definitions = '''
       ]}]'''
   [cases.child_as_middle1]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Middle1&"]
     arg_types = ["Child"]
     setup = '''
@@ -200,7 +200,7 @@ definitions = '''
       ]}]'''
   [cases.child_as_middle2]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Middle2&"]
     arg_types = ["Child"]
     setup = '''
@@ -224,7 +224,7 @@ definitions = '''
       ]}]'''
   [cases.child_as_child]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Child&"]
     arg_types = ["Child"]
     setup = '''

--- a/test/integration/inheritance_polymorphic_non_dynamic_base.toml
+++ b/test/integration/inheritance_polymorphic_non_dynamic_base.toml
@@ -22,7 +22,7 @@ definitions = '''
 [cases]
   [cases.a_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["A"]
     setup = "return {};"
@@ -47,7 +47,7 @@ definitions = '''
 
   [cases.b_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["B"]
     setup = '''
@@ -64,7 +64,7 @@ definitions = '''
       ]}]'''
   [cases.b_as_b]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const B&"]
     arg_types = ["B"]
     setup = '''
@@ -101,7 +101,7 @@ definitions = '''
 
   [cases.c_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["C"]
     setup = '''
@@ -118,7 +118,7 @@ definitions = '''
       ]}]'''
   [cases.c_as_b]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const B&"]
     arg_types = ["C"]
     setup = '''
@@ -138,7 +138,7 @@ definitions = '''
       ]}]'''
   [cases.c_as_c]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["--polymorphic-inheritance"]
+    cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const C&"]
     arg_types = ["C"]
     setup = '''

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -18,7 +18,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["int*"]
     setup = "return new int(1);"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "typeName": "int *",
       "staticSize": 8,
@@ -61,7 +61,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["void*"]
     setup = "return new int(1);"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "typeName": "void *",
       "staticSize": 8,
@@ -98,7 +98,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "typeName": "std::vector<int> *",
       "staticSize": 8,
@@ -140,7 +140,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const PrimitivePtrs&"]
     setup = "return PrimitivePtrs{0, new int(0), new int(0)};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":4,
@@ -164,7 +164,7 @@ definitions = '''
   [cases.struct_primitive_ptrs_null]
     param_types = ["const PrimitivePtrs&"]
     setup = "return PrimitivePtrs{0, nullptr, nullptr};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":0,
@@ -179,7 +179,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const VectorPtr&"]
     setup = "return VectorPtr{new std::vector<int>{1,2,3}};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize":8,
       "dynamicSize":36,
@@ -198,7 +198,7 @@ definitions = '''
   [cases.struct_vector_ptr_null]
     param_types = ["const VectorPtr&"]
     setup = "return VectorPtr{nullptr};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize":8,
       "dynamicSize":0,
@@ -211,7 +211,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const std::vector<int*>&"]
     setup = "return {{new int(1), nullptr, new int(3)}};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":32,
@@ -237,22 +237,6 @@ definitions = '''
         {"staticSize":8, "dynamicSize":0, "NOT": {"pointer":0}},
         {"staticSize":8, "dynamicSize":0, "pointer":0},
         {"staticSize":8, "dynamicSize":0, "NOT": {"pointer":0}}
-      ]}]'''
-  [cases.feature_flag]
-    oil_disable = "oil can't chase raw pointers safely"
-    param_types = ["const std::vector<int*>&"]
-    setup = "return {{new int(1), nullptr, new int(3)}};"
-    cli_options = ["-fchase-raw-pointers"]
-    expect_json = '''[{
-      "staticSize":24,
-      "dynamicSize":32,
-      "length":3,
-      "capacity":3,
-      "elementStaticSize":8,
-      "members":[
-        {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}},
-        {"staticSize":8, "dynamicSize":0, "pointer":0},
-        {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}}
       ]}]'''
   [cases.feature_flag_disabled]
     param_types = ["const PrimitivePtrs&"]

--- a/test/integration/pointers_function.toml
+++ b/test/integration/pointers_function.toml
@@ -33,7 +33,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{myFunction}};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 8,
       "dynamicSize": 0,
@@ -77,7 +77,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["std::function<void(int)> &"]
     setup = "return myFunction;"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "typeName": "function<void (int)>",
       "staticSize": 32,

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -23,7 +23,7 @@ definitions = '''
     oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "typeName": "IncompleteType *",
       "staticSize": 8,
@@ -86,7 +86,7 @@ definitions = '''
     oil_disable = "oil can't chase raw pointers safely"
     param_types = ["const IncompleteTypeContainer&"]
     setup = "return IncompleteTypeContainer{};"
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 88,
       "dynamicSize": 0,

--- a/test/integration/std_smart_ptr.toml
+++ b/test/integration/std_smart_ptr.toml
@@ -241,7 +241,7 @@ definitions = '''
     '''
   [cases.weak_ptr_int64_present_chase]
     param_types = ["std::weak_ptr<std::uint64_t>&"]
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     setup = '''
     static std::shared_ptr<std::uint64_t> shd = std::make_shared<std::uint64_t>(0xDEADBEEF);
     std::weak_ptr<std::uint64_t> weak = shd;
@@ -259,7 +259,7 @@ definitions = '''
     '''
   [cases.weak_ptr_int64_expired_chase]
     param_types = ["std::weak_ptr<std::uint64_t>&"]
-    cli_options = ["--chase-raw-pointers"]
+    cli_options = ["-fchase-raw-pointers"]
     setup = '''
     return std::make_shared<std::uint64_t>(0xDEADBEEF);
     '''

--- a/test/integration/thrift_isset.toml
+++ b/test/integration/thrift_isset.toml
@@ -84,7 +84,7 @@ namespace cpp2 {
       ret.c_ref() = 1;
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
@@ -107,7 +107,7 @@ namespace cpp2 {
       ret.j_ref() = 1;
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":44,
       "dynamicSize":0,
@@ -133,7 +133,7 @@ namespace cpp2 {
       ret.c_ref() = 1;
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":20,
       "dynamicSize":0,
@@ -152,7 +152,7 @@ namespace cpp2 {
       ret.b_ref() = 1;
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
@@ -171,7 +171,7 @@ namespace cpp2 {
       ret.f_ref() = 1;
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":28,
       "dynamicSize":0,
@@ -193,7 +193,7 @@ namespace cpp2 {
       ret.e_ref() = 1;
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":32,
       "dynamicSize":0,
@@ -223,26 +223,5 @@ namespace cpp2 {
         {"name":"__fbthrift_field_c", "staticSize":4, "NOT":"isset"},
         {"name":"__fbthrift_field_d", "staticSize":4, "NOT":"isset"},
         {"name":"__fbthrift_field_e", "staticSize":4, "NOT":"isset"},
-        {"name":"__isset", "staticSize":3}
-      ]}]'''
-
-  [cases.feature_flag]
-    param_types = ["const cpp2::MyThriftStructBoxed&"]
-    setup = '''
-      cpp2::MyThriftStructBoxed ret;
-      ret.d_ref() = 1;
-      ret.e_ref() = 1;
-      return ret;
-    '''
-    cli_options = ["-fcapture-thrift-isset"]
-    expect_json = '''[{
-      "staticSize":32,
-      "dynamicSize":0,
-      "members":[
-        {"name":"__fbthrift_field_a", "staticSize":8, "NOT":"isset"},
-        {"name":"__fbthrift_field_b", "staticSize":8, "NOT":"isset"},
-        {"name":"__fbthrift_field_c", "staticSize":4, "isset":false},
-        {"name":"__fbthrift_field_d", "staticSize":4, "isset":true},
-        {"name":"__fbthrift_field_e", "staticSize":4, "isset":true},
         {"name":"__isset", "staticSize":3}
       ]}]'''

--- a/test/integration/thrift_isset_missing.toml
+++ b/test/integration/thrift_isset_missing.toml
@@ -67,7 +67,7 @@ raw_definitions = '''
       ret.__isset.at(2) = true;
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
@@ -87,7 +87,7 @@ raw_definitions = '''
       ret.__isset.at(2) = true;
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
@@ -114,7 +114,7 @@ raw_definitions = '''
 
       return ret;
     '''
-    cli_options = ["--capture-thrift-isset"]
+    cli_options = ["-fcapture-thrift-isset"]
     expect_json = '''[{
       "staticSize":32,
       "dynamicSize":0,

--- a/tools/OITB.cpp
+++ b/tools/OITB.cpp
@@ -39,10 +39,6 @@ constexpr static OIOpts opts{
     OIOpt{'a', "log-all-structs", no_argument, nullptr,
           "Enable TreeBuilder::Config::logAllStructs (=true)\n"
           "Note: this option is already enabled, this is a no-op"},
-    OIOpt{'n', "chase-raw-pointers", no_argument, nullptr,
-          "Enable TreeBuilder::Config::chaseRawPointers (=true)"},
-    OIOpt{'w', "disable-padding-hunter", no_argument, nullptr,
-          "Disable TreeBuilder::Config::genPaddingStats (=false)"},
     OIOpt{'J', "dump-json", optional_argument, "[oid_out.json]",
           "File to dump the results to, as JSON\n"
           "(in addition to the default RocksDB output)"},
@@ -176,12 +172,6 @@ int main(int argc, char* argv[]) {
       case 'a':
         tbConfig.logAllStructs =
             true;  // Weird that we're setting it to true, again...
-        break;
-      case 'n':
-        tbConfig.features[Feature::ChaseRawPointers] = true;
-        break;
-      case 'w':
-        tbConfig.features[Feature::GenPaddingStats] = false;
         break;
       case 'J':
         tbConfig.jsonPath = optarg ? optarg : "oid_out.json";


### PR DESCRIPTION
## Summary

The Features change added a new system of feature flags that don't have a distinct command line argument each. This removes the old flags in favour of the new system.

## Test plan

- `make test`
- CI
