### PR TITLE
Unit tests: Remove unnecessary make_unique calls

### DIFF
--- a/test/test_add_padding.cpp
+++ b/test/test_add_padding.cpp
@@ -7,13 +7,13 @@
 using namespace type_graph;
 
 TEST(AddPaddingTest, BetweenMembers) {
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 16);
-  auto myint8 = std::make_unique<Primitive>(Primitive::Kind::Int8);
-  auto myint64 = std::make_unique<Primitive>(Primitive::Kind::Int64);
-  myclass->members.push_back(Member(myint8.get(), "n1", 0));
-  myclass->members.push_back(Member(myint64.get(), "n2", 8));
+  auto myclass = Class{Class::Kind::Class, "MyClass", 16};
+  auto myint8 = Primitive{Primitive::Kind::Int8};
+  auto myint64 = Primitive{Primitive::Kind::Int64};
+  myclass.members.push_back(Member(&myint8, "n1", 0));
+  myclass.members.push_back(Member(&myint64, "n2", 8));
 
-  test(AddPadding::createPass(), {*myclass}, R"(
+  test(AddPadding::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 16)
       Member: n1 (offset: 0)
         Primitive: int8_t
@@ -26,13 +26,13 @@ TEST(AddPaddingTest, BetweenMembers) {
 }
 
 TEST(AddPaddingTest, AtEnd) {
-  auto myclass = std::make_unique<Class>(Class::Kind::Struct, "MyStruct", 16);
-  auto myint8 = std::make_unique<Primitive>(Primitive::Kind::Int8);
-  auto myint64 = std::make_unique<Primitive>(Primitive::Kind::Int64);
-  myclass->members.push_back(Member(myint64.get(), "n1", 0));
-  myclass->members.push_back(Member(myint8.get(), "n2", 8));
+  auto myclass = Class{Class::Kind::Struct, "MyStruct", 16};
+  auto myint8 = Primitive{Primitive::Kind::Int8};
+  auto myint64 = Primitive{Primitive::Kind::Int64};
+  myclass.members.push_back(Member(&myint64, "n1", 0));
+  myclass.members.push_back(Member(&myint8, "n2", 8));
 
-  test(AddPadding::createPass(), {*myclass}, R"(
+  test(AddPadding::createPass(), {myclass}, R"(
 [0] Struct: MyStruct (size: 16)
       Member: n1 (offset: 0)
         Primitive: int64_t
@@ -45,13 +45,13 @@ TEST(AddPaddingTest, AtEnd) {
 }
 
 TEST(AddPaddingTest, UnionNotPadded) {
-  auto myclass = std::make_unique<Class>(Class::Kind::Union, "MyUnion", 8);
-  auto myint8 = std::make_unique<Primitive>(Primitive::Kind::Int8);
-  auto myint64 = std::make_unique<Primitive>(Primitive::Kind::Int64);
-  myclass->members.push_back(Member(myint64.get(), "n1", 0));
-  myclass->members.push_back(Member(myint8.get(), "n2", 0));
+  auto myclass = Class{Class::Kind::Union, "MyUnion", 8};
+  auto myint8 = Primitive{Primitive::Kind::Int8};
+  auto myint64 = Primitive{Primitive::Kind::Int64};
+  myclass.members.push_back(Member(&myint64, "n1", 0));
+  myclass.members.push_back(Member(&myint8, "n2", 0));
 
-  test(AddPadding::createPass(), {*myclass}, R"(
+  test(AddPadding::createPass(), {myclass}, R"(
 [0] Union: MyUnion (size: 8)
       Member: n1 (offset: 0)
         Primitive: int64_t

--- a/test/test_alignment_calc.cpp
+++ b/test/test_alignment_calc.cpp
@@ -1,13 +1,9 @@
 #include <gtest/gtest.h>
 
 #include "oi/type_graph/AlignmentCalc.h"
+#include "test/type_graph_utils.h"
 
 using namespace type_graph;
-
-// TODO put in header:
-void test(Pass pass,
-          std::vector<std::reference_wrapper<Type>> types,
-          std::string_view expected);
 
 TEST(AlignmentCalcTest, PrimitiveMembers) {
   auto myclass = Class{Class::Kind::Class, "MyClass", 16};

--- a/test/test_alignment_calc.cpp
+++ b/test/test_alignment_calc.cpp
@@ -10,13 +10,13 @@ void test(Pass pass,
           std::string_view expected);
 
 TEST(AlignmentCalcTest, PrimitiveMembers) {
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 16);
-  auto myint8 = std::make_unique<Primitive>(Primitive::Kind::Int8);
-  auto myint64 = std::make_unique<Primitive>(Primitive::Kind::Int64);
-  myclass->members.push_back(Member(myint8.get(), "n", 0));
-  myclass->members.push_back(Member(myint64.get(), "n", 8));
+  auto myclass = Class{Class::Kind::Class, "MyClass", 16};
+  auto myint8 = Primitive{Primitive::Kind::Int8};
+  auto myint64 = Primitive{Primitive::Kind::Int64};
+  myclass.members.push_back(Member(&myint8, "n", 0));
+  myclass.members.push_back(Member(&myint64, "n", 8));
 
-  test(AlignmentCalc::createPass(), {*myclass}, R"(
+  test(AlignmentCalc::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 16, align: 8)
       Member: n (offset: 0, align: 1)
         Primitive: int8_t
@@ -26,17 +26,17 @@ TEST(AlignmentCalcTest, PrimitiveMembers) {
 }
 
 TEST(AlignmentCalcTest, StructMembers) {
-  auto mystruct = std::make_unique<Class>(Class::Kind::Struct, "MyStruct", 8);
-  auto myint32 = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  mystruct->members.push_back(Member(myint32.get(), "n1", 0));
-  mystruct->members.push_back(Member(myint32.get(), "n2", 4));
+  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 8};
+  auto myint32 = Primitive{Primitive::Kind::Int32};
+  mystruct.members.push_back(Member(&myint32, "n1", 0));
+  mystruct.members.push_back(Member(&myint32, "n2", 4));
 
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 12);
-  auto myint8 = std::make_unique<Primitive>(Primitive::Kind::Int8);
-  myclass->members.push_back(Member(myint8.get(), "n", 0));
-  myclass->members.push_back(Member(mystruct.get(), "s", 4));
+  auto myclass = Class{Class::Kind::Class, "MyClass", 12};
+  auto myint8 = Primitive{Primitive::Kind::Int8};
+  myclass.members.push_back(Member(&myint8, "n", 0));
+  myclass.members.push_back(Member(&mystruct, "s", 4));
 
-  test(AlignmentCalc::createPass(), {*myclass}, R"(
+  test(AlignmentCalc::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 12, align: 4)
       Member: n (offset: 0, align: 1)
         Primitive: int8_t
@@ -50,21 +50,16 @@ TEST(AlignmentCalcTest, StructMembers) {
 }
 
 TEST(AlignmentCalcTest, StructInContainer) {
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 16);
-  auto myint8 = std::make_unique<Primitive>(Primitive::Kind::Int8);
-  auto myint64 = std::make_unique<Primitive>(Primitive::Kind::Int64);
-  myclass->members.push_back(Member(myint8.get(), "n", 0));
-  myclass->members.push_back(Member(myint64.get(), "n", 8));
+  auto myclass = Class{Class::Kind::Class, "MyClass", 16};
+  auto myint8 = Primitive{Primitive::Kind::Int8};
+  auto myint64 = Primitive{Primitive::Kind::Int64};
+  myclass.members.push_back(Member(&myint8, "n", 0));
+  myclass.members.push_back(Member(&myint64, "n", 8));
 
-  auto mycontainer = std::make_unique<Container>(ContainerInfo{}, 8);
-  mycontainer->templateParams.push_back(myclass.get());
+  auto mycontainer = Container{ContainerInfo{}, 8};
+  mycontainer.templateParams.push_back(&myclass);
 
-  AlignmentCalc calc;
-  calc.calculateAlignments({*mycontainer});
-
-  EXPECT_EQ(myclass->align(), 8);
-
-  test(AlignmentCalc::createPass(), {*mycontainer}, R"(
+  test(AlignmentCalc::createPass(), {mycontainer}, R"(
 [0] Container:  (size: 8)
       Param
 [1]     Class: MyClass (size: 16, align: 8)
@@ -76,13 +71,13 @@ TEST(AlignmentCalcTest, StructInContainer) {
 }
 
 TEST(AlignmentCalcTest, Packed) {
-  auto mystruct = std::make_unique<Class>(Class::Kind::Struct, "MyStruct", 9);
-  auto myint8 = std::make_unique<Primitive>(Primitive::Kind::Int8);
-  auto myint64 = std::make_unique<Primitive>(Primitive::Kind::Int64);
-  mystruct->members.push_back(Member(myint8.get(), "n1", 0));
-  mystruct->members.push_back(Member(myint64.get(), "n2", 1));
+  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 9};
+  auto myint8 = Primitive{Primitive::Kind::Int8};
+  auto myint64 = Primitive{Primitive::Kind::Int64};
+  mystruct.members.push_back(Member(&myint8, "n1", 0));
+  mystruct.members.push_back(Member(&myint64, "n2", 1));
 
-  test(AlignmentCalc::createPass(), {*mystruct}, R"(
+  test(AlignmentCalc::createPass(), {mystruct}, R"(
 [0] Struct: MyStruct (size: 9, align: 8, packed)
       Member: n1 (offset: 0, align: 1)
         Primitive: int8_t

--- a/test/test_flattener.cpp
+++ b/test/test_flattener.cpp
@@ -14,18 +14,18 @@ TEST(FlattenerTest, NoParents) {
   //     MyEnum e;
   //     MyStruct mystruct;
   //   };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto myenum = std::make_unique<Enum>("MyEnum", 4);
-  auto mystruct = std::make_unique<Class>(Class::Kind::Struct, "MyStruct", 4);
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 12);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto myenum = Enum{"MyEnum", 4};
+  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 4};
+  auto myclass = Class{Class::Kind::Class, "MyClass", 12};
 
-  mystruct->members.push_back(Member(myint.get(), "n0", 0));
+  mystruct.members.push_back(Member(&myint, "n0", 0));
 
-  myclass->members.push_back(Member(myint.get(), "n", 0));
-  myclass->members.push_back(Member(myenum.get(), "e", 4));
-  myclass->members.push_back(Member(mystruct.get(), "mystruct", 8));
+  myclass.members.push_back(Member(&myint, "n", 0));
+  myclass.members.push_back(Member(&myenum, "e", 4));
+  myclass.members.push_back(Member(&mystruct, "mystruct", 8));
 
-  test(Flattener::createPass(), {*myclass}, R"(
+  test(Flattener::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 12)
       Member: n (offset: 0)
         Primitive: int32_t
@@ -49,18 +49,18 @@ TEST(FlattenerTest, OnlyParents) {
   //     int b;
   //     int c;
   //   };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 8);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->parents.push_back(Parent(classC.get(), 4));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.parents.push_back(Parent(&classC, 4));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 8)
       Member: b (offset: 0)
         Primitive: int32_t
@@ -81,19 +81,19 @@ TEST(FlattenerTest, ParentsFirst) {
   //     int c;
   //     int a;
   //   };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 12);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->parents.push_back(Parent(classC.get(), 4));
-  classA->members.push_back(Member(myint.get(), "a", 8));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.parents.push_back(Parent(&classC, 4));
+  classA.members.push_back(Member(&myint, "a", 8));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
       Member: b (offset: 0)
         Primitive: int32_t
@@ -116,20 +116,20 @@ TEST(FlattenerTest, MembersFirst) {
   //     int b;
   //     int c;
   //   };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 12);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
 
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  classA->members.push_back(Member(myint.get(), "a", 0));
-  classA->parents.push_back(Parent(classB.get(), 4));
-  classA->parents.push_back(Parent(classC.get(), 8));
+  classA.members.push_back(Member(&myint, "a", 0));
+  classA.parents.push_back(Parent(&classB, 4));
+  classA.parents.push_back(Parent(&classC, 8));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
       Member: a (offset: 0)
         Primitive: int32_t
@@ -153,21 +153,21 @@ TEST(FlattenerTest, MixedMembersAndParents) {
   //     int a2;
   //     int c;
   //   };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 16);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 16};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
 
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->members.push_back(Member(myint.get(), "a1", 4));
-  classA->members.push_back(Member(myint.get(), "a2", 8));
-  classA->parents.push_back(Parent(classC.get(), 12));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.members.push_back(Member(&myint, "a1", 4));
+  classA.members.push_back(Member(&myint, "a2", 8));
+  classA.parents.push_back(Parent(&classC, 12));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 16)
       Member: b (offset: 0)
         Primitive: int32_t
@@ -192,19 +192,19 @@ TEST(FlattenerTest, EmptyParent) {
   //     int a1;
   //     int a2;
   //   };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 12);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 0);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{Class::Kind::Class, "ClassB", 0};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
 
-  classA->members.push_back(Member(myint.get(), "a1", 4));
-  classA->members.push_back(Member(myint.get(), "a2", 8));
-  classA->parents.push_back(Parent(classB.get(), 4));
-  classA->parents.push_back(Parent(classC.get(), 0));
+  classA.members.push_back(Member(&myint, "a1", 4));
+  classA.members.push_back(Member(&myint, "a2", 8));
+  classA.parents.push_back(Parent(&classB, 4));
+  classA.parents.push_back(Parent(&classC, 0));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
       Member: c (offset: 0)
         Primitive: int32_t
@@ -229,24 +229,24 @@ TEST(FlattenerTest, TwoDeep) {
   //     int c;
   //     int a;
   //   };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 16);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 8);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
-  auto classD = std::make_unique<Class>(Class::Kind::Class, "ClassD", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 16};
+  auto classB = Class{Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classD = Class{Class::Kind::Class, "ClassD", 4};
 
-  classD->members.push_back(Member(myint.get(), "d", 0));
+  classD.members.push_back(Member(&myint, "d", 0));
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
 
-  classB->parents.push_back(Parent(classD.get(), 0));
-  classB->members.push_back(Member(myint.get(), "b", 4));
+  classB.parents.push_back(Parent(&classD, 0));
+  classB.members.push_back(Member(&myint, "b", 4));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->parents.push_back(Parent(classC.get(), 8));
-  classA->members.push_back(Member(myint.get(), "a", 12));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.parents.push_back(Parent(&classC, 8));
+  classA.members.push_back(Member(&myint, "a", 12));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 16)
       Member: d (offset: 0)
         Primitive: int32_t
@@ -272,21 +272,21 @@ TEST(FlattenerTest, DiamondInheritance) {
   //     int c1;
   //     int a;
   //   };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 16);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 8);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 16};
+  auto classB = Class{Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
 
-  classB->parents.push_back(Parent(classC.get(), 0));
-  classB->members.push_back(Member(myint.get(), "b", 4));
+  classB.parents.push_back(Parent(&classC, 0));
+  classB.members.push_back(Member(&myint, "b", 4));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->parents.push_back(Parent(classC.get(), 8));
-  classA->members.push_back(Member(myint.get(), "a", 12));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.parents.push_back(Parent(&classC, 8));
+  classA.members.push_back(Member(&myint, "a", 12));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 16)
       Member: c (offset: 0)
         Primitive: int32_t
@@ -308,20 +308,20 @@ TEST(FlattenerTest, Member) {
   // Flattened:
   //   class B { int c; int b; };
   //   Class A { int a; B b; };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 12);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 8);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
 
-  classB->parents.push_back(Parent(classC.get(), 0));
-  classB->members.push_back(Member(myint.get(), "b", 4));
+  classB.parents.push_back(Parent(&classC, 0));
+  classB.members.push_back(Member(&myint, "b", 4));
 
-  classA->members.push_back(Member(myint.get(), "a", 0));
-  classA->members.push_back(Member(classB.get(), "b", 4));
+  classA.members.push_back(Member(&myint, "a", 0));
+  classA.members.push_back(Member(&classB, "b", 4));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
       Member: a (offset: 0)
         Primitive: int32_t
@@ -343,20 +343,20 @@ TEST(FlattenerTest, MemberOfParent) {
   // Flattened:
   //   class C { int c; };
   //   class A { int b; C c; int a; };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 12);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 8);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
 
-  classB->members.push_back(Member(myint.get(), "b", 0));
-  classB->members.push_back(Member(classC.get(), "c", 4));
+  classB.members.push_back(Member(&myint, "b", 0));
+  classB.members.push_back(Member(&classC, "c", 4));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->members.push_back(Member(myint.get(), "a", 8));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.members.push_back(Member(&myint, "a", 8));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
       Member: b (offset: 0)
         Primitive: int32_t
@@ -378,18 +378,18 @@ TEST(FlattenerTest, ContainerParam) {
   // Flattened:
   //   class A { int b; int a; };
   //   std::vector<A, int>
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 8);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
   auto container = getVector();
 
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->members.push_back(Member(myint.get(), "a", 4));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.members.push_back(Member(&myint, "a", 4));
 
-  container.templateParams.push_back(TemplateParam(classA.get()));
-  container.templateParams.push_back(TemplateParam(myint.get()));
+  container.templateParams.push_back(TemplateParam(&classA));
+  container.templateParams.push_back(TemplateParam(&myint));
 
   test(Flattener::createPass(), {container}, R"(
 [0] Container: std::vector (size: 24)
@@ -409,18 +409,18 @@ TEST(FlattenerTest, Array) {
   //   class B { int b; };
   //   class A : B { int a; };
   //   A[5]
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
+  auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 8);
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->members.push_back(Member(myint.get(), "a", 4));
+  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.members.push_back(Member(&myint, "a", 4));
 
-  auto arrayA = std::make_unique<Array>(classA.get(), 5);
+  auto arrayA = Array{&classA, 5};
 
-  test(Flattener::createPass(), {*arrayA}, R"(
+  test(Flattener::createPass(), {arrayA}, R"(
 [0] Array: (length: 5)
 [1]   Class: ClassA (size: 8)
         Member: b (offset: 0)
@@ -435,17 +435,17 @@ TEST(FlattenerTest, Typedef) {
   //   class B { int b; };
   //   class A : B { int a; };
   //   using aliasA = A;
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 8);
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->members.push_back(Member(myint.get(), "a", 4));
+  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.members.push_back(Member(&myint, "a", 4));
 
-  auto aliasA = std::make_unique<Typedef>("aliasA", classA.get());
+  auto aliasA = Typedef{"aliasA", &classA};
 
-  test(Flattener::createPass(), {*aliasA}, R"(
+  test(Flattener::createPass(), {aliasA}, R"(
 [0] Typedef: aliasA
 [1]   Class: ClassA (size: 8)
         Member: b (offset: 0)
@@ -460,17 +460,17 @@ TEST(FlattenerTest, TypedefParent) {
   //   class B { int b; };
   //   using aliasB = B;
   //   class A : aliasB { int a; };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  auto aliasB = std::make_unique<Typedef>("aliasB", classB.get());
+  auto aliasB = Typedef{"aliasB", &classB};
 
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 8);
-  classA->parents.push_back(Parent(aliasB.get(), 0));
-  classA->members.push_back(Member(myint.get(), "a", 4));
+  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  classA.parents.push_back(Parent(&aliasB, 0));
+  classA.members.push_back(Member(&myint, "a", 4));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 8)
       Member: b (offset: 0)
         Primitive: int32_t
@@ -483,21 +483,21 @@ TEST(FlattenerTest, Pointer) {
   // Original:
   //   class B { int b; };
   //   class A : B { int a; };
-  //   class C { A *a; };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
+  //   class C { A a; };
+  auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 8);
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->members.push_back(Member(myint.get(), "a", 4));
+  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.members.push_back(Member(&myint, "a", 4));
 
-  auto ptrA = std::make_unique<Pointer>(classA.get());
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 8);
-  classC->members.push_back(Member(ptrA.get(), "a", 0));
+  auto ptrA = Pointer{&classA};
+  auto classC = Class{Class::Kind::Class, "ClassC", 8};
+  classC.members.push_back(Member(&ptrA, "a", 0));
 
-  test(Flattener::createPass(), {*classC}, R"(
+  test(Flattener::createPass(), {classC}, R"(
 [0] Class: ClassC (size: 8)
       Member: a (offset: 0)
 [1]     Pointer
@@ -511,18 +511,18 @@ TEST(FlattenerTest, Pointer) {
 
 TEST(FlattenerTest, PointerCycle) {
   // Original:
-  //   class B { A* a };
+  //   class B { A a };
   //   class A { B b; };
   //
   // Flattened:
   //   No change
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 69);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 69);
-  auto ptrA = std::make_unique<Pointer>(classA.get());
-  classA->members.push_back(Member(classB.get(), "b", 0));
-  classB->members.push_back(Member(ptrA.get(), "a", 0));
+  auto classA = Class{Class::Kind::Class, "ClassA", 69};
+  auto classB = Class{Class::Kind::Class, "ClassB", 69};
+  auto ptrA = Pointer{&classA};
+  classA.members.push_back(Member(&classB, "b", 0));
+  classB.members.push_back(Member(&ptrA, "a", 0));
 
-  test(Flattener::createPass(), {*classA, *classB}, R"(
+  test(Flattener::createPass(), {classA, classB}, R"(
 [0] Class: ClassA (size: 69)
       Member: b (offset: 0)
 [1]     Class: ClassB (size: 69)
@@ -538,20 +538,20 @@ TEST(FlattenerTest, Alignment) {
   //   class alignas(16) C { int c; };
   //   class B { alignas(8) int b; };
   //   class A : B, C { int a; };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 12);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
-  classC->setAlign(16);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  classC.setAlign(16);
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
-  classB->members.push_back(Member(myint.get(), "b", 0, 8));
+  classC.members.push_back(Member(&myint, "c", 0));
+  classB.members.push_back(Member(&myint, "b", 0, 8));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->parents.push_back(Parent(classC.get(), 4));
-  classA->members.push_back(Member(myint.get(), "a", 8));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.parents.push_back(Parent(&classC, 4));
+  classA.members.push_back(Member(&myint, "a", 8));
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
       Member: b (offset: 0, align: 8)
         Primitive: int32_t
@@ -567,18 +567,18 @@ TEST(FlattenerTest, Functions) {
   //   class C { void funcC(); };
   //   class B : C { void funcB(); };
   //   class A : B { void funcA(); };
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 0);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 0);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 0);
+  auto classA = Class{Class::Kind::Class, "ClassA", 0};
+  auto classB = Class{Class::Kind::Class, "ClassB", 0};
+  auto classC = Class{Class::Kind::Class, "ClassC", 0};
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classB->parents.push_back(Parent(classC.get(), 0));
+  classA.parents.push_back(Parent(&classB, 0));
+  classB.parents.push_back(Parent(&classC, 0));
 
-  classA->functions.push_back(Function{"funcA"});
-  classB->functions.push_back(Function{"funcB"});
-  classC->functions.push_back(Function{"funcC"});
+  classA.functions.push_back(Function{"funcA"});
+  classB.functions.push_back(Function{"funcB"});
+  classC.functions.push_back(Function{"funcC"});
 
-  test(Flattener::createPass(), {*classA}, R"(
+  test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 0)
       Function: funcA
       Function: funcB
@@ -591,21 +591,21 @@ TEST(FlattenerTest, Children) {
   //   class C { int c; };
   //   class B { int b; };
   //   class A : B, C { };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 8);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 4);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
-  classB->members.push_back(Member(myint.get(), "b", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
+  classB.members.push_back(Member(&myint, "b", 0));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->parents.push_back(Parent(classC.get(), 4));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.parents.push_back(Parent(&classC, 4));
 
-  classB->children.push_back(*classA);
-  classC->children.push_back(*classA);
+  classB.children.push_back(classA);
+  classC.children.push_back(classA);
 
-  test(Flattener::createPass(), {*classB}, R"(
+  test(Flattener::createPass(), {classB}, R"(
 [0] Class: ClassB (size: 4)
       Member: b (offset: 0)
         Primitive: int32_t
@@ -624,28 +624,28 @@ TEST(FlattenerTest, ChildrenTwoDeep) {
   //   class C { int c; };
   //   class B : D { int b; };
   //   class A : B, C { int a; };
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 16);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 8);
-  auto classC = std::make_unique<Class>(Class::Kind::Class, "ClassC", 4);
-  auto classD = std::make_unique<Class>(Class::Kind::Class, "ClassD", 4);
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto classA = Class{Class::Kind::Class, "ClassA", 16};
+  auto classB = Class{Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classD = Class{Class::Kind::Class, "ClassD", 4};
 
-  classD->members.push_back(Member(myint.get(), "d", 0));
+  classD.members.push_back(Member(&myint, "d", 0));
 
-  classC->members.push_back(Member(myint.get(), "c", 0));
+  classC.members.push_back(Member(&myint, "c", 0));
 
-  classB->parents.push_back(Parent(classD.get(), 0));
-  classB->members.push_back(Member(myint.get(), "b", 4));
+  classB.parents.push_back(Parent(&classD, 0));
+  classB.members.push_back(Member(&myint, "b", 4));
 
-  classA->parents.push_back(Parent(classB.get(), 0));
-  classA->parents.push_back(Parent(classC.get(), 8));
-  classA->members.push_back(Member(myint.get(), "a", 12));
+  classA.parents.push_back(Parent(&classB, 0));
+  classA.parents.push_back(Parent(&classC, 8));
+  classA.members.push_back(Member(&myint, "a", 12));
 
-  classD->children.push_back(*classB);
-  classB->children.push_back(*classA);
-  classC->children.push_back(*classA);
+  classD.children.push_back(classB);
+  classB.children.push_back(classA);
+  classC.children.push_back(classA);
 
-  test(Flattener::createPass(), {*classD}, R"(
+  test(Flattener::createPass(), {classD}, R"(
 [0] Class: ClassD (size: 4)
       Member: d (offset: 0)
         Primitive: int32_t

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -7,170 +7,168 @@
 using namespace type_graph;
 
 TEST(NameGenTest, ClassParams) {
-  auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myclass = std::make_unique<Class>(Class::Kind::Struct,
-                                         "MyClass<MyParam, MyParam>", 13);
-  myclass->templateParams.push_back(myparam1.get());
-  myclass->templateParams.push_back(myparam2.get());
+  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myclass = Class{Class::Kind::Struct, "MyClass<MyParam, MyParam>", 13};
+  myclass.templateParams.push_back(&myparam1);
+  myclass.templateParams.push_back(&myparam2);
 
   NameGen nameGen;
-  nameGen.generateNames({*myclass});
+  nameGen.generateNames({myclass});
 
-  EXPECT_EQ(myclass->name(), "MyClass_0");
-  EXPECT_EQ(myparam1->name(), "MyParam_1");
-  EXPECT_EQ(myparam2->name(), "MyParam_2");
+  EXPECT_EQ(myclass.name(), "MyClass_0");
+  EXPECT_EQ(myparam1.name(), "MyParam_1");
+  EXPECT_EQ(myparam2.name(), "MyParam_2");
 }
 
 TEST(NameGenTest, ClassContainerParam) {
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
+  auto myint = Primitive{Primitive::Kind::Int32};
   auto myparam = getVector();
-  myparam.templateParams.push_back(myint.get());
+  myparam.templateParams.push_back(&myint);
 
-  auto myclass = std::make_unique<Class>(Class::Kind::Struct, "MyClass", 13);
-  myclass->templateParams.push_back(&myparam);
+  auto myclass = Class{Class::Kind::Struct, "MyClass", 13};
+  myclass.templateParams.push_back(&myparam);
 
   NameGen nameGen;
-  nameGen.generateNames({*myclass});
+  nameGen.generateNames({myclass});
 
-  EXPECT_EQ(myclass->name(), "MyClass_0");
+  EXPECT_EQ(myclass.name(), "MyClass_0");
   EXPECT_EQ(myparam.name(), "std::vector<int32_t>");
 }
 
 TEST(NameGenTest, ClassParents) {
-  auto myparent1 = std::make_unique<Class>(Class::Kind::Struct, "MyParent", 13);
-  auto myparent2 = std::make_unique<Class>(Class::Kind::Struct, "MyParent", 13);
-  auto myclass = std::make_unique<Class>(Class::Kind::Struct, "MyClass", 13);
-  myclass->parents.push_back(Parent{myparent1.get(), 0});
-  myclass->parents.push_back(Parent{myparent2.get(), 0});
+  auto myparent1 = Class{Class::Kind::Struct, "MyParent", 13};
+  auto myparent2 = Class{Class::Kind::Struct, "MyParent", 13};
+  auto myclass = Class{Class::Kind::Struct, "MyClass", 13};
+  myclass.parents.push_back(Parent{&myparent1, 0});
+  myclass.parents.push_back(Parent{&myparent2, 0});
 
   NameGen nameGen;
-  nameGen.generateNames({*myclass});
+  nameGen.generateNames({myclass});
 
-  EXPECT_EQ(myclass->name(), "MyClass_0");
-  EXPECT_EQ(myparent1->name(), "MyParent_1");
-  EXPECT_EQ(myparent2->name(), "MyParent_2");
+  EXPECT_EQ(myclass.name(), "MyClass_0");
+  EXPECT_EQ(myparent1.name(), "MyParent_1");
+  EXPECT_EQ(myparent2.name(), "MyParent_2");
 }
 
 TEST(NameGenTest, ClassMembers) {
-  auto mymember1 = std::make_unique<Class>(Class::Kind::Struct, "MyMember", 13);
-  auto mymember2 = std::make_unique<Class>(Class::Kind::Struct, "MyMember", 13);
-  auto myclass = std::make_unique<Class>(Class::Kind::Struct, "MyClass", 13);
+  auto mymember1 = Class{Class::Kind::Struct, "MyMember", 13};
+  auto mymember2 = Class{Class::Kind::Struct, "MyMember", 13};
+  auto myclass = Class{Class::Kind::Struct, "MyClass", 13};
 
   // A class may end up with members sharing a name after flattening
-  myclass->members.push_back(Member{mymember1.get(), "mem", 0});
-  myclass->members.push_back(Member{mymember2.get(), "mem", 0});
+  myclass.members.push_back(Member{&mymember1, "mem", 0});
+  myclass.members.push_back(Member{&mymember2, "mem", 0});
 
   NameGen nameGen;
-  nameGen.generateNames({*myclass});
+  nameGen.generateNames({myclass});
 
-  EXPECT_EQ(myclass->name(), "MyClass_0");
-  EXPECT_EQ(myclass->members[0].name, "mem_0");
-  EXPECT_EQ(myclass->members[1].name, "mem_1");
-  EXPECT_EQ(mymember1->name(), "MyMember_1");
-  EXPECT_EQ(mymember2->name(), "MyMember_2");
+  EXPECT_EQ(myclass.name(), "MyClass_0");
+  EXPECT_EQ(myclass.members[0].name, "mem_0");
+  EXPECT_EQ(myclass.members[1].name, "mem_1");
+  EXPECT_EQ(mymember1.name(), "MyMember_1");
+  EXPECT_EQ(mymember2.name(), "MyMember_2");
 }
 
 TEST(NameGenTest, ClassChildren) {
-  auto mychild1 = std::make_unique<Class>(Class::Kind::Struct, "MyChild", 13);
-  auto mychild2 = std::make_unique<Class>(Class::Kind::Struct, "MyChild", 13);
-  auto myclass = std::make_unique<Class>(Class::Kind::Struct, "MyClass", 13);
-  myclass->children.push_back(*mychild1);
-  myclass->children.push_back(*mychild2);
+  auto mychild1 = Class{Class::Kind::Struct, "MyChild", 13};
+  auto mychild2 = Class{Class::Kind::Struct, "MyChild", 13};
+  auto myclass = Class{Class::Kind::Struct, "MyClass", 13};
+  myclass.children.push_back(mychild1);
+  myclass.children.push_back(mychild2);
 
   NameGen nameGen;
-  nameGen.generateNames({*myclass});
+  nameGen.generateNames({myclass});
 
-  EXPECT_EQ(myclass->name(), "MyClass_0");
-  EXPECT_EQ(mychild1->name(), "MyChild_1");
-  EXPECT_EQ(mychild2->name(), "MyChild_2");
+  EXPECT_EQ(myclass.name(), "MyClass_0");
+  EXPECT_EQ(mychild1.name(), "MyChild_1");
+  EXPECT_EQ(mychild2.name(), "MyChild_2");
 }
 
 TEST(NameGenTest, ContainerParams) {
-  auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(myparam1.get());
-  mycontainer.templateParams.push_back(myparam2.get());
+  mycontainer.templateParams.push_back(&myparam1);
+  mycontainer.templateParams.push_back(&myparam2);
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer});
 
-  EXPECT_EQ(myparam1->name(), "MyParam_0");
-  EXPECT_EQ(myparam2->name(), "MyParam_1");
+  EXPECT_EQ(myparam1.name(), "MyParam_0");
+  EXPECT_EQ(myparam2.name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
 }
 
 TEST(NameGenTest, ContainerParamsDuplicates) {
-  auto myparam = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(myparam.get());
-  mycontainer.templateParams.push_back(myparam.get());
+  mycontainer.templateParams.push_back(&myparam);
+  mycontainer.templateParams.push_back(&myparam);
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer});
 
-  EXPECT_EQ(myparam->name(), "MyParam_0");
+  EXPECT_EQ(myparam.name(), "MyParam_0");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_0>");
 }
 
 TEST(NameGenTest, ContainerParamsDuplicatesDeep) {
-  auto myparam = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer1 = getVector();
-  mycontainer1.templateParams.push_back(myparam.get());
+  mycontainer1.templateParams.push_back(&myparam);
 
   auto mycontainer2 = getVector();
-  mycontainer2.templateParams.push_back(myparam.get());
+  mycontainer2.templateParams.push_back(&myparam);
   mycontainer2.templateParams.push_back(&mycontainer1);
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer2});
 
-  EXPECT_EQ(myparam->name(), "MyParam_0");
+  EXPECT_EQ(myparam.name(), "MyParam_0");
   EXPECT_EQ(mycontainer1.name(), "std::vector<MyParam_0>");
   EXPECT_EQ(mycontainer2.name(),
             "std::vector<MyParam_0, std::vector<MyParam_0>>");
 }
 
 TEST(NameGenTest, ContainerParamsDuplicatesAcrossContainers) {
-  auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myparam3 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam3 = Class{Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer1 = getVector();
-  mycontainer1.templateParams.push_back(myparam1.get());
-  mycontainer1.templateParams.push_back(myparam2.get());
+  mycontainer1.templateParams.push_back(&myparam1);
+  mycontainer1.templateParams.push_back(&myparam2);
 
   auto mycontainer2 = getVector();
-  mycontainer2.templateParams.push_back(myparam2.get());
-  mycontainer2.templateParams.push_back(myparam3.get());
+  mycontainer2.templateParams.push_back(&myparam2);
+  mycontainer2.templateParams.push_back(&myparam3);
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer1, mycontainer2});
 
-  EXPECT_EQ(myparam1->name(), "MyParam_0");
-  EXPECT_EQ(myparam2->name(), "MyParam_1");
-  EXPECT_EQ(myparam3->name(), "MyParam_2");
+  EXPECT_EQ(myparam1.name(), "MyParam_0");
+  EXPECT_EQ(myparam2.name(), "MyParam_1");
+  EXPECT_EQ(myparam3.name(), "MyParam_2");
   EXPECT_EQ(mycontainer1.name(), "std::vector<MyParam_0, MyParam_1>");
   EXPECT_EQ(mycontainer2.name(), "std::vector<MyParam_1, MyParam_2>");
 }
 
 TEST(NameGenTest, ContainerParamsConst) {
-  auto myparam1 =
-      std::make_unique<Class>(Class::Kind::Struct, "MyConstParam", 13);
-  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam1 = Class{Class::Kind::Struct, "MyConstParam", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(
-      TemplateParam{myparam1.get(), {Qualifier::Const}});
-  mycontainer.templateParams.push_back(TemplateParam{myparam2.get()});
+      TemplateParam{&myparam1, {Qualifier::Const}});
+  mycontainer.templateParams.push_back(TemplateParam{&myparam2});
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer});
 
-  EXPECT_EQ(myparam1->name(), "MyConstParam_0");
-  EXPECT_EQ(myparam2->name(), "MyParam_1");
+  EXPECT_EQ(myparam1.name(), "MyConstParam_0");
+  EXPECT_EQ(myparam2.name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<const MyConstParam_0, MyParam_1>");
 }
 
@@ -200,125 +198,124 @@ TEST(NameGenTest, ContainerParamsValue) {
 }
 
 TEST(NameGenTest, Array) {
-  auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(myparam1.get());
-  mycontainer.templateParams.push_back(myparam2.get());
+  mycontainer.templateParams.push_back(&myparam1);
+  mycontainer.templateParams.push_back(&myparam2);
 
-  auto myarray = std::make_unique<Array>(&mycontainer, 5);
+  auto myarray = Array{&mycontainer, 5};
 
   NameGen nameGen;
-  nameGen.generateNames({*myarray});
+  nameGen.generateNames({myarray});
 
-  EXPECT_EQ(myparam1->name(), "MyParam_0");
-  EXPECT_EQ(myparam2->name(), "MyParam_1");
+  EXPECT_EQ(myparam1.name(), "MyParam_0");
+  EXPECT_EQ(myparam2.name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
-  EXPECT_EQ(myarray->name(), "OIArray<std::vector<MyParam_0, MyParam_1>, 5>");
+  EXPECT_EQ(myarray.name(), "OIArray<std::vector<MyParam_0, MyParam_1>, 5>");
 }
 
 TEST(NameGenTest, Typedef) {
-  auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(myparam1.get());
-  mycontainer.templateParams.push_back(myparam2.get());
+  mycontainer.templateParams.push_back(&myparam1);
+  mycontainer.templateParams.push_back(&myparam2);
 
-  auto mytypedef = std::make_unique<Typedef>("MyTypedef", &mycontainer);
+  auto mytypedef = Typedef{"MyTypedef", &mycontainer};
 
   NameGen nameGen;
-  nameGen.generateNames({*mytypedef});
+  nameGen.generateNames({mytypedef});
 
-  EXPECT_EQ(myparam1->name(), "MyParam_1");
-  EXPECT_EQ(myparam2->name(), "MyParam_2");
+  EXPECT_EQ(myparam1.name(), "MyParam_1");
+  EXPECT_EQ(myparam2.name(), "MyParam_2");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_1, MyParam_2>");
-  EXPECT_EQ(mytypedef->name(), "MyTypedef_0");
+  EXPECT_EQ(mytypedef.name(), "MyTypedef_0");
 }
 
 TEST(NameGenTest, TypedefAliasTemplate) {
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto mytypedef =
-      std::make_unique<Typedef>("MyTypedef<ParamA, ParamB>", myint.get());
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto mytypedef = Typedef{"MyTypedef<ParamA, ParamB>", &myint};
 
   NameGen nameGen;
-  nameGen.generateNames({*mytypedef});
+  nameGen.generateNames({mytypedef});
 
-  EXPECT_EQ(mytypedef->name(), "MyTypedef_0");
+  EXPECT_EQ(mytypedef.name(), "MyTypedef_0");
 }
 
 TEST(NameGenTest, Pointer) {
-  auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(myparam1.get());
-  mycontainer.templateParams.push_back(myparam2.get());
+  mycontainer.templateParams.push_back(&myparam1);
+  mycontainer.templateParams.push_back(&myparam2);
 
-  auto mypointer = std::make_unique<Pointer>(&mycontainer);
+  auto mypointer = Pointer{&mycontainer};
 
   NameGen nameGen;
-  nameGen.generateNames({*mypointer});
+  nameGen.generateNames({mypointer});
 
-  EXPECT_EQ(myparam1->name(), "MyParam_0");
-  EXPECT_EQ(myparam2->name(), "MyParam_1");
+  EXPECT_EQ(myparam1.name(), "MyParam_0");
+  EXPECT_EQ(myparam2.name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
-  EXPECT_EQ(mypointer->name(), "std::vector<MyParam_0, MyParam_1>*");
+  EXPECT_EQ(mypointer.name(), "std::vector<MyParam_0, MyParam_1>*");
 }
 
 TEST(NameGenTest, Dummy) {
-  auto dummy = std::make_unique<Dummy>(12, 34);
+  auto dummy = Dummy{12, 34};
 
   NameGen nameGen;
-  nameGen.generateNames({*dummy});
+  nameGen.generateNames({dummy});
 
-  EXPECT_EQ(dummy->name(), "DummySizedOperator<12, 34>");
+  EXPECT_EQ(dummy.name(), "DummySizedOperator<12, 34>");
 }
 
 TEST(NameGenTest, DummyAllocator) {
-  auto myparam1 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
-  auto myparam2 = std::make_unique<Class>(Class::Kind::Struct, "MyParam", 13);
+  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(myparam1.get());
-  mycontainer.templateParams.push_back(myparam2.get());
+  mycontainer.templateParams.push_back(&myparam1);
+  mycontainer.templateParams.push_back(&myparam2);
 
-  auto myalloc = std::make_unique<DummyAllocator>(mycontainer, 12, 34);
+  auto myalloc = DummyAllocator{mycontainer, 12, 34};
 
   NameGen nameGen;
-  nameGen.generateNames({*myalloc});
+  nameGen.generateNames({myalloc});
 
-  EXPECT_EQ(myparam1->name(), "MyParam_0");
-  EXPECT_EQ(myparam2->name(), "MyParam_1");
+  EXPECT_EQ(myparam1.name(), "MyParam_0");
+  EXPECT_EQ(myparam2.name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
-  EXPECT_EQ(myalloc->name(),
+  EXPECT_EQ(myalloc.name(),
             "DummyAllocator<std::vector<MyParam_0, MyParam_1>, 12, 34>");
 }
 
 TEST(NameGenTest, Cycle) {
-  auto classA = std::make_unique<Class>(Class::Kind::Class, "ClassA", 69);
-  auto classB = std::make_unique<Class>(Class::Kind::Class, "ClassB", 69);
-  auto ptrA = std::make_unique<Pointer>(classA.get());
-  classA->members.push_back(Member(classB.get(), "b", 0));
-  classB->members.push_back(Member(ptrA.get(), "a", 0));
+  auto classA = Class{Class::Kind::Class, "ClassA", 69};
+  auto classB = Class{Class::Kind::Class, "ClassB", 69};
+  auto ptrA = Pointer{&classA};
+  classA.members.push_back(Member(&classB, "b", 0));
+  classB.members.push_back(Member(&ptrA, "a", 0));
 
   NameGen nameGen;
-  nameGen.generateNames({*classA});
+  nameGen.generateNames({classA});
 
-  EXPECT_EQ(classA->name(), "ClassA_0");
-  EXPECT_EQ(classB->name(), "ClassB_1");
+  EXPECT_EQ(classA.name(), "ClassA_0");
+  EXPECT_EQ(classB.name(), "ClassB_1");
 }
 
 TEST(NameGenTest, ContainerCycle) {
   auto container = getVector();
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 69);
-  myclass->members.push_back(Member(&container, "c", 0));
-  container.templateParams.push_back(TemplateParam(myclass.get()));
+  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  myclass.members.push_back(Member(&container, "c", 0));
+  container.templateParams.push_back(TemplateParam(&myclass));
 
   NameGen nameGen;
-  nameGen.generateNames({*myclass});
+  nameGen.generateNames({myclass});
 
-  EXPECT_EQ(myclass->name(), "MyClass_0");
+  EXPECT_EQ(myclass.name(), "MyClass_0");
   EXPECT_EQ(container.name(), "std::vector<MyClass_0>");
 }

--- a/test/test_remove_top_level_pointer.cpp
+++ b/test/test_remove_top_level_pointer.cpp
@@ -7,14 +7,14 @@
 using namespace type_graph;
 
 TEST(RemoveTopLevelPointerTest, TopLevelPointerRemoved) {
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
+  auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 4);
-  myclass->members.push_back(Member(myint.get(), "n", 0));
+  auto myclass = Class{Class::Kind::Class, "MyClass", 4};
+  myclass.members.push_back(Member(&myint, "n", 0));
 
-  auto ptrA = std::make_unique<Pointer>(myclass.get());
+  auto ptrA = Pointer{&myclass};
 
-  test(RemoveTopLevelPointer::createPass(), {*ptrA}, R"(
+  test(RemoveTopLevelPointer::createPass(), {ptrA}, R"(
 [0] Class: MyClass (size: 4)
       Member: n (offset: 0)
         Primitive: int32_t
@@ -22,12 +22,12 @@ TEST(RemoveTopLevelPointerTest, TopLevelPointerRemoved) {
 }
 
 TEST(RemoveTopLevelPointerTest, TopLevelClassUntouched) {
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
+  auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 4);
-  myclass->members.push_back(Member(myint.get(), "n", 0));
+  auto myclass = Class{Class::Kind::Class, "MyClass", 4};
+  myclass.members.push_back(Member(&myint, "n", 0));
 
-  test(RemoveTopLevelPointer::createPass(), {*myclass}, R"(
+  test(RemoveTopLevelPointer::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 4)
       Member: n (offset: 0)
         Primitive: int32_t
@@ -35,13 +35,13 @@ TEST(RemoveTopLevelPointerTest, TopLevelClassUntouched) {
 }
 
 TEST(RemoveTopLevelPointerTest, IntermediatePointerUntouched) {
-  auto myint = std::make_unique<Primitive>(Primitive::Kind::Int32);
-  auto ptrInt = std::make_unique<Pointer>(myint.get());
+  auto myint = Primitive{Primitive::Kind::Int32};
+  auto ptrInt = Pointer{&myint};
 
-  auto myclass = std::make_unique<Class>(Class::Kind::Class, "MyClass", 4);
-  myclass->members.push_back(Member(ptrInt.get(), "n", 0));
+  auto myclass = Class{Class::Kind::Class, "MyClass", 4};
+  myclass.members.push_back(Member(&ptrInt, "n", 0));
 
-  test(RemoveTopLevelPointer::createPass(), {*myclass}, R"(
+  test(RemoveTopLevelPointer::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 4)
       Member: n (offset: 0)
 [1]     Pointer

--- a/test/test_topo_sorter.cpp
+++ b/test/test_topo_sorter.cpp
@@ -4,10 +4,9 @@
 
 #include "oi/type_graph/TopoSorter.h"
 #include "oi/type_graph/Types.h"
+#include "test/type_graph_utils.h"
 
 using namespace type_graph;
-
-Container getVector();  // TODO put in a header
 
 template <typename T>
 using ref = std::reference_wrapper<T>;


### PR DESCRIPTION
This was a purely mechanical change made with some find-and-replace macros. The tests still pass afterwards.

The second commit I'm bundling into this PR is a lot smaller and just moves the last remaining tests onto using the type_graph_utils helpers.