### PR TITLE
Timing: add generated code jit timing feature

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -105,6 +105,9 @@ void addIncludes(const TypeGraph& typeGraph,
     includes.emplace("functional");
     includes.emplace("oi/types/st.h");
   }
+  if (features[Feature::JitTiming]) {
+    includes.emplace("chrono");
+  }
   for (const Type& t : typeGraph.finalTypes) {
     if (const auto* c = dynamic_cast<const Container*>(&t)) {
       includes.emplace(c->containerInfo_.header);
@@ -684,10 +687,10 @@ void CodeGen::generate(
 
   if (config_.features[Feature::TypedDataSegment]) {
     FuncGen::DefineTopLevelGetSizeRefTyped(
-        code, SymbolService::getTypeName(drgnType));
+        code, SymbolService::getTypeName(drgnType), config_.features);
   } else {
-    FuncGen::DefineTopLevelGetSizeRef(code,
-                                      SymbolService::getTypeName(drgnType));
+    FuncGen::DefineTopLevelGetSizeRef(
+        code, SymbolService::getTypeName(drgnType), config_.features);
   }
 
   if (VLOG_IS_ON(3)) {

--- a/oi/Features.cpp
+++ b/oi/Features.cpp
@@ -42,6 +42,8 @@ std::string_view featureHelp(Feature f) {
       return "Log information from the JIT code for debugging.";
     case Feature::PolymorphicInheritance:
       return "Follow polymorphic inheritance hierarchies in the probed object.";
+    case Feature::JitTiming:
+      return "Instrument the JIT code with timing for performance testing.";
 
     case Feature::UnknownFeature:
       throw std::runtime_error("should not ask for help for UnknownFeature!");

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -30,6 +30,7 @@
   X(TypedDataSegment, "typed-data-segment")     \
   X(GenJitDebug, "gen-jit-debug")               \
   X(JitLogging, "jit-logging")                  \
+  X(JitTiming, "jit-timing")                    \
   X(PolymorphicInheritance, "polymorphic-inheritance")
 
 namespace ObjectIntrospection {

--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "oi/ContainerInfo.h"
+#include "oi/Features.h"
 
 namespace fs = std::filesystem;
 
@@ -39,10 +40,10 @@ class FuncGen {
 
   bool DeclareGetSizeFuncs(std::string& testCode,
                            const ContainerInfoRefSet& containerInfo,
-                           bool chaseRawPointers);
+                           ObjectIntrospection::FeatureSet features);
   bool DefineGetSizeFuncs(std::string& testCode,
                           const ContainerInfoRefSet& containerInfo,
-                          bool chaseRawPointers);
+                          ObjectIntrospection::FeatureSet features);
 
   static void DeclareGetContainer(std::string& testCode);
 
@@ -54,16 +55,22 @@ class FuncGen {
                                           const std::string& type,
                                           const std::string& linkageName);
 
-  static void DefineTopLevelGetSizeRef(std::string& testCode,
-                                       const std::string& rawType);
-  static void DefineTopLevelGetSizeRefTyped(std::string& testCode,
-                                            const std::string& rawType);
+  static void DefineTopLevelGetSizeRef(
+      std::string& testCode,
+      const std::string& rawType,
+      ObjectIntrospection::FeatureSet features);
+  static void DefineTopLevelGetSizeRefTyped(
+      std::string& testCode,
+      const std::string& rawType,
+      ObjectIntrospection::FeatureSet features);
 
   static void DefineTopLevelGetSizeRefRet(std::string& testCode,
                                           const std::string& type);
 
-  static void DefineTopLevelGetSizeSmartPtr(std::string& testCode,
-                                            const std::string& rawType);
+  static void DefineTopLevelGetSizeSmartPtr(
+      std::string& testCode,
+      const std::string& rawType,
+      ObjectIntrospection::FeatureSet features);
 
   static void DefineGetSizeTypedValueFunc(std::string& testCode,
                                           const std::string& ctype);

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -2734,6 +2734,10 @@ bool OIDebugger::decodeTargetData(const DataHeader& dataHeader,
     return false;
   }
 
+  if (generatorConfig.features[Feature::JitTiming]) {
+    LOG(INFO) << "JIT Timing: " << dataHeader.timeTakenNs << "ns";
+  }
+
   /*
    * Currently  we use MAX_INT to indicate two things:
    *  - a single MAX_INT indicates the end of results for  the current object
@@ -2741,6 +2745,7 @@ bool OIDebugger::decodeTargetData(const DataHeader& dataHeader,
    */
   folly::ByteRange range(dataHeader.data, dataHeader.size - sizeof(dataHeader));
 
+  outVec.push_back(0);
   outVec.push_back(0);
   outVec.push_back(0);
   outVec.push_back(0);

--- a/oi/OIDebugger.h
+++ b/oi/OIDebugger.h
@@ -265,6 +265,7 @@ class OIDebugger {
     uintptr_t magicId;
     uintptr_t cookie;
     uintptr_t size;
+    uintptr_t timeTakenNs;
 
     /*
      * Flexible Array Member are not standard in C++, but this is

--- a/oi/TreeBuilder.cpp
+++ b/oi/TreeBuilder.cpp
@@ -227,7 +227,7 @@ void TreeBuilder::build(const std::vector<uint64_t>& data,
   th = &typeHierarchy;
   oidData = &data;
 
-  oidDataIndex = 3;  // HACK: OID's first 3 outputs are dummy 0s
+  oidDataIndex = 4;  // HACK: OID's first 4 outputs are dummy 0s
 
   ObjectIntrospection::Metrics::Tracing _("build_tree");
   VLOG(1) << "Building tree...";


### PR DESCRIPTION
## Summary

Adds a timing call at the beginning and end of the generated code functions and store the time taken in nanoseconds in the data segment. Currently this is output at `LOG(INFO)` level. IMO this belongs in RocksDB and `oid_out.json`, but it requires a bit of a format change so I'll leave it until it's necessary.

This required adding another `uintptr_t` typed element to the data segment prefix, because adding it at the end of the data segment means keeping overhead of setting lengths and such after the call. Probe effect should be minimal as is, but as it's feature gated and off by default I haven't bothered measuring it. I added some names to pieces in these entry functions while I was in there, and also cleaned up a type in the typed data segment entry.

## Test plan
- CI
- `[]: make test: 100% tests passed, 0 tests failed out of 578`
- `["-fjit-timing"]: make test: 100% tests passed, 0 tests failed out of 578`
- `["-ftype-graph"]: make test: 95% tests passed, 31 tests failed out of 578`
- `["-ftype-graph", "-fjit-timing"]: make test: 95% tests passed, 31 tests failed out of 578`
- `["-ftyped-data-segment"]: make test: 87% tests passed, 77 tests failed out of 578`
- `["-ftyped-data-segment", "-fjit-timing"]: make test: 87% tests passed, 77 tests failed out of 578`
(that was hard work)
