### PR TITLE
feature flag jit-logging

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -72,8 +72,9 @@ struct OIArray {
 )";
 }
 
-void defineJitLog(std::string& code) {
-  code += R"(
+void defineJitLog(FeatureSet features, std::string& code) {
+  if (features[Feature::JitLogging]) {
+    code += R"(
 #define JLOG(str)                           \
   do {                                      \
     if (__builtin_expect(logFile, 0)) {     \
@@ -88,6 +89,12 @@ void defineJitLog(std::string& code) {
     }                                   \
   } while (false)
 )";
+  } else {
+    code += R"(
+#define JLOG(str)
+#define JLOGPTR(ptr)
+)";
+  }
 }
 
 void addIncludes(const TypeGraph& typeGraph,
@@ -621,7 +628,7 @@ void CodeGen::generate(
   }
   addIncludes(typeGraph, config_.features, code);
   defineArray(code);
-  defineJitLog(code);  // TODO: feature gate this
+  defineJitLog(config_.features, code);
 
   if (config_.features[Feature::TypedDataSegment]) {
     FuncGen::DefineDataSegmentDataBuffer(code);

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -28,6 +28,7 @@
   X(TypeGraph, "type-graph")                    \
   X(TypedDataSegment, "typed-data-segment")     \
   X(GenJitDebug, "gen-jit-debug")               \
+  X(JitLogging, "jit-logging")                  \
   X(PolymorphicInheritance, "polymorphic-inheritance")
 
 namespace ObjectIntrospection {

--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -3049,21 +3049,30 @@ bool OICodeGen::generateJitCode(std::string& code) {
     code.append(R"(
       #define SAVE_SIZE(val)
       #define SAVE_DATA(val)    StoreData(val, returnArg)
-
-      #define JLOG(str)                           \
-        do {                                      \
-          if (__builtin_expect(logFile, 0)) {     \
-            write(logFile, str, sizeof(str) - 1); \
-          }                                       \
-        } while (false)
-
-      #define JLOGPTR(ptr)                    \
-        do {                                  \
-          if (__builtin_expect(logFile, 0)) { \
-            __jlogptr((uintptr_t)ptr);        \
-          }                                   \
-        } while (false)
     )");
+
+    if (config.features[Feature::JitLogging]) {
+      code.append(R"(
+        #define JLOG(str)                           \
+          do {                                      \
+            if (__builtin_expect(logFile, 0)) {     \
+              write(logFile, str, sizeof(str) - 1); \
+            }                                       \
+          } while (false)
+
+        #define JLOGPTR(ptr)                    \
+          do {                                  \
+            if (__builtin_expect(logFile, 0)) { \
+              __jlogptr((uintptr_t)ptr);        \
+            }                                   \
+          } while (false)
+      )");
+    } else {
+      code.append(R"(
+        #define JLOG(str)
+        #define JLOGPTR(ptr)
+      )");
+    }
   } else {
     code.append(R"(
       #define SAVE_SIZE(val)    AddData(val, returnArg)

--- a/oi/OID.cpp
+++ b/oi/OID.cpp
@@ -112,7 +112,6 @@ constexpr static OIOpts opts{
           "Accepts multiplicative suffix: K, M, G, T, P, E"},
     OIOpt{'d', "debug-level", required_argument, "<level>",
           "Verbose level for logging"},
-    OIOpt{'l', "jit-logging", no_argument, nullptr, "Enable JIT's logs"},
     OIOpt{'r', "remove-mappings", no_argument, nullptr,
           "Remove oid mappings from target process"},
     OIOpt{'s', "script", required_argument, nullptr, "</path/to/script.oid>"},
@@ -257,7 +256,6 @@ struct Config {
   int timeout_s;
   bool cacheRemoteUpload;
   bool cacheRemoteDownload;
-  bool enableJitLogging;
   bool removeMappings;
   bool compAndExit;
   bool genPaddingStats = true;
@@ -300,7 +298,6 @@ static ExitStatus::ExitStatus runScript(
     return ExitStatus::UsageError;
   }
   oid->setCustomCodeFile(oidConfig.customCodeFile);
-  oid->setEnableJitLogging(oidConfig.enableJitLogging);
   oid->setHardDisableDrgn(oidConfig.hardDisableDrgn);
 
   VLOG(1) << "OIDebugger constructor took " << std::dec
@@ -535,9 +532,6 @@ int main(int argc, char* argv[]) {
         // Upstream glog defines `GLOG_INFO` as 0 https://fburl.com/ydjajhz0,
         // but internally it's defined as 1 https://fburl.com/code/9fwams75
         gflags::SetCommandLineOption("minloglevel", "0");
-        break;
-      case 'l':
-        oidConfig.enableJitLogging = true;
         break;
       case 'k':
         oidConfig.customCodeFile = optarg;

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -1826,7 +1826,7 @@ bool OIDebugger::removeTraps(pid_t pid) {
     it = activeTraps.erase(it);
   }
 
-  if (enableJitLogging) {
+  if (generatorConfig.features[Feature::JitLogging]) {
     /* Flush the JIT log, so it's always written on disk at least once */
     if (!remoteSyscall<SysFsync>(segConfig.logFile).has_value()) {
       LOG(ERROR) << "Failed to flush the JIT Log";
@@ -1840,7 +1840,6 @@ bool OIDebugger::removeTraps(pid_t pid) {
                << " (Reason: " << strerror(errno) << ")";
     return false;
   }
-
   return true;
 }
 
@@ -2334,7 +2333,8 @@ bool OIDebugger::compileCode() {
       return false;
     }
 
-    int logFile = enableJitLogging ? segConfig.logFile : 0;
+    int logFile =
+        generatorConfig.features[Feature::JitLogging] ? segConfig.logFile : 0;
     if (!writeTargetMemory(&logFile, (void*)syntheticSymbols["logFile"],
                            sizeof(logFile))) {
       LOG(ERROR) << "Failed to write logFile in probe's cookieValue";

--- a/oi/OIDebugger.h
+++ b/oi/OIDebugger.h
@@ -138,13 +138,8 @@ class OIDebugger {
     customCodeFile = std::move(newCCT);
   }
 
-  void setEnableJitLogging(bool enable) {
-    enableJitLogging = enable;
-  }
-
  private:
   bool debug = false;
-  bool enableJitLogging = false;
   pid_t traceePid{};
   uint64_t objectAddr{};
   oidMode mode{OID_MODE_THREAD};


### PR DESCRIPTION
## Summary
Convert jit-logging to be a feature flag. This removes the `-l` option and adds a `jit-logging` feature flag. This also means that when jit logging is not enabled the JLOG* macros generate nothing so we remove all the extraneous branching.

## Test plan
No new test regressions in the test suite.

I manually ran oid with the current codegen implementation against a test binary (an old version of mttest <sigh>) and the number of instructions generated for the main text segment was 1251 with jit-logging enabled and 885 without (default). Previously this would have been 1251 instructions in both.

I also ran the same oid invocations but with the type-graph implementation (-ftype-graph) and it produced the same results.