### PR TITLE
thrift isset: add type handler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ workflows:
             - build-gcc
           oid_test_args: "-ftyped-data-segment"
           tests_regex: "OidIntegration\\..*"
-          exclude_regex: ".*inheritance_polymorphic.*|.*thrift_.*|.*std_vector_del_allocator_a|.*cycles_.*"
+          exclude_regex: ".*inheritance_polymorphic.*|.*std_vector_del_allocator_a|.*cycles_.*"
       - coverage:
           name: coverage
           requires:

--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -72,4 +72,7 @@ class CodeGen {
   void getClassSizeFuncConcrete(std::string_view funcName,
                                 const type_graph::Class& c,
                                 std::string& code) const;
+  void addTypeHandlers(const type_graph::TypeGraph& typeGraph,
+                       std::string& code);
+  void getClassTypeHandler(const type_graph::Class& c, std::string& code);
 };

--- a/types/thrift_isset_type.toml
+++ b/types/thrift_isset_type.toml
@@ -16,3 +16,6 @@ decl = """
 func = """
 // DummyFunc %1%
 """
+handler = """
+// DummyHandler %1%
+"""


### PR DESCRIPTION
## Summary

Adds Thrift Isset support with `-ftyped-data-segment`. This was a little fiddly as a few of the CodeGen functions rely on knowing if they're the last run of the loop, which falls apart when ignoring padding. The final generated code is quite neat though.

## Test plan

- `OID_TEST_ARGS='-ftyped-data-segment' make test: 96% tests passed, 24 tests failed out of 591` (thrift failures gone)
- CI

Generated code example:
```
template <typename DB>
class TypeHandler<DB, MyThriftStructUnpacked_0> {
  using thrift_data = apache::thrift::TStructDataStorage<cpp2::MyThriftStructUnpacked>;
  static int getThriftIsset(const MyThriftStructUnpacked_0& t, size_t i) {
    if (&thrift_data::isset_indexes == nullptr) return -1;

    auto idx = thrift_data::isset_indexes[i];
    if (idx == -1) return -1;

    return t.__isset_3.get(idx);
  }

 public:
  using type = types::st::Pair<DB, types::st::VarInt<DB>, types::st::Pair<DB, typename TypeHandler<DB, decltype(MyThriftStructUnpacked_0::__fbthrift_field_a_0)>::type, types::st::Pair<DB, types::st::VarInt<DB>, types::st::Pair<DB, typename TypeHandler<DB, decltype(MyThriftStructUnpacked_0::__fbthrift_field_b_1)>::type, types::st::Pair<DB, types::st::VarInt<DB>, types::st::Pair<DB, typename TypeHandler<DB, decltype(MyThriftStructUnpacked_0::__fbthrift_field_c_2)>::type, typename TypeHandler<DB, decltype(MyThriftStructUnpacked_0::__isset_3)>::type>>>>>>;
  static types::st::Unit<DB> getSizeType(
      const MyThriftStructUnpacked_0& t,
      typename TypeHandler<DB, MyThriftStructUnpacked_0>::type returnArg) {
    auto ret = returnArg
  .write(getThriftIsset(t, 0))
  .delegate([&t](auto ret) {
    return OIInternal::getSizeType<DB>(t.__fbthrift_field_a_0, ret);
})
  .write(getThriftIsset(t, 1))
  .delegate([&t](auto ret) {
    return OIInternal::getSizeType<DB>(t.__fbthrift_field_b_1, ret);
})
  .write(getThriftIsset(t, 2))
  .delegate([&t](auto ret) {
    return OIInternal::getSizeType<DB>(t.__fbthrift_field_c_2, ret);
});
return OIInternal::getSizeType<DB>(t.__isset_3, ret);
  }
};
```
