### PR TITLE
TreeBuilder Type Checking part 2A

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,13 @@ workflows:
           oid_test_args: "-ftyped-data-segment"
           tests_regex: "OidIntegration\\..*"
           exclude_regex: ".*inheritance_polymorphic.*|.*pointers.*|.*arrays_member_int0|.*cycles_.*"
+      - test:
+          name: test-tree-builder-type-checking-gcc
+          requires:
+            - build-gcc
+          oid_test_args: "-ftree-builder-type-checking"
+          tests_regex: "OidIntegration\\..*"
+          exclude_regex: ".*inheritance_polymorphic.*|.*pointers.*|.*arrays_member_int0|.*cycles_.*"
       - coverage:
           name: coverage
           requires:
@@ -40,6 +47,10 @@ workflows:
           name: coverage-typed-data-segment
           requires:
             - test-typed-data-segment-gcc
+      - coverage:
+          name: coverage-tree-builder-type-checking
+          requires:
+            - test-tree-builder-type-checking-gcc
 
       - build:
           name: build-clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,10 @@ target_link_libraries(oicore
 )
 
 ### TreeBuilder
-add_library(treebuilder oi/TreeBuilder.cpp)
+add_library(treebuilder
+  oi/TreeBuilder.cpp
+  oi/exporters/TypeCheckingWalker.cpp
+)
 add_dependencies(treebuilder librocksdb)
 target_link_libraries(treebuilder
   ${rocksdb_BINARY_DIR}/librocksdb.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ add_library(oicore
 add_dependencies(oicore libdrgn)
 target_include_directories(oicore SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
 target_compile_definitions(oicore PRIVATE ${LLVM_DEFINITIONS})
+target_include_directories(oicore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 llvm_map_components_to_libnames(llvm_libs core native mcjit x86disassembler)
 target_link_libraries(oicore

--- a/include/oi/types/dy.h
+++ b/include/oi/types/dy.h
@@ -93,6 +93,6 @@ class List {
   Dynamic element;
 };
 
-}  // namespace ObjectIntrospection
+}  // namespace ObjectIntrospection::types::dy
 
 #endif

--- a/include/oi/types/dy.h
+++ b/include/oi/types/dy.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OI_TYPES_DY_H
+#define OI_TYPES_DY_H 1
+
+/*
+ * Dynamic Types
+ *
+ * These types are a dynamic (runtime) description of the types in
+ * <oi/include/types/st.h>. We use static types to ensure that what is written
+ * in the data segment is a known type. Dynamic types extend this to runtime,
+ * allowing TreeBuilder to check that what it is reading out of the data segment
+ * is what went in. Static types are written with heavy usage of templating so
+ * they can be inlined and compiled to nothing in the JIT output. When
+ * translating these types to OID/OITB they cannot be compiled in, so we
+ * represent the template arguments with member fields instead.
+ *
+ * Each type in this namespace corresponds 1-1 with a type in
+ * ObjectIntrospection::types::st, except Dynamic which references them all. See
+ * the types in st.h for the description of what each type contains.
+ *
+ * All types in this file include a constexpr constructor. This allows a single
+ * extern const variable in the JIT code to include pointer references to other
+ * dynamic elements. To map from a Static Type to a Dynamic Type, we store each
+ * template parameter as a field or std::span in a field.
+ */
+
+#include <functional>
+#include <span>
+#include <variant>
+
+namespace ObjectIntrospection::types::dy {
+
+class Unit;
+class VarInt;
+class Pair;
+class Sum;
+class List;
+
+/*
+ * Dynamic
+ *
+ * The cornerstone of the dynamic types is the Dynamic type, a variant which
+ * holds a pointer of each different type. This is essentially a tagged pointer.
+ */
+using Dynamic = std::variant<std::reference_wrapper<const Unit>,
+                             std::reference_wrapper<const VarInt>,
+                             std::reference_wrapper<const Pair>,
+                             std::reference_wrapper<const Sum>,
+                             std::reference_wrapper<const List> >;
+
+class Unit {};
+class VarInt {};
+
+class Pair {
+ public:
+  constexpr Pair(Dynamic first_, Dynamic second_)
+      : first(first_), second(second_) {
+  }
+
+  Dynamic first;
+  Dynamic second;
+};
+
+class Sum {
+ public:
+  template <size_t N>
+  constexpr Sum(const std::array<Dynamic, N>& variants_) : variants(variants_) {
+  }
+
+  std::span<const Dynamic> variants;
+};
+
+class List {
+ public:
+  constexpr List(Dynamic element_) : element(element_) {
+  }
+
+  Dynamic element;
+};
+
+}  // namespace ObjectIntrospection
+
+#endif

--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -109,7 +109,7 @@ void addIncludes(const TypeGraph& typeGraph,
   if (features[Feature::TreeBuilderTypeChecking]) {
     includes.emplace("oi/types/dy.h");
 
-    code += "#define DEFINE_DESCRIBE 1\n"; // added before all includes
+    code += "#define DEFINE_DESCRIBE 1\n";  // added before all includes
   }
   if (features[Feature::JitTiming]) {
     includes.emplace("chrono");

--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -106,6 +106,11 @@ void addIncludes(const TypeGraph& typeGraph,
     includes.emplace("functional");
     includes.emplace("oi/types/st.h");
   }
+  if (features[Feature::TreeBuilderTypeChecking]) {
+    includes.emplace("oi/types/dy.h");
+
+    code += "#define DEFINE_DESCRIBE 1\n"; // added before all includes
+  }
   if (features[Feature::JitTiming]) {
     includes.emplace("chrono");
   }
@@ -867,12 +872,15 @@ void CodeGen::generate(
   code += "\nusing __ROOT_TYPE__ = " + rootType.name() + ";\n";
   code += "} // namespace\n} // namespace OIInternal\n";
 
+  const auto typeName = SymbolService::getTypeName(drgnType);
   if (config_.features[Feature::TypedDataSegment]) {
-    FuncGen::DefineTopLevelGetSizeRefTyped(
-        code, SymbolService::getTypeName(drgnType), config_.features);
+    FuncGen::DefineTopLevelGetSizeRefTyped(code, typeName, config_.features);
   } else {
-    FuncGen::DefineTopLevelGetSizeRef(
-        code, SymbolService::getTypeName(drgnType), config_.features);
+    FuncGen::DefineTopLevelGetSizeRef(code, typeName, config_.features);
+  }
+
+  if (config_.features[Feature::TreeBuilderTypeChecking]) {
+    FuncGen::DefineOutputType(code, typeName);
   }
 
   if (VLOG_IS_ON(3)) {

--- a/oi/Features.cpp
+++ b/oi/Features.cpp
@@ -36,6 +36,9 @@ std::string_view featureHelp(Feature f) {
       return "Use Type Graph for code generation (CodeGen v2).";
     case Feature::TypedDataSegment:
       return "Use Typed Data Segment in generated code.";
+    case Feature::TreeBuilderTypeChecking:
+      return "Use Typed Data Segment to perform runtime Type Checking in "
+             "TreeBuilder.";
     case Feature::TreeBuilderV2:
       return "Use Tree Builder v2 for reading the data segment";
     case Feature::GenJitDebug:

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -21,17 +21,18 @@
 
 #include "oi/EnumBitset.h"
 
-#define OI_FEATURE_LIST                         \
-  X(ChaseRawPointers, "chase-raw-pointers")     \
-  X(PackStructs, "pack-structs")                \
-  X(GenPaddingStats, "gen-padding-stats")       \
-  X(CaptureThriftIsset, "capture-thrift-isset") \
-  X(TypeGraph, "type-graph")                    \
-  X(TypedDataSegment, "typed-data-segment")     \
-  X(TreeBuilderV2, "tree-builder-v2")           \
-  X(GenJitDebug, "gen-jit-debug")               \
-  X(JitLogging, "jit-logging")                  \
-  X(JitTiming, "jit-timing")                    \
+#define OI_FEATURE_LIST                                    \
+  X(ChaseRawPointers, "chase-raw-pointers")                \
+  X(PackStructs, "pack-structs")                           \
+  X(GenPaddingStats, "gen-padding-stats")                  \
+  X(CaptureThriftIsset, "capture-thrift-isset")            \
+  X(TypeGraph, "type-graph")                               \
+  X(TypedDataSegment, "typed-data-segment")                \
+  X(TreeBuilderTypeChecking, "tree-builder-type-checking") \
+  X(TreeBuilderV2, "tree-builder-v2")                      \
+  X(GenJitDebug, "gen-jit-debug")                          \
+  X(JitLogging, "jit-logging")                             \
+  X(JitTiming, "jit-timing")                               \
   X(PolymorphicInheritance, "polymorphic-inheritance")
 
 namespace ObjectIntrospection {

--- a/oi/FuncGen.cpp
+++ b/oi/FuncGen.cpp
@@ -364,6 +364,26 @@ void FuncGen::DefineTopLevelGetSizeRefTyped(std::string& testCode,
   testCode.append(fmt.str());
 }
 
+/*
+ * DefineOutputType
+ *
+ * Present the dynamic type of an object for OID/OIL/OITB to link against.
+ */
+void FuncGen::DefineOutputType(std::string& code, const std::string& rawType) {
+  std::string func = R"(
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunknown-attributes"
+    /* RawType: %1% */
+    extern const types::dy::Dynamic __attribute__((used, retain)) outputType%2$016x =
+      OIInternal::TypeHandler<DataBuffer::DataSegment, OIInternal::__ROOT_TYPE__>::type::describe;
+    #pragma GCC diagnostic pop
+  )";
+
+  boost::format fmt =
+      boost::format(func) % rawType % std::hash<std::string>{}(rawType);
+  code.append(fmt.str());
+}
+
 void FuncGen::DefineTopLevelGetSizeRefRet(std::string& testCode,
                                           const std::string& rawType) {
   std::string func = R"(

--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -63,6 +63,8 @@ class FuncGen {
       std::string& testCode,
       const std::string& rawType,
       ObjectIntrospection::FeatureSet features);
+  static void DefineOutputType(std::string& testCode,
+                               const std::string& rawType);
 
   static void DefineTopLevelGetSizeRefRet(std::string& testCode,
                                           const std::string& type);

--- a/oi/Headers.h
+++ b/oi/Headers.h
@@ -21,6 +21,7 @@ namespace headers {
 // These externs are provided by our build system. See resources/CMakeLists.txt
 extern const std::string_view oi_OITraceCode_cpp;
 extern const std::string_view oi_types_st_h;
+extern const std::string_view oi_types_dy_h;
 
 }  // namespace headers
 }  // namespace ObjectIntrospection

--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -523,6 +523,14 @@ bool OICompiler::compile(const std::string& code,
         "/synthetic/headers", clang::frontend::IncludeDirGroup::IndexHeaderMap,
         false, false);
   }
+  if (config.features[Feature::TreeBuilderTypeChecking]) {
+    compInv->getPreprocessorOpts().addRemappedFile(
+        "/synthetic/headers/oi/types/dy.h",
+        MemoryBuffer::getMemBuffer(headers::oi_types_dy_h).release());
+    headerSearchOptions.AddPath(
+        "/synthetic/headers", clang::frontend::IncludeDirGroup::IndexHeaderMap,
+        false, false);
+  }
 
   compInv->getFrontendOpts().OutputFile = objectPath;
   compInv->getTargetOpts().Triple =

--- a/oi/OIUtils.cpp
+++ b/oi/OIUtils.cpp
@@ -180,6 +180,18 @@ std::optional<ObjectIntrospection::FeatureSet> processConfigFile(
     }
   }
 
+  if (featuresSet[Feature::TreeBuilderTypeChecking] &&
+      !featuresSet[Feature::TypedDataSegment]) {
+    if (auto search = featureMap.find(Feature::TypedDataSegment);
+        search != featureMap.end() && !search->second) {
+      LOG(ERROR) << "TreeBuilderTypeChecking feature requires TypedDataSegment "
+                    "feature to be enabled but it was explicitly disabled!";
+      return {};
+    }
+    featuresSet[Feature::TypedDataSegment] = true;
+    LOG(WARNING) << "TreeBuilderTypeChecking feature requires TypedDataSegment "
+                    "feature to be enabled, enabling now.";
+  }
   if (featuresSet[Feature::TypedDataSegment] &&
       !featuresSet[Feature::TypeGraph]) {
     if (auto search = featureMap.find(Feature::TypeGraph);

--- a/oi/exporters/TypeCheckingWalker.cpp
+++ b/oi/exporters/TypeCheckingWalker.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "TypeCheckingWalker.h"
+
+#include <type_traits>
+
+template <class>
+inline constexpr bool always_false_v = false;
+
+namespace ObjectIntrospection {
+namespace exporters {
+
+std::optional<TypeCheckingWalker::Element> TypeCheckingWalker::advance() {
+  if (stack.empty()) {
+    return std::nullopt;
+  }
+
+  auto el = stack.top();
+  stack.pop();
+
+  return std::visit(
+      [this](auto&& r) -> std::optional<TypeCheckingWalker::Element> {
+        const auto& ty = r.get();
+        using T = std::decay_t<decltype(ty)>;
+
+        if constexpr (std::is_same_v<T, types::dy::Unit>) {
+          // Unit type - noop.
+          return advance();
+        } else if constexpr (std::is_same_v<T, types::dy::VarInt>) {
+          // VarInt type - pop one element and return as a `VarInt`.
+          return TypeCheckingWalker::VarInt{popFront()};
+        } else if constexpr (std::is_same_v<T, types::dy::Pair>) {
+          // Pair type - read all of left then all of right. Recurse to get the
+          // values.
+          stack.push(ty.second);
+          stack.push(ty.first);
+          return advance();
+        } else if constexpr (std::is_same_v<T, types::dy::List>) {
+          // List type - pop one element as the length of the list, and place
+          // that many of the element type on the stack. Return the value as a
+          // `ListLength`.
+          auto el = popFront();
+          for (size_t i = 0; i < el; i++) {
+            stack.push(ty.element);
+          }
+          return TypeCheckingWalker::ListLength{el};
+        } else if constexpr (std::is_same_v<T, types::dy::Sum>) {
+          // Sum type - pop one element as the index of the tagged union, and
+          // place the matching element type on the stack. Return the value as a
+          // `SumIndex`. Throw if the index is invalid.
+          auto el = popFront();
+          if (el >= ty.variants.size()) {
+            throw std::runtime_error(std::string("invalid sum index: got ") +
+                                     std::to_string(el) + ", max " +
+                                     std::to_string(ty.variants.size()));
+          }
+          stack.push(ty.variants[el]);
+          return TypeCheckingWalker::SumIndex{el};
+        } else {
+          static_assert(always_false_v<T>, "non-exhaustive visitor!");
+        }
+      },
+      el);
+}
+
+}  // namespace exporters
+}  // namespace ObjectIntrospection

--- a/oi/exporters/TypeCheckingWalker.h
+++ b/oi/exporters/TypeCheckingWalker.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+/*
+ * TypeCheckingWalker
+ *
+ * Walks a dynamic data segment type simultaneously with the contents of the
+ * data segment, providing context to each extracted element.
+ *
+ * The dynamic types are implemented as a stack machine. Handling a type
+ * pops the top element, handles it which may involve pushing more types onto
+ * the stack, and returns an element from the data segment if appropriate or
+ * recurses. See the implementation for details.
+ */
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <stack>
+#include <stdexcept>
+#include <variant>
+
+#include "oi/types/dy.h"
+
+namespace ObjectIntrospection {
+namespace exporters {
+
+class TypeCheckingWalker {
+ public:
+  struct VarInt {
+    uint64_t value;
+  };
+  struct SumIndex {
+    uint64_t index;
+  };
+  struct ListLength {
+    uint64_t length;
+  };
+  using Element = std::variant<VarInt, SumIndex, ListLength>;
+
+  TypeCheckingWalker(types::dy::Dynamic rootType,
+                     std::span<const uint64_t> buffer)
+      : stack({rootType}), buf(buffer) {
+  }
+
+  std::optional<Element> advance();
+
+ private:
+  std::stack<types::dy::Dynamic> stack;
+  std::span<const uint64_t> buf;
+
+ private:
+  uint64_t popFront() {
+    if (buf.empty()) {
+      throw std::runtime_error("unexpected end of data segment");
+    }
+    auto el = buf.front();
+    buf = buf.last(buf.size() - 1);
+    return el;
+  }
+};
+
+}  // namespace exporters
+}  // namespace ObjectIntrospection

--- a/oi/exporters/test/TypeCheckingWalkerTest.cpp
+++ b/oi/exporters/test/TypeCheckingWalkerTest.cpp
@@ -1,0 +1,185 @@
+#include <gtest/gtest.h>
+
+#include "oi/exporters/TypeCheckingWalker.h"
+
+using namespace ObjectIntrospection;
+using exporters::TypeCheckingWalker;
+
+TEST(TypeCheckingWalker, TestUnit) {
+  // ASSIGN
+  std::vector<uint64_t> data;
+  types::dy::Unit rootType;
+
+  TypeCheckingWalker walker(rootType, data);
+
+  // ACT
+  auto first = walker.advance();
+
+  // ASSERT
+  ASSERT_FALSE(first.has_value());
+}
+
+TEST(TypeCheckingWalker, TestVarInt) {
+  // ASSIGN
+  uint64_t val = 51566;
+  std::vector<uint64_t> data{val};
+  types::dy::VarInt rootType;
+
+  TypeCheckingWalker walker(rootType, data);
+
+  // ACT
+  auto first = walker.advance();
+
+  // ASSERT
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::VarInt>(*first));
+  EXPECT_EQ(std::get<TypeCheckingWalker::VarInt>(*first).value, val);
+}
+
+TEST(TypeCheckingWalker, TestPair) {
+  // ASSIGN
+  uint64_t firstVal = 37894;
+  uint64_t secondVal = 6667;
+  std::vector<uint64_t> data{firstVal, secondVal};
+
+  types::dy::VarInt left;
+  types::dy::VarInt right;
+  types::dy::Pair rootType{left, right};
+
+  TypeCheckingWalker walker(rootType, data);
+
+  // ACT
+  auto first = walker.advance();
+  auto second = walker.advance();
+  auto third = walker.advance();
+
+  // ASSERT
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::VarInt>(*first));
+  EXPECT_EQ(std::get<TypeCheckingWalker::VarInt>(*first).value, firstVal);
+
+  ASSERT_TRUE(second.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::VarInt>(*second));
+  EXPECT_EQ(std::get<TypeCheckingWalker::VarInt>(*second).value, secondVal);
+
+  ASSERT_FALSE(third.has_value());
+}
+
+TEST(TypeCheckingWalker, TestSumUnit) {
+  // ASSIGN
+  uint64_t sumIndex = 0;
+  std::vector<uint64_t> data{sumIndex};
+
+  types::dy::Unit unit;
+  types::dy::VarInt varint;
+  std::array<types::dy::Dynamic, 2> elements{unit, varint};
+  types::dy::Sum rootType{elements};
+
+  TypeCheckingWalker walker(rootType, data);
+
+  // ACT
+  auto first = walker.advance();
+  auto second = walker.advance();
+
+  // ASSERT
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::SumIndex>(*first));
+  EXPECT_EQ(std::get<TypeCheckingWalker::SumIndex>(*first).index, sumIndex);
+
+  ASSERT_FALSE(second.has_value());
+}
+
+TEST(TypeCheckingWalker, TestSumVarInt) {
+  // ASSIGN
+  uint64_t sumIndex = 1;
+  uint64_t val = 63557;
+  std::vector<uint64_t> data{sumIndex, val};
+
+  types::dy::Unit unit;
+  types::dy::VarInt varint;
+  std::array<types::dy::Dynamic, 2> elements{unit, varint};
+  types::dy::Sum rootType{elements};
+
+  TypeCheckingWalker walker(rootType, data);
+
+  // ACT
+  auto first = walker.advance();
+  auto second = walker.advance();
+  auto third = walker.advance();
+
+  // ASSERT
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::SumIndex>(*first));
+  EXPECT_EQ(std::get<TypeCheckingWalker::SumIndex>(*first).index, sumIndex);
+
+  ASSERT_TRUE(second.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::VarInt>(*second));
+  EXPECT_EQ(std::get<TypeCheckingWalker::VarInt>(*second).value, val);
+
+  ASSERT_FALSE(third.has_value());
+}
+
+TEST(TypeCheckingWalker, TestListEmpty) {
+  // ASSIGN
+  uint64_t listLength = 0;
+  std::vector<uint64_t> data{listLength};
+
+  types::dy::VarInt varint;
+  types::dy::List rootType{varint};
+
+  TypeCheckingWalker walker(rootType, data);
+
+  // ACT
+  auto first = walker.advance();
+  auto second = walker.advance();
+
+  // ASSERT
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::ListLength>(*first));
+  EXPECT_EQ(std::get<TypeCheckingWalker::ListLength>(*first).length,
+            listLength);
+
+  ASSERT_FALSE(second.has_value());
+}
+
+TEST(TypeCheckingWalker, TestListSome) {
+  // ASSIGN
+  std::array<uint64_t, 3> listElements{59942, 44126, 64525};
+  std::vector<uint64_t> data{listElements.size(), listElements[0],
+                             listElements[1], listElements[2]};
+
+  types::dy::VarInt varint;
+  types::dy::List rootType{varint};
+
+  TypeCheckingWalker walker(rootType, data);
+
+  // ACT
+  auto first = walker.advance();
+  auto second = walker.advance();
+  auto third = walker.advance();
+  auto fourth = walker.advance();
+  auto fifth = walker.advance();
+
+  // ASSERT
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::ListLength>(*first));
+  EXPECT_EQ(std::get<TypeCheckingWalker::ListLength>(*first).length,
+            listElements.size());
+
+  ASSERT_TRUE(second.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::VarInt>(*second));
+  EXPECT_EQ(std::get<TypeCheckingWalker::VarInt>(*second).value,
+            listElements[0]);
+
+  ASSERT_TRUE(third.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::VarInt>(*third));
+  EXPECT_EQ(std::get<TypeCheckingWalker::VarInt>(*third).value,
+            listElements[1]);
+
+  ASSERT_TRUE(fourth.has_value());
+  ASSERT_TRUE(std::holds_alternative<TypeCheckingWalker::VarInt>(*fourth));
+  EXPECT_EQ(std::get<TypeCheckingWalker::VarInt>(*fourth).value,
+            listElements[2]);
+
+  ASSERT_FALSE(fifth.has_value());
+}

--- a/oi/types/test/StaticTest.cpp
+++ b/oi/types/test/StaticTest.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#define DEFINE_DESCRIBE 1
+#include "oi/types/dy.h"
+#include "oi/types/st.h"
+
+using namespace ObjectIntrospection;
+
+class DummyDataBuffer {};
+
+TEST(StaticTypes, TestUnitToDynamic) {
+  // ASSIGN
+  using ty = types::st::Unit<DummyDataBuffer>;
+
+  // ACT
+  types::dy::Dynamic dynamicType = ty::describe;
+
+  // ASSERT
+  ASSERT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::Unit>>(
+          dynamicType));
+}
+
+TEST(StaticTypes, TestVarIntToDynamic) {
+  // ASSIGN
+  using ty = types::st::VarInt<DummyDataBuffer>;
+
+  // ACT
+  types::dy::Dynamic dynamicType = ty::describe;
+
+  // ASSERT
+  ASSERT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::VarInt>>(
+          dynamicType));
+}
+
+TEST(StaticTypes, TestPairToDynamic) {
+  // ASSIGN
+  using left = types::st::VarInt<DummyDataBuffer>;
+  using right = types::st::VarInt<DummyDataBuffer>;
+  using ty = types::st::Pair<DummyDataBuffer, left, right>;
+
+  // ACT
+  types::dy::Dynamic dynamicType = ty::describe;
+
+  // ASSERT
+  ASSERT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::Pair>>(
+          dynamicType));
+  const types::dy::Pair& pairType =
+      std::get<std::reference_wrapper<const types::dy::Pair>>(dynamicType);
+
+  EXPECT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::VarInt>>(
+          pairType.first));
+  EXPECT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::VarInt>>(
+          pairType.second));
+}
+
+TEST(StaticTypes, TestSumToDynamic) {
+  // ASSIGN
+  using left = types::st::Unit<DummyDataBuffer>;
+  using right = types::st::VarInt<DummyDataBuffer>;
+  using ty = types::st::Sum<DummyDataBuffer, left, right>;
+
+  // ACT
+  types::dy::Dynamic dynamicType = ty::describe;
+
+  // ASSERT
+  ASSERT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::Sum>>(
+          dynamicType));
+  const types::dy::Sum& sumType =
+      std::get<std::reference_wrapper<const types::dy::Sum>>(dynamicType);
+
+  ASSERT_EQ(sumType.variants.size(), 2);
+  EXPECT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::Unit>>(
+          sumType.variants[0]));
+  EXPECT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::VarInt>>(
+          sumType.variants[1]));
+}
+
+TEST(StaticTypes, TestListToDynamic) {
+  // ASSIGN
+  using el = types::st::VarInt<DummyDataBuffer>;
+  using ty = types::st::List<DummyDataBuffer, el>;
+
+  // ACT
+  types::dy::Dynamic dynamicType = ty::describe;
+
+  // ASSERT
+  ASSERT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::List>>(
+          dynamicType));
+  const types::dy::List& listType =
+      std::get<std::reference_wrapper<const types::dy::List>>(dynamicType);
+
+  EXPECT_TRUE(
+      std::holds_alternative<std::reference_wrapper<const types::dy::VarInt>>(
+          listType.element));
+}

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -8,6 +8,7 @@ function(embed_headers output)
   file(APPEND ${output} "namespace headers {\n\n")
 
   set(HEADERS
+    ../include/oi/types/dy.h
     ../include/oi/types/st.h
     ../oi/OITraceCode.cpp
   )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,6 +95,12 @@ cpp_unittest(
   DEPS oicore
 )
 
