### PR TITLE
ci: retry tests once on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,7 @@ jobs:
               --output-on-failure \
               --schedule-random \
               --timeout 60 \
+              --repeat until-pass:2 \
               --output-junit results.xml
       - store_test_results:
           path: build/test/results.xml


### PR DESCRIPTION
## Summary

CI tests are experiencing spurious SIGPIPEs with increasing regularity, particularly with running even more tests under type graph. Turn the `--repeat until-pass` flag back up to 2 to allow one retry per test in lieu of fixing this properly. Relates to #189.

## Test plan

CI
