### PR TITLE
TypeGraph: Make original fully qualified names available for Class types

### DIFF
--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -42,7 +42,8 @@ class DrgnParser {
 
  private:
   Type* enumerateType(struct drgn_type* type);
-  Container* enumerateContainer(struct drgn_type* type);
+  Container* enumerateContainer(struct drgn_type* type,
+                                const std::string& fqName);
   Type* enumerateClass(struct drgn_type* type);
   Enum* enumerateEnum(struct drgn_type* type);
   Typedef* enumerateTypedef(struct drgn_type* type);

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -121,8 +121,20 @@ class Class : public Type {
     Union,
   };
 
+  Class(Kind kind,
+        std::string name,
+        std::string fqName,
+        size_t size,
+        int virtuality = 0)
+      : kind_(kind),
+        name_(std::move(name)),
+        fqName_(std::move(fqName)),
+        size_(size),
+        virtuality_(virtuality) {
+  }
+
   Class(Kind kind, const std::string& name, size_t size, int virtuality = 0)
-      : kind_(kind), name_(name), size_(size), virtuality_(virtuality) {
+      : Class(kind, name, name, size, virtuality) {
   }
 
   DECLARE_ACCEPT
@@ -163,6 +175,10 @@ class Class : public Type {
     packed_ = true;
   }
 
+  const std::string& fqName() const {
+    return fqName_;
+  }
+
   bool isDynamic() const;
 
   std::vector<TemplateParam> templateParams;
@@ -175,6 +191,7 @@ class Class : public Type {
  private:
   Kind kind_;
   std::string name_;
+  std::string fqName_;
   size_t size_;
   int virtuality_;
   uint64_t align_ = 0;


### PR DESCRIPTION
The worry about doing this earlier was performance, but on a further reading of the code, both legacy OICodeGen and new DrgnParser have been calling into drgn_type_fully_qualified_name() for every class for a long time already.