+cpp_unittest(
+  NAME types_static_test
+  SRCS ../oi/types/test/StaticTest.cpp
+  DEPS oicore
+)
+
 # Integration tests
 if (WITH_FLAKY_TESTS)
   add_test(
@@ -110,4 +116,3 @@ endif()
 
 include_directories("${PROJECT_SOURCE_DIR}/extern/drgn/build")
 add_subdirectory("integration")
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,12 @@ cpp_unittest(
   DEPS oicore
 )
 
+cpp_unittest(
+  NAME type_checking_walker_test
+  SRCS ../oi/exporters/test/TypeCheckingWalkerTest.cpp
+  DEPS treebuilder
+)
+
 # Integration tests
 if (WITH_FLAKY_TESTS)
   add_test(

--- a/test/integration/arrays.toml
+++ b/test/integration/arrays.toml
@@ -44,7 +44,7 @@ definitions = '''
         "dynamicSize":0
       }]}]'''
   [cases.multidim_legacy] # Test for legacy behaviour. Remove with OICodeGen
-    cli_options = ["-Ftype-graph", "-Ftyped-data-segment"]
+    cli_options = ["-Ftype-graph", "-Ftyped-data-segment", "-Ftree-builder-type-checking"]
     param_types = ["const MultiDim&"]
     setup = "return {};"
     expect_json = '''[{


### PR DESCRIPTION
## Summary

- Adds a system to convert the static types from #157 into a dynamic representation, using constexpr and all computed at compile time.
- Tests that the dynamic representation is accurate for the various static types.
- Adds a `TypeCheckingWalker` which allows you to extract from a data segment with type knowledge. For example, the number of items in a list (N) must be succeeded by N*Elements of the list.
- Tests `TypeCheckingWalker` against each existing dynamic type.

It does not stitch these parts together for use in TreeBuilder yet. That will be in the next PR and will finish off phase 2.

Relates to #95 

## Test plan

- CI
