### PR TITLE
static types: place in own header for testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # object-introspection
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.20)
 project(object-introspection)
 
 # Lets find_program() locate SETUID binaries

--- a/include/oi/types/st.h
+++ b/include/oi/types/st.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef OI_TYPES_ST_H
+#define OI_TYPES_ST_H 1
+
+namespace ObjectIntrospection {
+namespace types {
+namespace st {
+
+template <typename DataBuffer>
+class Unit {
+ public:
+  Unit(DataBuffer db) : _buf(db) {
+  }
+
+  size_t offset() {
+    return _buf.offset();
+  }
+
+  template <typename T>
+  T cast() {
+    return T(_buf);
+  }
+
+  template <typename F>
+  Unit<DataBuffer> delegate(F const& cb) {
+    return cb(*this);
+  }
+
+ private:
+  DataBuffer _buf;
+};
+
+template <typename DataBuffer>
+class VarInt {
+ public:
+  VarInt(DataBuffer db) : _buf(db) {
+  }
+
+  Unit<DataBuffer> write(uint64_t val) {
+    while (val >= 128) {
+      _buf.write_byte(0x80 | (val & 0x7f));
+      val >>= 7;
+    }
+    _buf.write_byte(uint8_t(val));
+    return Unit<DataBuffer>(_buf);
+  }
+
+ private:
+  DataBuffer _buf;
+};
+
+template <typename DataBuffer, typename T1, typename T2>
+class Pair {
+ public:
+  Pair(DataBuffer db) : _buf(db) {
+  }
+  template <class U>
+  T2 write(U val) {
+    Unit<DataBuffer> second = T1(_buf).write(val);
+    return second.template cast<T2>();
+  }
+  template <typename F>
+  T2 delegate(F const& cb) {
+    T1 first = T1(_buf);
+    Unit<DataBuffer> second = cb(first);
+    return second.template cast<T2>();
+  }
+
+ private:
+  DataBuffer _buf;
+};
+
+template <typename DataBuffer, typename... Types>
+class Sum {
+ private:
+  template <size_t I, typename... Elements>
+  struct Selector;
+  template <size_t I, typename Head, typename... Tail>
+  struct Selector<I, Head, Tail...> {
+    using type = typename std::conditional<
+        I == 0,
+        Head,
+        typename Selector<I - 1, Tail...>::type>::type;
+  };
+  template <size_t I>
+  struct Selector<I> {
+    using type = int;
+  };
+
+ public:
+  Sum(DataBuffer db) : _buf(db) {
+  }
+  template <size_t I>
+  typename Selector<I, Types...>::type write() {
+    Pair<DataBuffer, VarInt<DataBuffer>, typename Selector<I, Types...>::type>
+        buf(_buf);
+    return buf.write(I);
+  }
+  template <size_t I, typename F>
+  Unit<DataBuffer> delegate(F const& cb) {
+    auto tail = write<I>();
+    return cb(tail);
+  }
+
+ private:
+  DataBuffer _buf;
+};
+
+template <typename DataBuffer, typename T>
+class ListContents {
+ public:
+  ListContents(DataBuffer db) : _buf(db) {
+  }
+
+  template <typename F>
+  ListContents<DataBuffer, T> delegate(F const& cb) {
+    T head = T(_buf);
+    Unit<DataBuffer> tail = cb(head);
+    return tail.template cast<ListContents<DataBuffer, T>>();
+  }
+
+  Unit<DataBuffer> finish() {
+    return {_buf};
+  }
+
+ private:
+  DataBuffer _buf;
+};
+
+template <typename DataBuffer, typename T>
+using List = Pair<DataBuffer, VarInt<DataBuffer>, ListContents<DataBuffer, T>>;
+
+}  // namespace st
+}  // namespace types
+}  // namespace ObjectIntrospection
+
+#endif

--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -69,6 +69,5 @@ class FuncGen {
                                           const std::string& ctype);
 
   static void DefineDataSegmentDataBuffer(std::string& testCode);
-  static void DefineStaticTypes(std::string& testCode);
   static void DefineBasicTypeHandlers(std::string& testCode);
 };

