### PR TITLE
codegen: store prev defined containers as a class field

### DIFF
--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -18,6 +18,7 @@
 #include <filesystem>
 #include <functional>
 #include <string>
+#include <unordered_set>
 
 #include "ContainerInfo.h"
 #include "OICodeGen.h"
@@ -56,4 +57,5 @@ class CodeGen {
   OICodeGen::Config config_;
   SymbolService& symbols_;
   std::vector<ContainerInfo> containerInfos_;
+  std::unordered_set<const ContainerInfo*> definedContainers_;
 };


### PR DESCRIPTION
## Summary

Codegen failed (non-deterministically) to produce container implementations if it ran twice, which it does under multi-argument probing. This change adds the `usedContainers_` list as a class field, meaning it has the same lifetime as the vector and thus the pointers should be consistent, and each new codegen gets to add its own containers.

It makes a few of the `namespace {}` functions a little messy, but I did it this way instead of adding them as member functions to prevent exposing the private interface of `Codegen.h` to the type_graph internal `Container`.

## Test plan

- CI
