### PR TITLE
TopoSorter: Fix sorting of container template parameters

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -150,18 +150,12 @@ void genDeclsEnum(const Enum& e, std::string& code) {
   code += ";\n";
 }
 
-void genDeclsTypedef(const Typedef& td, std::string& code) {
-  code += "using " + td.name() + " = " + td.underlyingType()->name() + ";\n";
-}
-
 void genDecls(const TypeGraph& typeGraph, std::string& code) {
   for (const Type& t : typeGraph.finalTypes) {
     if (const auto* c = dynamic_cast<const Class*>(&t)) {
       genDeclsClass(*c, code);
     } else if (const auto* e = dynamic_cast<const Enum*>(&t)) {
       genDeclsEnum(*e, code);
-    } else if (const auto* td = dynamic_cast<const Typedef*>(&t)) {
-      genDeclsTypedef(*td, code);
     }
   }
 }

--- a/oi/type_graph/TopoSorter.h
+++ b/oi/type_graph/TopoSorter.h
@@ -51,6 +51,9 @@ class TopoSorter : public RecursiveVisitor {
   std::unordered_set<Type*> visited_;
   std::vector<std::reference_wrapper<Type>> sortedTypes_;
   std::queue<std::reference_wrapper<Type>> typesToSort_;
+
+  void visitAfter(Type& type);
+  void visitAfter(Type* type);
 };
 
 }  // namespace type_graph

--- a/test/test_topo_sorter.cpp
+++ b/test/test_topo_sorter.cpp
@@ -153,11 +153,41 @@ MyChild
 }
 
 TEST(TopoSorterTest, Containers) {
+  auto myparam1 = Class{Class::Kind::Struct, "MyParam1", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam2", 13};
+  auto mycontainer = getMap();
+  mycontainer.templateParams.push_back((&myparam1));
+  mycontainer.templateParams.push_back((&myparam2));
+
+  test({mycontainer}, R"(
+MyParam1
+MyParam2
+std::map
+)");
+}
+
+TEST(TopoSorterTest, ContainersVector) {
+  // std::vector allows forward declared template parameters
   auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back((&myparam));
 
-  test({mycontainer}, "MyParam\nstd::vector");
+  test({mycontainer}, R"(
+std::vector
+MyParam
+)");
+}
+
+TEST(TopoSorterTest, ContainersList) {
+  // std::list allows forward declared template parameters
+  auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
+  auto mycontainer = getList();
+  mycontainer.templateParams.push_back((&myparam));
+
+  test({mycontainer}, R"(
+std::list
+MyParam
+)");
 }
 
 TEST(TopoSorterTest, Arrays) {

--- a/test/type_graph_utils.cpp
+++ b/test/type_graph_utils.cpp
@@ -59,3 +59,15 @@ Container getVector() {
   info.stubTemplateParams = {1};
   return Container{info, 24};
 }
+
+Container getMap() {
+  static ContainerInfo info{"std::map", STD_MAP_TYPE, "map"};
+  info.stubTemplateParams = {2, 3};
+  return Container{info, 48};
+}
+
+Container getList() {
+  static ContainerInfo info{"std::list", LIST_TYPE, "list"};
+  info.stubTemplateParams = {1};
+  return Container{info, 24};
+}

--- a/test/type_graph_utils.h
+++ b/test/type_graph_utils.h
@@ -24,3 +24,5 @@ void test(type_graph::Pass pass,
           std::string_view expectedAfter);
 
 type_graph::Container getVector();
+type_graph::Container getMap();
+type_graph::Container getList();


### PR DESCRIPTION
For std::vector and std::list, template parameters are not required to be defined before they can be used. Delay sorting them until the end.

Also fix a CodeGen bug where we were defining typedefs in the middle of the forward declarations. They only need to be defined when other types are defined.


References:
https://eel.is/c++draft/vector.overview#4
http://eel.is/c++draft/list.overview#3
https://eel.is/c++draft/forward.list.overview#4