### PR TITLE
Printer: Improvements for displaying large type graphs

### DIFF
--- a/oi/type_graph/PassManager.cpp
+++ b/oi/type_graph/PassManager.cpp
@@ -17,6 +17,7 @@
 
 #include <glog/logging.h>
 
+#include <iostream>
 #include <sstream>
 
 #include "Printer.h"
@@ -40,14 +41,14 @@ void print(const TypeGraph& typeGraph) {
   if (!VLOG_IS_ON(1))
     return;
 
-  // TODO: Long strings will be truncated by glog. Find another way to do this
   std::stringstream out;
-  Printer printer{out};
+  Printer printer{out, typeGraph.size()};
   for (const auto& type : typeGraph.rootTypes()) {
     printer.print(type);
   }
 
-  LOG(INFO) << "\n" << out.str();
+  // Long strings will be truncated by glog, use std::cerr instead
+  std::cerr << "\n" << out.str();
 }
 }  // namespace
 

--- a/oi/type_graph/Printer.cpp
+++ b/oi/type_graph/Printer.cpp
@@ -15,7 +15,14 @@
  */
 #include "Printer.h"
 
+#include <cmath>
+
 namespace type_graph {
+
+Printer::Printer(std::ostream& out, size_t numTypes) : out_(out) {
+  // Enough space for "[XYZ] ", where XYZ is the largest node number:
+  baseIndent_ = static_cast<int>(log10(static_cast<double>(numTypes)) + 1) + 3;
+}
 
 void Printer::print(Type& type) {
   depth_++;
@@ -121,23 +128,25 @@ void Printer::visit(const DummyAllocator& d) {
 }
 
 bool Printer::prefix(const Type* type) {
+  int indent = baseIndent_ + depth_ * 2;
+
   if (type) {
     if (auto it = nodeNums_.find(type); it != nodeNums_.end()) {
       // Node has already been printed - print a reference to it this time
-      out_ << std::string(depth_ * 2, ' ');
-      int node_num = it->second;
-      out_ << "    [" << node_num << "]" << std::endl;
+      out_ << std::string(indent, ' ');
+      int nodeNum = it->second;
+      out_ << "[" << nodeNum << "]" << std::endl;
       return true;
     }
 
-    int node_num = nextNodeNum_++;
-    out_ << "[" << node_num << "] ";  // TODO pad numbers
-    nodeNums_.insert({type, node_num});
-  } else {
-    // Extra padding
-    out_ << "    ";  // TODO make variable size
+    int nodeNum = nextNodeNum_++;
+    std::string nodeId = "[" + std::to_string(nodeNum) + "]";
+    out_ << nodeId;
+    indent -= nodeId.size();
+    nodeNums_.insert({type, nodeNum});
   }
-  out_ << std::string(depth_ * 2, ' ');
+
+  out_ << std::string(indent, ' ');
   return false;
 }
 

--- a/oi/type_graph/Printer.h
+++ b/oi/type_graph/Printer.h
@@ -28,8 +28,8 @@ namespace type_graph {
  */
 class Printer : public ConstVisitor {
  public:
-  Printer(std::ostream& out) : out_(out) {
-  }
+  Printer(std::ostream& out, size_t numTypes);
+
   void print(Type& type);
 
   void visit(const Class& c) override;
@@ -53,6 +53,7 @@ class Printer : public ConstVisitor {
   static std::string align_str(uint64_t align);
 
   std::ostream& out_;
+  int baseIndent_;
   int depth_ = -1;
   int nextNodeNum_ = 0;
   std::unordered_map<const Type*, int> nodeNums_;

--- a/oi/type_graph/TypeGraph.h
+++ b/oi/type_graph/TypeGraph.h
@@ -25,6 +25,10 @@ namespace type_graph {
 
 class TypeGraph {
  public:
+  size_t size() const noexcept {
+    return types_.size();
+  }
+
   // TODO provide iterator instead of direct vector access?
   std::vector<std::reference_wrapper<Type>>& rootTypes() {
     return rootTypes_;

--- a/test/test_add_padding.cpp
+++ b/test/test_add_padding.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "oi/type_graph/AddPadding.h"
-#include "oi/type_graph/Printer.h"
 #include "oi/type_graph/Types.h"
 #include "test/type_graph_utils.h"
 

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -57,7 +57,7 @@ void DrgnParserTest::test(std::string_view function,
   Type* type = drgnParser.parse(drgnRoot->type.type);
 
   std::stringstream out;
-  Printer printer(out);
+  Printer printer{out, typeGraph.size()};
   printer.print(*type);
 
   // TODO standardise expected-actual order

--- a/test/test_remove_ignored.cpp
+++ b/test/test_remove_ignored.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include "oi/type_graph/Printer.h"
 #include "oi/type_graph/RemoveIgnored.h"
 #include "oi/type_graph/Types.h"
 #include "test/type_graph_utils.h"

--- a/test/test_type_identifier.cpp
+++ b/test/test_type_identifier.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include "oi/type_graph/Printer.h"
 #include "oi/type_graph/TypeIdentifier.h"
 #include "oi/type_graph/Types.h"
 #include "test/type_graph_utils.h"

--- a/test/type_graph_utils.cpp
+++ b/test/type_graph_utils.cpp
@@ -19,7 +19,7 @@ void check(const std::vector<ref<Type>>& types,
            std::string_view expected,
            std::string_view comment) {
   std::stringstream out;
-  type_graph::Printer printer(out);
+  type_graph::Printer printer(out, types.size());
 
   for (const auto& type : types) {
     printer.print(type);

--- a/test/type_graph_utils.cpp
+++ b/test/type_graph_utils.cpp
@@ -33,7 +33,9 @@ void test(type_graph::Pass pass,
           std::vector<ref<Type>> rootTypes,
           std::string_view expectedBefore,
           std::string_view expectedAfter) {
-  check(rootTypes, expectedBefore, "before running pass");
+  if (expectedBefore.data()) {
+    check(rootTypes, expectedBefore, "before running pass");
+  }
 
   TypeGraph typeGraph;
   for (const auto& type : rootTypes) {
@@ -42,20 +44,14 @@ void test(type_graph::Pass pass,
 
   pass.run(typeGraph);
 
-  check(rootTypes, expectedAfter, "after running pass");
+  // Must use typeGraph's root types here, as the pass may have modified them
+  check(typeGraph.rootTypes(), expectedAfter, "after running pass");
 }
 
 void test(type_graph::Pass pass,
           std::vector<ref<Type>> rootTypes,
           std::string_view expectedAfter) {
-  TypeGraph typeGraph;
-  for (const auto& type : rootTypes) {
-    typeGraph.addRoot(type);
-  }
-
-  pass.run(typeGraph);
-
-  check(rootTypes, expectedAfter, "after");
+  test(pass, rootTypes, {}, expectedAfter);
 }
 
 Container getVector() {


### PR DESCRIPTION
- Don't truncate output above 30k characters
- Include enough padding at the begining of lines to account for large node IDs

Before:
```
[1070]                       Class: ClassName
                            Param                                                                                                                                                                                                                                                                                                          
                              Enum: ParamName (size: 4)
```

After:
```
[1070]                       Class: ClassName
                               Param                                                                                                                                                                                                                                                                                                       
                                 Enum: ParamName (size: 4)
```