### PR TITLE
help: improve feature descriptions

### DIFF
--- a/oi/Features.cpp
+++ b/oi/Features.cpp
@@ -16,8 +16,39 @@
 #include "Features.h"
 
 #include <map>
+#include <numeric>
+#include <stdexcept>
 
 namespace ObjectIntrospection {
+namespace {
+
+std::string_view featureHelp(Feature f) {
+  switch (f) {
+    case Feature::ChaseRawPointers:
+      return "Chase raw pointers in the probed object.";
+    case Feature::PackStructs:
+      return "Pack structs.";
+    case Feature::GenPaddingStats:
+      return "Generate statistics on padding of structures.";
+    case Feature::CaptureThriftIsset:
+      return "Capture isset data for Thrift object.";
+    case Feature::TypeGraph:
+      return "Use Type Graph for code generation (CodeGen V2).";
+    case Feature::TypedDataSegment:
+      return "Use Typed Data Segment in generated code.";
+    case Feature::GenJitDebug:
+      return "Generate debug information for the JIT object.";
+    case Feature::JitLogging:
+      return "Log information from the JIT code for debugging.";
+    case Feature::PolymorphicInheritance:
+      return "Follow polymorphic inheritance hierarchies in the probed object.";
+
+    case Feature::UnknownFeature:
+      throw std::runtime_error("should not ask for help for UnknownFeature!");
+  }
+}
+
+}  // namespace
 
 Feature featureFromStr(std::string_view str) {
   static const std::map<std::string_view, Feature> nameMap = {
@@ -42,6 +73,22 @@ const char* featureToStr(Feature f) {
 
     default:
       return "UnknownFeature";
+  }
+}
+
+void featuresHelp(std::ostream& out) {
+  out << "FEATURES SUMMARY" << std::endl;
+
+  size_t longestName = std::accumulate(
+      allFeatures.begin(), allFeatures.end(), 0, [](size_t acc, Feature f) {
+        return std::max(acc, std::string_view(featureToStr(f)).size());
+      });
+
+  for (Feature f : allFeatures) {
+    std::string_view name(featureToStr(f));
+
+    out << "  " << name << std::string(longestName - name.size() + 2, ' ')
+        << featureHelp(f) << std::endl;
   }
 }
 

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <array>
+#include <ostream>
 #include <string_view>
 
 #include "oi/EnumBitset.h"
@@ -42,6 +43,7 @@ enum class Feature {
 
 Feature featureFromStr(std::string_view);
 const char* featureToStr(Feature);
+void featuresHelp(std::ostream& out);
 
 constexpr std::array allFeatures = {
 #define X(name, _) Feature::name,

--- a/oi/OID.cpp
+++ b/oi/OID.cpp
@@ -145,25 +145,18 @@ constexpr static OIOpts opts{
     OIOpt{'a', "log-all-structs", no_argument, nullptr, "Log all structures"},
     OIOpt{'m', "mode", required_argument, "[prod]",
           "Allows to specify a mode of operation/group of settings"},
-    OIOpt{'f', "enable-feature", required_argument, nullptr,
-          "Enable a specific feature: ["
-#define X(name, str) str ","
-          OI_FEATURE_LIST
-#undef X
-          "]"},
-    OIOpt{'F', "disable-feature", required_argument, nullptr,
-          "Disable a specific feature: ["
-#define X(name, str) str ","
-          OI_FEATURE_LIST
-#undef X
-          "]"},
+    OIOpt{'f', "enable-feature", required_argument, "FEATURE",
+          "Enable feature"},
+    OIOpt{'F', "disable-feature", required_argument, "FEATURE",
+          "Disable feature"},
 };
 
 void usage() {
-  std::cout << "usage: oid ...\n";
-  std::cout << opts;
+  std::cerr << "usage: oid ...\n";
+  std::cerr << opts << std::endl;
+  featuresHelp(std::cerr);
 
-  std::cout << "\n\tFor problem reporting, questions and general comments "
+  std::cerr << "\n\tFor problem reporting, questions and general comments "
                "please pop along"
                "\n\tto the Object Introspection Workplace group at "
                "https://fburl.com/oid.\n"

--- a/tools/OITB.cpp
+++ b/tools/OITB.cpp
@@ -42,18 +42,10 @@ constexpr static OIOpts opts{
     OIOpt{'J', "dump-json", optional_argument, "[oid_out.json]",
           "File to dump the results to, as JSON\n"
           "(in addition to the default RocksDB output)"},
-    OIOpt{'f', "enable-feature", required_argument, nullptr,
-          "Enable a specific feature: ["
-#define X(name, str) str ","
-          OI_FEATURE_LIST
-#undef X
-          "]"},
-    OIOpt{'F', "disable-feature", required_argument, nullptr,
-          "Disable a specific feature: ["
-#define X(name, str) str ","
-          OI_FEATURE_LIST
-#undef X
-          "]"},
+    OIOpt{'f', "enable-feature", required_argument, "FEATURE",
+          "Enable feature"},
+    OIOpt{'F', "disable-feature", required_argument, "FEATURE",
+          "Disable feature"},
 };
 
 static void usage(std::ostream& out) {
@@ -65,7 +57,8 @@ static void usage(std::ostream& out) {
 
   out << "\nusage: oitb [opts...] [--] <path-th> <path-pd> "
          "<path-dataseg-dump>\n";
-  out << opts;
+  out << opts << std::endl;
+  featuresHelp(out);
 
   out << std::endl;
 }


### PR DESCRIPTION
## Summary

Features previously had no descriptions and were all crammed onto one line. Improve the help of OID and OITB to make it clearer what each feature does.

This isn't ideal formatting but it's definitely better than what was there before. I might clean this up more at some point.

## Test plan
Before:
```
$ make oid && build/oid --help
usage: oid ...
  -h,--help                      Print this message and exit
  -p,--pid <pid>                 Target process to attach to
  -c,--config-file               </path/to/oid.toml>
  -x,--data-buf-size <bytes>     Size of data segment (default:1MB)
                                 Accepts multiplicative suffix: K, M, G, T, P, E
  -d,--debug-level <level>       Verbose level for logging
  -r,--remove-mappings           Remove oid mappings from target process
  -s,--script                    </path/to/script.oid>
  -S,--script-source             type:symbol:arg
  -t,--timeout <seconds>         How long to probe the target process for
  -k,--custom-code-file          </path/to/code.cpp>
                                 Use your own CPP file instead of CodeGen
  -e,--compile-and-exit          Compile only then exit
  -o,--cache-path <path>         Enable caching using the provided directory
  -u,--cache-remote              Enable upload/download of cache files
                                 Pick from {both,upload,download}
  -i,--debug-path                </path/to/binary>
                                 Run oid on a executable with debug infos instead of a running process
  -J,--dump-json [oid_out.json]  File to dump the results to, as JSON
                                 (in addition to the default RocksDB output)
  -B,--dump-data-segment         Dump the data segment's content, before TreeBuilder processes it
                                 Each argument gets its own dump file: 'dataseg.<oid-pid>.<arg>.dump'
  -a,--log-all-structs           Log all structures
  -m,--mode [prod]               Allows to specify a mode of operation/group of settings
  -f,--enable-feature            Enable a specific feature: [chase-raw-pointers,pack-structs,gen-padding-stats,capture-thrift-isset,type-graph,typed-data-segment,gen-jit-debug,jit-logging,polymorphic-inheritance,]
  -F,--disable-feature           Disable a specific feature: [chase-raw-pointers,pack-structs,gen-padding-stats,capture-thrift-isset,type-graph,typed-data-segment,gen-jit-debug,jit-logging,polymorphic-inheritance,]

        For problem reporting, questions and general comments please pop along
        to the Object Introspection Workplace group at https://fburl.com/oid.
```

After:
```
$ make oid && build/oid --help
usage: oid ...
  -h,--help                      Print this message and exit
  -p,--pid <pid>                 Target process to attach to
  -c,--config-file               </path/to/oid.toml>
  -x,--data-buf-size <bytes>     Size of data segment (default:1MB)
                                 Accepts multiplicative suffix: K, M, G, T, P, E
  -d,--debug-level <level>       Verbose level for logging
  -r,--remove-mappings           Remove oid mappings from target process
  -s,--script                    </path/to/script.oid>
  -S,--script-source             type:symbol:arg
  -t,--timeout <seconds>         How long to probe the target process for
  -k,--custom-code-file          </path/to/code.cpp>
                                 Use your own CPP file instead of CodeGen
  -e,--compile-and-exit          Compile only then exit
  -o,--cache-path <path>         Enable caching using the provided directory
  -u,--cache-remote              Enable upload/download of cache files
                                 Pick from {both,upload,download}
  -i,--debug-path                </path/to/binary>
                                 Run oid on a executable with debug infos instead of a running process
  -J,--dump-json [oid_out.json]  File to dump the results to, as JSON
                                 (in addition to the default RocksDB output)
  -B,--dump-data-segment         Dump the data segment's content, before TreeBuilder processes it
                                 Each argument gets its own dump file: 'dataseg.<oid-pid>.<arg>.dump'
  -a,--log-all-structs           Log all structures
  -m,--mode [prod]               Allows to specify a mode of operation/group of settings
  -f,--enable-feature FEATURE    Enable feature
  -F,--disable-feature FEATURE   Disable feature

FEATURES SUMMARY
  chase-raw-pointers       Chase raw pointers in the probed object.
  pack-structs             Pack structs.
  gen-padding-stats        Generate statistics on padding of structures.
  capture-thrift-isset     Capture isset data for Thrift object.
  type-graph               Use Type Graph for code generation (CodeGen V2).
  typed-data-segment       Use Typed Data Segment in generated code.
  gen-jit-debug            Generate debug information for the JIT object.
  jit-logging              Log information from the JIT code for debugging.
  polymorphic-inheritance  Follow polymorphic inheritance hierarchies in the probed object.

        For problem reporting, questions and general comments please pop along
        to the Object Introspection Workplace group at https://fburl.com/oid.
```
