### PR TITLE
NameGen: Handle containers with zero template params

### DIFF
--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -83,6 +83,10 @@ void NameGen::visit(Class& c) {
 }
 
 void NameGen::visit(Container& c) {
+  if (c.templateParams.empty()) {
+    return;
+  }
+
   for (const auto& template_param : c.templateParams) {
     visit(*template_param.type);
   }

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -174,6 +174,15 @@ TEST(NameGenTest, ContainerParamsConst) {
   EXPECT_EQ(mycontainer.name(), "std::vector<const MyConstParam_0, MyParam_1>");
 }
 
+TEST(NameGenTest, ContainerNoParams) {
+  auto mycontainer = getVector();
+
+  NameGen nameGen;
+  nameGen.generateNames({mycontainer});
+
+  EXPECT_EQ(mycontainer.name(), "std::vector");
+}
+
 TEST(NameGenTest, Array) {
   auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
   auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);


### PR DESCRIPTION
Previously we always deleted the last two characters and appended a `>`.

Old:
```
MyContaine>
```

New:
```
MyContainer
```