### PR TITLE
features: add GenJitDebug

### DIFF
--- a/oi/Features.h
+++ b/oi/Features.h
@@ -27,6 +27,7 @@
   X(CaptureThriftIsset, "capture-thrift-isset") \
   X(TypeGraph, "type-graph")                    \
   X(TypedDataSegment, "typed-data-segment")     \
+  X(GenJitDebug, "gen-jit-debug")               \
   X(PolymorphicInheritance, "polymorphic-inheritance")
 
 namespace ObjectIntrospection {

--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -522,7 +522,7 @@ bool OICompiler::compile(const std::string& code,
   compInv->getCodeGenOpts().OptimizationLevel = 3;
   compInv->getCodeGenOpts().NoUseJumpTables = 1;
 
-  if (config.generateJitDebugInfo) {
+  if (config.features[Feature::GenJitDebug]) {
     compInv->getCodeGenOpts().setDebugInfo(codegenoptions::FullDebugInfo);
   }
 

--- a/oi/OICompiler.h
+++ b/oi/OICompiler.h
@@ -25,6 +25,7 @@
 #include <string_view>
 #include <unordered_map>
 
+#include "oi/Features.h"
 #include "oi/SymbolService.h"
 #include "oi/X86InstDefs.h"
 
@@ -41,8 +42,7 @@ class OICompiler {
  public:
   /* Configuration option for `OICompiler` */
   struct Config {
-    /* Whether to generate DWARF debug info for the JIT code */
-    bool generateJitDebugInfo = false;
+    ObjectIntrospection::FeatureSet features;
 
     std::vector<fs::path> userHeaderPaths{};
     std::vector<fs::path> sysHeaderPaths{};

--- a/oi/OID.cpp
+++ b/oi/OID.cpp
@@ -143,8 +143,6 @@ constexpr static OIOpts opts{
         'B', "dump-data-segment", no_argument, nullptr,
         "Dump the data segment's content, before TreeBuilder processes it\n"
         "Each argument gets its own dump file: 'dataseg.<oid-pid>.<arg>.dump'"},
-    OIOpt{'j', "generate-jit-debug", no_argument, nullptr,
-          "Output debug info for the generated JIT code"},
     OIOpt{'a', "log-all-structs", no_argument, nullptr, "Log all structures"},
     OIOpt{'m', "mode", required_argument, "[prod]",
           "Allows to specify a mode of operation/group of settings"},
@@ -261,7 +259,6 @@ struct Config {
   bool cacheRemoteDownload;
   bool enableJitLogging;
   bool removeMappings;
-  bool generateJitDebug;
   bool compAndExit;
   bool genPaddingStats = true;
   bool attachToProcess = true;
@@ -304,7 +301,6 @@ static ExitStatus::ExitStatus runScript(
   }
   oid->setCustomCodeFile(oidConfig.customCodeFile);
   oid->setEnableJitLogging(oidConfig.enableJitLogging);
-  oid->setGenerateJitDebugInfo(oidConfig.generateJitDebug);
   oid->setHardDisableDrgn(oidConfig.hardDisableDrgn);
 
   VLOG(1) << "OIDebugger constructor took " << std::dec
@@ -563,9 +559,6 @@ int main(int argc, char* argv[]) {
       case 'e':
         oidConfig.compAndExit = true;
         break;
-      case 'j':
-        oidConfig.generateJitDebug = true;
-        break;
       case 'c':
         oidConfig.configFile = std::string(optarg);
 
@@ -692,6 +685,7 @@ int main(int argc, char* argv[]) {
   if (!featureSet) {
     return ExitStatus::UsageError;
   }
+  compilerConfig.features = *featureSet;
   codeGenConfig.features = *featureSet;
   tbConfig.features = *featureSet;
 

--- a/oi/OIDebugger.h
+++ b/oi/OIDebugger.h
@@ -48,9 +48,6 @@ class OIDebugger {
   bool processTargetData();
   bool executeCode(pid_t);
   void setDataSegmentSize(size_t);
-  void setGenerateJitDebugInfo(bool genJitDebugInfo) {
-    compilerConfig.generateJitDebugInfo = genJitDebugInfo;
-  }
   void restoreState(void);
   bool segConfigExists(void) const {
     return segConfig.existingConfig;

--- a/oi/OILibraryImpl.cpp
+++ b/oi/OILibraryImpl.cpp
@@ -80,7 +80,6 @@ bool OILibraryImpl::unmapSegment() {
 void OILibraryImpl::initCompiler() {
   symbols = std::make_shared<SymbolService>(getpid());
 
-  compilerConfig.generateJitDebugInfo = _self->opts.generateJitDebugInfo;
   generatorConfig.useDataSegment = false;
 }
 
@@ -90,12 +89,14 @@ bool OILibraryImpl::processConfigFile() {
       {
           {Feature::ChaseRawPointers, _self->opts.chaseRawPointers},
           {Feature::PackStructs, true},
+          {Feature::GenJitDebug, _self->opts.generateJitDebugInfo},
       },
       compilerConfig, generatorConfig);
   if (!features) {
     return false;
   }
   generatorConfig.features = *features;
+  compilerConfig.features = *features;
   return true;
 }
 


### PR DESCRIPTION
## Summary

Passes through the generate JIT debug info option to OICompiler as part of the feature set rather than as a separate flag. This will ensure it builds a different cache in remote builds, and allows other features to affect the compilation in future.

## Test plan

- `[]: make test: 100% tests passed, 0 tests failed out of 577`
- `["-fgen-jit-debug"]: make test: 100% tests passed, 0 tests failed out of 577`

off:
```
size -A /tmp/oid-integration-sMsGIK/*.o
/tmp/oid-integration-sMsGIK/1748082814871496692.o  :
section              size   addr
.text                 855      0
.bss              1048593      0
.rodata.str1.1         33      0
.rodata.str1.16        17      0
.comment              113      0
.note.GNU-stack         0      0
.eh_frame             144      0
Total             1049755
```

on:
```
$ size -A /tmp/oid-integration-wiSs4N/*.o
/tmp/oid-integration-wiSs4N/1748082814871496692.o  :
section              size   addr
.text                 855      0
.bss              1048593      0
.rodata.str1.1         33      0
.rodata.str1.16        17      0
.debug_loc           1076      0
.debug_abbrev        1292      0
.debug_info         11253      0
.debug_ranges          48      0
.debug_str           7439      0
.debug_pubnames      1157      0
.debug_pubtypes      1656      0
.comment              113      0
.note.GNU-stack         0      0
.eh_frame             144      0
.debug_line          1640      0
Total             1075316
```