--- a/oi/Headers.h
+++ b/oi/Headers.h
@@ -19,7 +19,8 @@ namespace ObjectIntrospection {
 namespace headers {
 
 // These externs are provided by our build system. See resources/CMakeLists.txt
-extern const std::string_view OITraceCode_cpp;
+extern const std::string_view oi_OITraceCode_cpp;
+extern const std::string_view oi_types_st_h;
 
 }  // namespace headers
 }  // namespace ObjectIntrospection

--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -40,6 +40,7 @@
 #include <boost/range/combine.hpp>
 #include <boost/scope_exit.hpp>
 
+#include "oi/Headers.h"
 #include "oi/Metrics.h"
 
 extern "C" {
@@ -512,6 +513,15 @@ bool OICompiler::compile(const std::string& code,
   for (const auto& path : config.sysHeaderPaths) {
     headerSearchOptions.AddPath(
         path.c_str(), clang::frontend::IncludeDirGroup::System, false, false);
+  }
+
+  if (config.features[Feature::TypedDataSegment]) {
+    compInv->getPreprocessorOpts().addRemappedFile(
+        "/synthetic/headers/oi/types/st.h",
+        MemoryBuffer::getMemBuffer(headers::oi_types_st_h).release());
+    headerSearchOptions.AddPath(
+        "/synthetic/headers", clang::frontend::IncludeDirGroup::IndexHeaderMap,
+        false, false);
   }
 
   compInv->getFrontendOpts().OutputFile = objectPath;

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -2908,7 +2908,7 @@ std::optional<std::string> OIDebugger::generateCode(const irequest& req) {
     return std::nullopt;
   }
 
-  std::string code(headers::OITraceCode_cpp);
+  std::string code(headers::oi_OITraceCode_cpp);
 
   auto codegen = OICodeGen::buildFromConfig(generatorConfig, *symbols);
   if (!codegen) {

--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -135,7 +135,7 @@ fs::path OIGenerator::generateForType(const OICodeGen::Config& generatorConfig,
     return {};
   }
 
-  std::string code(headers::OITraceCode_cpp);
+  std::string code(headers::oi_OITraceCode_cpp);
 
   codegen->setRootType(type);
   codegen->setLinkageName(linkageName);

--- a/oi/OILibraryImpl.cpp
+++ b/oi/OILibraryImpl.cpp
@@ -161,7 +161,7 @@ int OILibraryImpl::compileCode() {
     return Response::OIL_COMPILATION_FAILURE;
   }
 
-  std::string code(headers::OITraceCode_cpp);
+  std::string code(headers::oi_OITraceCode_cpp);
 
   auto codegen = OICodeGen::buildFromConfig(generatorConfig, *symbols);
   if (!codegen) {

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -8,12 +8,25 @@ function(embed_headers output)
   file(APPEND ${output} "namespace headers {\n\n")
 
   set(HEADERS
+    ../include/oi/types/st.h
     ../oi/OITraceCode.cpp
   )
   foreach(header ${HEADERS})
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${header})
+
+    file(REAL_PATH ${header} file_real_path)
+    set(include_path ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+    cmake_path(IS_PREFIX include_path ${file_real_path} NORMALIZE in_include)
+    if (${in_include})
+      file(RELATIVE_PATH file_rel_path ${include_path} ${file_real_path})
+    else()
+      file(RELATIVE_PATH file_rel_path ${CMAKE_CURRENT_SOURCE_DIR}/.. ${file_real_path})
+    endif()
+
+    string(MAKE_C_IDENTIFIER ${file_rel_path} varname)
     get_filename_component(filename ${header} NAME)
-    string(MAKE_C_IDENTIFIER ${filename} varname)
+
     file(READ ${header} contents)
     file(APPEND ${output} "const std::string_view ${varname} = R\"CONTENTS(${contents})CONTENTS\";\n\n")
   endforeach()

--- a/types/README.md
+++ b/types/README.md
@@ -49,7 +49,7 @@ This document describes the format of the container definition files contained i
 A `TypeHandler` class describes both what a type will write into the data segment
 and how to write it. It consists of two major parts:
 - `using type = ...;` - describe what it will write into the data segment.
-- `static StaticTypes::Unit<DB> getSizeType(...)` - a function which takes a
+- `static types::st::Unit<DB> getSizeType(...)` - a function which takes a
   const reference to a container and a `::type` by value and fills in the type.
 
 Example:
@@ -57,9 +57,9 @@ Example:
 template <typename DB, typename T0>
 struct TypeHandler<DB, std::string<T0>> {
   using type =
-      StaticTypes::Pair<DB, StaticTypes::VarInt<DB>, StaticTypes::VarInt<DB>>;
+      types::st::Pair<DB, types::st::VarInt<DB>, types::st::VarInt<DB>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const std::string<T0> & container,
       typename TypeHandler<DB, std::string<T0>>::type returnArg) {
     bool sso = ((uintptr_t)container.data() <

--- a/types/array_type.toml
+++ b/types/array_type.toml
@@ -32,9 +32,9 @@ void getSizeType(const %1%<T,N> &container, size_t& returnArg)
 handler = """
 template<typename DB, typename T0, long unsigned int N>
 struct TypeHandler<DB, %1%<T0, N>> {
-  using type = StaticTypes::List<DB, typename TypeHandler<DB, T0>::type>;
+  using type = types::st::List<DB, typename TypeHandler<DB, T0>::type>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, N> &container,
       typename TypeHandler<DB, %1%<T0,N>>::type returnArg) {
     auto tail = returnArg.write(container.size());

--- a/types/cxx11_list_type.toml
+++ b/types/cxx11_list_type.toml
@@ -36,11 +36,11 @@ void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1>
 struct TypeHandler<DB, %1% <T0, T1>> {
-  using type = StaticTypes::Pair<DB,
-        StaticTypes::VarInt<DB>,
-        StaticTypes::List<DB, typename TypeHandler<DB, T0>::type>>;
+  using type = types::st::Pair<DB,
+        types::st::VarInt<DB>,
+        types::st::List<DB, typename TypeHandler<DB, T0>::type>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1% <T0, T1> & container,
       typename TypeHandler<DB, %1% <T0, T1>>::type returnArg) {
     auto tail = returnArg.write((uintptr_t)&container)

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -40,9 +40,9 @@ handler = """
 template <typename DB, typename T0>
 struct TypeHandler<DB, %1% <T0>> {
   using type =
-      StaticTypes::Pair<DB, StaticTypes::VarInt<DB>, StaticTypes::VarInt<DB>>;
+      types::st::Pair<DB, types::st::VarInt<DB>, types::st::VarInt<DB>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1% <T0> & container,
       typename TypeHandler<DB, %1% <T0>>::type returnArg) {
     bool sso = ((uintptr_t)container.data() <

--- a/types/deque_list_type.toml
+++ b/types/deque_list_type.toml
@@ -36,11 +36,11 @@ void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1>
 struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
-      StaticTypes::List<DB, typename TypeHandler<DB, T0>::type>>;
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::List<DB, typename TypeHandler<DB, T0>::type>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1>& container,
       typename TypeHandler<DB, %1%<T0, T1>>::type returnArg) {
     auto tail = returnArg.write((uintptr_t)&container)

--- a/types/fb_string_type.toml
+++ b/types/fb_string_type.toml
@@ -41,16 +41,16 @@ void getSizeType(const %1%<E, T, A, Storage> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1, typename T2, typename T3>
 struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
-      StaticTypes::Pair<DB,
-        StaticTypes::VarInt<DB>,
-        StaticTypes::Pair<DB,
-          StaticTypes::VarInt<DB>,
-          StaticTypes::VarInt<DB>
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::Pair<DB,
+        types::st::VarInt<DB>,
+        types::st::Pair<DB,
+          types::st::VarInt<DB>,
+          types::st::VarInt<DB>
       >>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1, T2, T3>& container,
       typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
     auto last = returnArg.write((uintptr_t)container.data())

--- a/types/list_type.toml
+++ b/types/list_type.toml
@@ -36,11 +36,11 @@ void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1>
 struct TypeHandler<DB, %1% <T0, T1>> {
-  using type = StaticTypes::Pair<DB,
-        StaticTypes::VarInt<DB>,
-        StaticTypes::List<DB, typename TypeHandler<DB, T0>::type>>;
+  using type = types::st::Pair<DB,
+        types::st::VarInt<DB>,
+        types::st::List<DB, typename TypeHandler<DB, T0>::type>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1% <T0, T1> & container,
       typename TypeHandler<DB, %1% <T0, T1>>::type returnArg) {
     auto tail = returnArg.write((uintptr_t)&container)

--- a/types/multi_map_type.toml
+++ b/types/multi_map_type.toml
@@ -36,12 +36,12 @@ void getSizeType(const %1%<Key,T,Compare,Allocator> &container, size_t& returnAr
 handler = """
 template <typename DB, typename T0, typename T1, typename T2, typename T3>
 struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = StaticTypes::List<DB, StaticTypes::Pair<DB,
+  using type = types::st::List<DB, types::st::Pair<DB,
       typename TypeHandler<DB, T0>::type,
       typename TypeHandler<DB, T1>::type
     >>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1, T2, T3>& container,
       typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
     auto tail = returnArg.write(container.size());

--- a/types/optional_type.toml
+++ b/types/optional_type.toml
@@ -31,12 +31,12 @@ void getSizeType(const %1%<T>& container, size_t& returnArg) {
 handler = """
 template <typename DB, typename T0>
 struct TypeHandler<DB, %1%<T0>> {
-    using type = StaticTypes::Sum<DB,
-      StaticTypes::Unit<DB>,
+    using type = types::st::Sum<DB,
+      types::st::Unit<DB>,
       typename TypeHandler<DB, T0>::type
     >;
 
-    static StaticTypes::Unit<DB> getSizeType(
+    static types::st::Unit<DB> getSizeType(
         const %1%<T0>& container,
         typename TypeHandler<DB, %1%<T0>>::type returnArg) {
       if (container) {

--- a/types/pair_type.toml
+++ b/types/pair_type.toml
@@ -29,11 +29,11 @@ void getSizeType(const %1%<P,Q> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1>
 struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = StaticTypes::Pair<DB,
+  using type = types::st::Pair<DB,
       typename TypeHandler<DB, T0>::type,
       typename TypeHandler<DB, T1>::type>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1> & container,
       typename TypeHandler<DB, %1%<T0, T1>>::type returnArg) {
     return OIInternal::getSizeType<DB>(

--- a/types/priority_queue_container_adapter_type.toml
+++ b/types/priority_queue_container_adapter_type.toml
@@ -36,11 +36,11 @@ void getSizeType(const %1%<T, Container, Cmp> &containerAdapter, size_t& returnA
 handler = """
 template <typename DB, typename T0, typename T1, typename T2>
 struct TypeHandler<DB, %1%<T0, T1, T2>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
       typename TypeHandler<DB, T1>::type>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1, T2>& container,
       typename TypeHandler<DB, %1%<T0, T1, T2>>::type returnArg) {
     auto tail = returnArg.write((uintptr_t)&container);

--- a/types/queue_container_adapter_type.toml
+++ b/types/queue_container_adapter_type.toml
@@ -35,11 +35,11 @@ void getSizeType(const %1%<T, Container> &containerAdapter, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1>
 struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
       typename TypeHandler<DB, T1>::type>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1% <T0, T1> & container,
       typename TypeHandler<DB, %1% <T0, T1>>::type returnArg) {
     auto tail = returnArg.write((uintptr_t)&container);

--- a/types/ref_wrapper_type.toml
+++ b/types/ref_wrapper_type.toml
@@ -33,14 +33,14 @@ void getSizeType(const %1%<T> &ref, size_t& returnArg)
 handler = """
 template <typename DB, typename T0>
 struct TypeHandler<DB, %1%<T0>> {
-    using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
-      StaticTypes::Sum<DB,
-        StaticTypes::Unit<DB>,
+    using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::Sum<DB,
+        types::st::Unit<DB>,
         typename TypeHandler<DB, T0>::type
     >>;
 
-    static StaticTypes::Unit<DB> getSizeType(
+    static types::st::Unit<DB> getSizeType(
         const %1%<T0>& container,
         typename TypeHandler<DB, %1%<T0>>::type returnArg) {
       auto r0 = returnArg.write((uintptr_t)&(container.get()));

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -38,13 +38,13 @@ void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0>
 struct TypeHandler<DB, %1% <T0>> {
-  using type = StaticTypes::Pair<
-      DB, StaticTypes::VarInt<DB>,
-      StaticTypes::Pair<
-          DB, StaticTypes::VarInt<DB>,
-          StaticTypes::List<DB, typename TypeHandler<DB, T0>::type>>>;
+  using type = types::st::Pair<
+      DB, types::st::VarInt<DB>,
+      types::st::Pair<
+          DB, types::st::VarInt<DB>,
+          types::st::List<DB, typename TypeHandler<DB, T0>::type>>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1% <T0> & container,
       typename TypeHandler<DB, %1% <T0>>::type returnArg) {
     auto tail = returnArg.write((uintptr_t)&container)

--- a/types/set_type.toml
+++ b/types/set_type.toml
@@ -39,11 +39,11 @@ void getSizeType(const %1%<Key, Compare, Alloc> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1, typename T2>
 struct TypeHandler<DB, %1% <T0, T1, T2>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
-      StaticTypes::List<DB, typename TypeHandler<DB, T0>::type>>;
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::List<DB, typename TypeHandler<DB, T0>::type>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1, T2>& container,
       typename TypeHandler<DB, %1%<T0, T1, T2>>::type returnArg) {
     constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2>::node_type);

--- a/types/shrd_ptr_type.toml
+++ b/types/shrd_ptr_type.toml
@@ -39,15 +39,15 @@ template <typename DB, typename T0>
 struct TypeHandler<DB, %1%<T0>> {
     using type = typename std::conditional<
       std::is_void<T0>::value,
-      StaticTypes::Unit<DB>,
-      StaticTypes::Pair<DB,
-        StaticTypes::VarInt<DB>,
-        StaticTypes::Sum<DB,
-          StaticTypes::Unit<DB>,
+      types::st::Unit<DB>,
+      types::st::Pair<DB,
+        types::st::VarInt<DB>,
+        types::st::Sum<DB,
+          types::st::Unit<DB>,
           typename TypeHandler<DB, T0>::type
       >>>::type;
 
-    static StaticTypes::Unit<DB> getSizeType(
+    static types::st::Unit<DB> getSizeType(
         const %1%<T0>& container,
         typename TypeHandler<DB, %1%<T0>>::type returnArg) {
       if constexpr (!std::is_void<T0>::value) {

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -34,11 +34,11 @@ void getSizeType(const %1%<T,Compare, Allocator, GrowthPolicy, Container> &conta
 handler = """
 template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
 struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
       typename TypeHandler<DB, T4>::type>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1, T2, T3, T4>& container,
       typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
     auto tail = returnArg.write((uintptr_t)&container);

--- a/types/stack_container_adapter_type.toml
+++ b/types/stack_container_adapter_type.toml
@@ -35,11 +35,11 @@ void getSizeType(const %1%<T, Container> &containerAdapter, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1>
 struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
       typename TypeHandler<DB, T1>::type>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1% <T0, T1> & container,
       typename TypeHandler<DB, %1% <T0, T1>>::type returnArg) {
     auto tail = returnArg.write((uintptr_t)&container);

--- a/types/std_map_type.toml
+++ b/types/std_map_type.toml
@@ -40,14 +40,14 @@ void getSizeType(const %1%<K, T, C, A> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1, typename T2, typename T3>
 struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
-      StaticTypes::List<DB, StaticTypes::Pair<DB,
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::List<DB, types::st::Pair<DB,
         typename TypeHandler<DB, T0>::type,
         typename TypeHandler<DB, T1>::type
     >>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1, T2, T3>& container,
       typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
     constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3>::node_type);

--- a/types/std_unordered_map_type.toml
+++ b/types/std_unordered_map_type.toml
@@ -42,16 +42,16 @@ void getSizeType(const %1%<K, T, H, KE, A> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
 struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = StaticTypes::Pair<DB,
-      StaticTypes::VarInt<DB>,
-      StaticTypes::Pair<DB,
-        StaticTypes::VarInt<DB>,
-        StaticTypes::List<DB, StaticTypes::Pair<DB,
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::Pair<DB,
+        types::st::VarInt<DB>,
+        types::st::List<DB, types::st::Pair<DB,
           typename TypeHandler<DB, T0>::type,
           typename TypeHandler<DB, T1>::type
     >>>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1, T2, T3, T4>& container,
       typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
     constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3, T4>::node_type);

--- a/types/std_variant.toml
+++ b/types/std_variant.toml
@@ -39,9 +39,9 @@ void getSizeType(const %1%<Types...> &container, size_t& returnArg)
 handler = """
 template <typename DB, typename... Types>
 struct TypeHandler<DB, %1%<Types...>> {
-    using type = StaticTypes::Sum<DB, typename TypeHandler<DB, Types>::type..., StaticTypes::Unit<DB>>;
+    using type = types::st::Sum<DB, typename TypeHandler<DB, Types>::type..., types::st::Unit<DB>>;
 
-    static StaticTypes::Unit<DB> getSizeType(
+    static types::st::Unit<DB> getSizeType(
         const %1%<Types...>& container,
         typename TypeHandler<DB, %1%<Types...>>::type returnArg) {
       return getSizeTypeRecursive(container, returnArg);
@@ -49,7 +49,7 @@ struct TypeHandler<DB, %1%<Types...>> {
 
   private:
     template <size_t I = 0>
-    static StaticTypes::Unit<DB> getSizeTypeRecursive(
+    static types::st::Unit<DB> getSizeTypeRecursive(
         const %1%<Types...>& container,
         typename TypeHandler<DB, %1%<Types...>>::type returnArg) {
       if constexpr (I < sizeof...(Types)) {

--- a/types/uniq_ptr_type.toml
+++ b/types/uniq_ptr_type.toml
@@ -40,15 +40,15 @@ template <typename DB, typename T0, typename T1>
 struct TypeHandler<DB, %1%<T0,T1>> {
     using type = typename std::conditional<
       std::is_void<T0>::value,
-      StaticTypes::Unit<DB>,
-      StaticTypes::Pair<DB,
-        StaticTypes::VarInt<DB>,
-        StaticTypes::Sum<DB,
-          StaticTypes::Unit<DB>,
+      types::st::Unit<DB>,
+      types::st::Pair<DB,
+        types::st::VarInt<DB>,
+        types::st::Sum<DB,
+          types::st::Unit<DB>,
           typename TypeHandler<DB, T0>::type
       >>>::type;
 
-    static StaticTypes::Unit<DB> getSizeType(
+    static types::st::Unit<DB> getSizeType(
         const %1%<T0,T1>& container,
         typename TypeHandler<DB, %1%<T0,T1>>::type returnArg) {
       if constexpr (!std::is_void<T0>::value) {

--- a/types/unordered_set_type.toml
+++ b/types/unordered_set_type.toml
@@ -40,13 +40,13 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
 handler = """
 template <typename DB, typename T0, typename T1, typename T2, typename T3>
 struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = StaticTypes::Pair<
-      DB, StaticTypes::VarInt<DB>,
-      StaticTypes::Pair<
-          DB, StaticTypes::VarInt<DB>,
-          StaticTypes::List<DB, typename TypeHandler<DB, T0>::type>>>;
+  using type = types::st::Pair<
+      DB, types::st::VarInt<DB>,
+      types::st::Pair<
+          DB, types::st::VarInt<DB>,
+          types::st::List<DB, typename TypeHandler<DB, T0>::type>>>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0, T1, T2, T3>& container,
       typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
     constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3>::node_type);

--- a/types/weak_ptr_type.toml
+++ b/types/weak_ptr_type.toml
@@ -27,9 +27,9 @@ void getSizeType(const %1%<T> &s_ptr, size_t& returnArg)
 handler = """
 template <typename DB, typename T0>
 struct TypeHandler<DB, %1%<T0>> {
-  using type = StaticTypes::Unit<DB>;
+  using type = types::st::Unit<DB>;
 
-  static StaticTypes::Unit<DB> getSizeType(
+  static types::st::Unit<DB> getSizeType(
       const %1%<T0>& container,
       typename TypeHandler<DB, %1%<T0>>::type returnArg) {
     return returnArg;


### PR DESCRIPTION
## Summary

This moves the static types used by `-ftyped-data-segment` to a header named `oi/types/st.h`, and changes the namespace from `ObjectIntrospection::StaticTypes` to `ObjectIntrospection::types::st` (named as such because `static` is a reserved keyword). This lays the groundwork for adding `types::dy` (Dynamic) next to it, and allows the static types to be used in future unit tests because they are now a valid header.

Messed around with `resources/CMakeLists.txt` a bit to name headers based on their include paths rather than just the filename. Updated the minimum version to 3.20 to get the new `cmake_path` function. Having had a look at https://repology.org/project/cmake/versions it seems like very few distros are stuck on 3.19.

## Test plan

- CI
- `OID_TEST_ARGS=-ftyped-data-segment make test`
