### PR TITLE
TypeGraph: Add Node IDs to non-leaf types

### DIFF
--- a/oi/type_graph/AddPadding.cpp
+++ b/oi/type_graph/AddPadding.cpp
@@ -98,13 +98,12 @@ void AddPadding::addPadding(const Member& prevMember,
 
   if (paddingBits % 8 == 0) {
     // Pad with an array of bytes
-    auto* primitive = typeGraph_.make_type<Primitive>(Primitive::Kind::Int8);
-    auto* paddingArray =
-        typeGraph_.make_type<Array>(primitive, paddingBits / 8);
+    auto* primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int8);
+    auto* paddingArray = typeGraph_.makeType<Array>(primitive, paddingBits / 8);
     paddedMembers.emplace_back(paddingArray, MemberPrefix, prevMemberEndBits);
   } else {
     // Pad with a bitfield
-    auto* primitive = typeGraph_.make_type<Primitive>(Primitive::Kind::Int64);
+    auto* primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int64);
     paddedMembers.emplace_back(primitive, MemberPrefix, prevMemberEndBits,
                                paddingBits);
   }

--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -86,7 +86,7 @@ Type* DrgnParser::enumerateType(struct drgn_type* type) {
     return it->second;
 
   if (!drgn_utils::isSizeComplete(type)) {
-    return make_type<Primitive>(nullptr, Primitive::Kind::Void);
+    return makeType<Primitive>(nullptr, Primitive::Kind::Void);
   }
 
   enum drgn_type_kind kind = drgn_type_kind(type);
@@ -135,7 +135,7 @@ Container* DrgnParser::enumerateContainer(struct drgn_type* type,
 
     VLOG(2) << "Matching container `" << containerInfo.typeName << "` from `"
             << fqName << "`" << std::endl;
-    auto* c = make_type<Container>(type, containerInfo, size);
+    auto* c = makeType<Container>(type, containerInfo, size);
     enumerateClassTemplateParams(type, c->templateParams);
     return c;
   }
@@ -183,8 +183,8 @@ Type* DrgnParser::enumerateClass(struct drgn_type* type) {
                             std::to_string(drgn_type_kind(type))};
   }
 
-  auto c = make_type<Class>(type, kind, std::move(name), std::move(fqName),
-                            size, virtuality);
+  auto c = makeType<Class>(type, kind, std::move(name), std::move(fqName), size,
+                           virtuality);
 
   enumerateClassTemplateParams(type, c->templateParams);
   enumerateClassParents(type, c->parents);
@@ -417,7 +417,7 @@ Enum* DrgnParser::enumerateEnum(struct drgn_type* type) {
   std::string name = drgn_type_tag(type);
   uint64_t size = get_drgn_type_size(type);
   ;
-  return make_type<Enum>(type, name, size);
+  return makeType<Enum>(type, name, size);
 }
 
 Typedef* DrgnParser::enumerateTypedef(struct drgn_type* type) {
@@ -426,13 +426,13 @@ Typedef* DrgnParser::enumerateTypedef(struct drgn_type* type) {
 
   struct drgn_type* underlyingType = drgn_type_type(type).type;
   auto t = enumerateType(underlyingType);
-  return make_type<Typedef>(type, name, t);
+  return makeType<Typedef>(type, name, t);
 }
 
 Type* DrgnParser::enumeratePointer(struct drgn_type* type) {
   if (!chasePointer()) {
     // TODO dodgy nullptr - primitives should be handled as singletons
-    return make_type<Primitive>(nullptr, Primitive::Kind::UIntPtr);
+    return makeType<Primitive>(nullptr, Primitive::Kind::UIntPtr);
   }
 
   struct drgn_type* pointeeType = drgn_type_type(type).type;
@@ -440,14 +440,14 @@ Type* DrgnParser::enumeratePointer(struct drgn_type* type) {
   // TODO why was old CodeGen following funciton pointers?
 
   Type* t = enumerateType(pointeeType);
-  return make_type<Pointer>(type, t);
+  return makeType<Pointer>(type, t);
 }
 
 Array* DrgnParser::enumerateArray(struct drgn_type* type) {
   struct drgn_type* elementType = drgn_type_type(type).type;
   uint64_t len = drgn_type_length(type);
   auto t = enumerateType(elementType);
-  return make_type<Array>(type, t, len);
+  return makeType<Array>(type, t, len);
 }
 
 Primitive* DrgnParser::enumeratePrimitive(struct drgn_type* type) {
@@ -469,7 +469,7 @@ Primitive* DrgnParser::enumeratePrimitive(struct drgn_type* type) {
       throw DrgnParserError{"Invalid drgn type kind for primitive: " +
                             std::to_string(drgn_type_kind(type))};
   }
-  return make_type<Primitive>(type, kind);
+  return makeType<Primitive>(type, kind);
 }
 
 bool DrgnParser::chasePointer() const {

--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -68,10 +68,8 @@ class DrgnParser {
   std::unordered_map<struct drgn_type*, Type*> drgn_types_;
 
   template <typename T, typename... Args>
-  T* make_type(struct drgn_type* type, Args&&... args) {
-    auto type_unique_ptr = std::make_unique<T>(std::forward<Args>(args)...);
-    auto type_raw_ptr = type_unique_ptr.get();
-    typeGraph_.add(std::move(type_unique_ptr));
+  T* makeType(struct drgn_type* type, Args&&... args) {
+    auto* type_raw_ptr = typeGraph_.makeType<T>(std::forward<Args>(args)...);
     drgn_types_.insert({type, type_raw_ptr});
     return type_raw_ptr;
   }

--- a/oi/type_graph/RemoveIgnored.cpp
+++ b/oi/type_graph/RemoveIgnored.cpp
@@ -44,9 +44,9 @@ void RemoveIgnored::visit(Class& c) {
     if (!ignoreMember(c.name(), c.members[i].name)) {
       continue;
     }
-    auto* primitive = typeGraph_.make_type<Primitive>(Primitive::Kind::Int8);
+    auto* primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int8);
     auto* paddingArray =
-        typeGraph_.make_type<Array>(primitive, c.members[i].type->size());
+        typeGraph_.makeType<Array>(primitive, c.members[i].type->size());
     c.members[i] =
         Member{paddingArray, c.members[i].name, c.members[i].bitOffset};
   }

--- a/oi/type_graph/TypeGraph.cpp
+++ b/oi/type_graph/TypeGraph.cpp
@@ -18,7 +18,7 @@
 namespace type_graph {
 
 template <>
-Primitive* TypeGraph::make_type<Primitive>(Primitive::Kind kind) {
+Primitive* TypeGraph::makeType<Primitive>(Primitive::Kind kind) {
   switch (kind) {
     case Primitive::Kind::Int8:
       static Primitive pInt8{kind};

--- a/oi/type_graph/TypeGraph.h
+++ b/oi/type_graph/TypeGraph.h
@@ -23,6 +23,11 @@
 
 namespace type_graph {
 
+/*
+ * TypeGraph
+ *
+ * Holds the nodes and metadata which form a type graph.
+ */
 class TypeGraph {
  public:
   size_t size() const noexcept {
@@ -42,24 +47,33 @@ class TypeGraph {
     rootTypes_.push_back(type);
   }
 
-  // Override of the generic make_type function that returns singleton Primitive
+  // Override of the generic makeType function that returns singleton Primitive
   // objects
   template <typename T>
-  Primitive* make_type(Primitive::Kind kind);
+  Primitive* makeType(Primitive::Kind kind);
 
   template <typename T, typename... Args>
-  T* make_type(Args&&... args) {
+  T* makeType(Args&&... args) {
     static_assert(!std::is_same<T, Primitive>::value,
                   "Primitive singleton override should be used");
-
-    auto type_unique_ptr = std::make_unique<T>(std::forward<Args>(args)...);
-    auto type_raw_ptr = type_unique_ptr.get();
-    types_.push_back(std::move(type_unique_ptr));
-    return type_raw_ptr;
-  }
-
-  void add(std::unique_ptr<Type> type) {
-    types_.push_back(std::move(type));
+    if constexpr (std::is_same<T, Class>::value ||
+                  std::is_same<T, Container>::value ||
+                  std::is_same<T, Array>::value ||
+                  std::is_same<T, Typedef>::value ||
+                  std::is_same<T, Pointer>::value) {
+      // Node ID required
+      auto type_unique_ptr =
+          std::make_unique<T>(next_id_++, std::forward<Args>(args)...);
+      auto type_raw_ptr = type_unique_ptr.get();
+      types_.push_back(std::move(type_unique_ptr));
+      return type_raw_ptr;
+    } else {
+      // No Node ID
+      auto type_unique_ptr = std::make_unique<T>(std::forward<Args>(args)...);
+      auto type_raw_ptr = type_unique_ptr.get();
+      types_.push_back(std::move(type_unique_ptr));
+      return type_raw_ptr;
+    }
   }
 
   // TODO dodgy (use a getter instead to allow returning a const vector):
@@ -69,6 +83,7 @@ class TypeGraph {
   std::vector<std::reference_wrapper<Type>> rootTypes_;
   // Store all type objects in vectors for ownership. Order is not significant.
   std::vector<std::unique_ptr<Type>> types_;
+  NodeId next_id_ = 0;
 };
 
 }  // namespace type_graph

--- a/oi/type_graph/TypeIdentifier.cpp
+++ b/oi/type_graph/TypeIdentifier.cpp
@@ -74,7 +74,7 @@ void TypeIdentifier::visit(Container& c) {
         if (std::regex_search(paramClass->fqName(), info.matcher)) {
           // Create dummy containers
           auto* dummy =
-              typeGraph_.make_type<Container>(info, param.type->size());
+              typeGraph_.makeType<Container>(info, param.type->size());
           dummy->templateParams = paramClass->templateParams;
           c.templateParams[i] = dummy;
           replaced = true;
@@ -99,11 +99,11 @@ void TypeIdentifier::visit(Container& c) {
         auto* allocator =
             dynamic_cast<Class*>(param.type);  // TODO please don't do this...
         Type& typeToAllocate = *allocator->templateParams.at(0).type;
-        auto* dummy = typeGraph_.make_type<DummyAllocator>(typeToAllocate, size,
-                                                           param.type->align());
+        auto* dummy = typeGraph_.makeType<DummyAllocator>(typeToAllocate, size,
+                                                          param.type->align());
         c.templateParams[i] = dummy;
       } else {
-        auto* dummy = typeGraph_.make_type<Dummy>(size, param.type->align());
+        auto* dummy = typeGraph_.makeType<Dummy>(size, param.type->align());
         c.templateParams[i] = dummy;
       }
     }

--- a/test/test_add_padding.cpp
+++ b/test/test_add_padding.cpp
@@ -7,7 +7,7 @@
 using namespace type_graph;
 
 TEST(AddPaddingTest, BetweenMembers) {
-  auto myclass = Class{Class::Kind::Class, "MyClass", 16};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
   myclass.members.push_back(Member(&myint8, "n1", 0));
@@ -26,7 +26,7 @@ TEST(AddPaddingTest, BetweenMembers) {
 }
 
 TEST(AddPaddingTest, AtEnd) {
-  auto myclass = Class{Class::Kind::Struct, "MyStruct", 16};
+  auto myclass = Class{0, Class::Kind::Struct, "MyStruct", 16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
   myclass.members.push_back(Member(&myint64, "n1", 0));
@@ -45,7 +45,7 @@ TEST(AddPaddingTest, AtEnd) {
 }
 
 TEST(AddPaddingTest, UnionNotPadded) {
-  auto myclass = Class{Class::Kind::Union, "MyUnion", 8};
+  auto myclass = Class{0, Class::Kind::Union, "MyUnion", 8};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
   myclass.members.push_back(Member(&myint64, "n1", 0));
@@ -61,7 +61,7 @@ TEST(AddPaddingTest, UnionNotPadded) {
 }
 
 TEST(AddPaddingTest, Bitfields) {
-  auto myclass = Class{Class::Kind::Class, "MyClass", 16};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 16};
   auto myint64 = Primitive{Primitive::Kind::Int64};
   auto myint16 = Primitive{Primitive::Kind::Int16};
   auto myint8 = Primitive{Primitive::Kind::Int8};

--- a/test/test_alignment_calc.cpp
+++ b/test/test_alignment_calc.cpp
@@ -6,7 +6,7 @@
 using namespace type_graph;
 
 TEST(AlignmentCalcTest, PrimitiveMembers) {
-  auto myclass = Class{Class::Kind::Class, "MyClass", 16};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
   myclass.members.push_back(Member(&myint8, "n", 0));
@@ -22,12 +22,12 @@ TEST(AlignmentCalcTest, PrimitiveMembers) {
 }
 
 TEST(AlignmentCalcTest, StructMembers) {
-  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 8};
+  auto mystruct = Class{1, Class::Kind::Struct, "MyStruct", 8};
   auto myint32 = Primitive{Primitive::Kind::Int32};
   mystruct.members.push_back(Member(&myint32, "n1", 0));
   mystruct.members.push_back(Member(&myint32, "n2", 4 * 8));
 
-  auto myclass = Class{Class::Kind::Class, "MyClass", 12};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 12};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   myclass.members.push_back(Member(&myint8, "n", 0));
   myclass.members.push_back(Member(&mystruct, "s", 4 * 8));
@@ -46,13 +46,13 @@ TEST(AlignmentCalcTest, StructMembers) {
 }
 
 TEST(AlignmentCalcTest, StructInContainer) {
-  auto myclass = Class{Class::Kind::Class, "MyClass", 16};
+  auto myclass = Class{1, Class::Kind::Class, "MyClass", 16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
   myclass.members.push_back(Member(&myint8, "n", 0));
   myclass.members.push_back(Member(&myint64, "n", 8 * 8));
 
-  auto mycontainer = Container{ContainerInfo{}, 8};
+  auto mycontainer = Container{0, ContainerInfo{}, 8};
   mycontainer.templateParams.push_back(&myclass);
 
   test(AlignmentCalc::createPass(), {mycontainer}, R"(
@@ -67,7 +67,7 @@ TEST(AlignmentCalcTest, StructInContainer) {
 }
 
 TEST(AlignmentCalcTest, Packed) {
-  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 9};
+  auto mystruct = Class{0, Class::Kind::Struct, "MyStruct", 9};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
   mystruct.members.push_back(Member(&myint8, "n1", 0));

--- a/test/test_codegen.cpp
+++ b/test/test_codegen.cpp
@@ -38,7 +38,7 @@ void testTransform(Type& type,
 TEST(CodeGenTest, TransformContainerAllocator) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myalloc = Class{Class::Kind::Struct, "MyAlloc", 8};
+  auto myalloc = Class{1, Class::Kind::Struct, "MyAlloc", 8};
   myalloc.templateParams.push_back(TemplateParam{&myint});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
@@ -76,22 +76,23 @@ TEST(CodeGenTest, TransformContainerAllocatorParamInParent) {
 
   Primitive myint{Primitive::Kind::Int32};
 
-  Container pair{pairInfo, 8};
+  Container pair{3, pairInfo, 8};
   pair.templateParams.push_back(TemplateParam{&myint, {Qualifier::Const}});
   pair.templateParams.push_back(TemplateParam{&myint});
 
-  Class myallocBase{Class::Kind::Struct,
+  Class myallocBase{2, Class::Kind::Struct,
                     "MyAllocBase<std::pair<const int, int>>", 1};
   myallocBase.templateParams.push_back(TemplateParam{&pair});
   myallocBase.functions.push_back(Function{"allocate"});
   myallocBase.functions.push_back(Function{"deallocate"});
 
-  Class myalloc{Class::Kind::Struct, "MyAlloc<std::pair<const int, int>>", 1};
+  Class myalloc{1, Class::Kind::Struct, "MyAlloc<std::pair<const int, int>>",
+                1};
   myalloc.parents.push_back(Parent{&myallocBase, 0});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
 
-  Container map{mapInfo, 24};
+  Container map{0, mapInfo, 24};
   map.templateParams.push_back(TemplateParam{&myint});
   map.templateParams.push_back(TemplateParam{&myint});
   map.templateParams.push_back(TemplateParam{&myalloc});

--- a/test/test_flattener.cpp
+++ b/test/test_flattener.cpp
@@ -16,8 +16,8 @@ TEST(FlattenerTest, NoParents) {
   //   };
   auto myint = Primitive{Primitive::Kind::Int32};
   auto myenum = Enum{"MyEnum", 4};
-  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 4};
-  auto myclass = Class{Class::Kind::Class, "MyClass", 12};
+  auto mystruct = Class{1, Class::Kind::Struct, "MyStruct", 4};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 12};
 
   mystruct.members.push_back(Member(&myint, "n0", 0));
 
@@ -50,9 +50,9 @@ TEST(FlattenerTest, OnlyParents) {
   //     int c;
   //   };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 8};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 8};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
   classB.members.push_back(Member(&myint, "b", 0));
@@ -82,9 +82,9 @@ TEST(FlattenerTest, ParentsFirst) {
   //     int a;
   //   };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
   classB.members.push_back(Member(&myint, "b", 0));
@@ -117,9 +117,9 @@ TEST(FlattenerTest, MembersFirst) {
   //     int c;
   //   };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
 
@@ -154,9 +154,9 @@ TEST(FlattenerTest, MixedMembersAndParents) {
   //     int c;
   //   };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 16};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 16};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
 
@@ -193,9 +193,9 @@ TEST(FlattenerTest, EmptyParent) {
   //     int a2;
   //   };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
-  auto classB = Class{Class::Kind::Class, "ClassB", 0};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 0};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
 
@@ -230,10 +230,10 @@ TEST(FlattenerTest, TwoDeep) {
   //     int a;
   //   };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 16};
-  auto classB = Class{Class::Kind::Class, "ClassB", 8};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
-  auto classD = Class{Class::Kind::Class, "ClassD", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 16};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
+  auto classD = Class{3, Class::Kind::Class, "ClassD", 4};
 
   classD.members.push_back(Member(&myint, "d", 0));
 
@@ -273,9 +273,9 @@ TEST(FlattenerTest, DiamondInheritance) {
   //     int a;
   //   };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 16};
-  auto classB = Class{Class::Kind::Class, "ClassB", 8};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 16};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
 
@@ -309,9 +309,9 @@ TEST(FlattenerTest, Member) {
   //   class B { int c; int b; };
   //   Class A { int a; B b; };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
-  auto classB = Class{Class::Kind::Class, "ClassB", 8};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
 
@@ -344,9 +344,9 @@ TEST(FlattenerTest, MemberOfParent) {
   //   class C { int c; };
   //   class A { int b; C c; int a; };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
-  auto classB = Class{Class::Kind::Class, "ClassB", 8};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
 
@@ -379,8 +379,8 @@ TEST(FlattenerTest, ContainerParam) {
   //   class A { int b; int a; };
   //   std::vector<A, int>
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 8};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classA = Class{1, Class::Kind::Class, "ClassA", 8};
+  auto classB = Class{2, Class::Kind::Class, "ClassB", 4};
   auto container = getVector();
 
   classB.members.push_back(Member(&myint, "b", 0));
@@ -411,14 +411,14 @@ TEST(FlattenerTest, Array) {
   //   A[5]
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classB = Class{2, Class::Kind::Class, "ClassB", 4};
   classB.members.push_back(Member(&myint, "b", 0));
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  auto classA = Class{1, Class::Kind::Class, "ClassA", 8};
   classA.parents.push_back(Parent(&classB, 0));
   classA.members.push_back(Member(&myint, "a", 4 * 8));
 
-  auto arrayA = Array{&classA, 5};
+  auto arrayA = Array{0, &classA, 5};
 
   test(Flattener::createPass(), {arrayA}, R"(
 [0] Array: (length: 5)
@@ -436,14 +436,14 @@ TEST(FlattenerTest, Typedef) {
   //   class A : B { int a; };
   //   using aliasA = A;
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classB = Class{2, Class::Kind::Class, "ClassB", 4};
   classB.members.push_back(Member(&myint, "b", 0));
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  auto classA = Class{1, Class::Kind::Class, "ClassA", 8};
   classA.parents.push_back(Parent(&classB, 0));
   classA.members.push_back(Member(&myint, "a", 4 * 8));
 
-  auto aliasA = Typedef{"aliasA", &classA};
+  auto aliasA = Typedef{0, "aliasA", &classA};
 
   test(Flattener::createPass(), {aliasA}, R"(
 [0] Typedef: aliasA
@@ -461,12 +461,12 @@ TEST(FlattenerTest, TypedefParent) {
   //   using aliasB = B;
   //   class A : aliasB { int a; };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
   classB.members.push_back(Member(&myint, "b", 0));
 
-  auto aliasB = Typedef{"aliasB", &classB};
+  auto aliasB = Typedef{2, "aliasB", &classB};
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 8};
   classA.parents.push_back(Parent(&aliasB, 0));
   classA.members.push_back(Member(&myint, "a", 4 * 8));
 
@@ -486,15 +486,15 @@ TEST(FlattenerTest, Pointer) {
   //   class C { A a; };
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classB = Class{3, Class::Kind::Class, "ClassB", 4};
   classB.members.push_back(Member(&myint, "b", 0));
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 8};
+  auto classA = Class{2, Class::Kind::Class, "ClassA", 8};
   classA.parents.push_back(Parent(&classB, 0));
   classA.members.push_back(Member(&myint, "a", 4 * 8));
 
-  auto ptrA = Pointer{&classA};
-  auto classC = Class{Class::Kind::Class, "ClassC", 8};
+  auto ptrA = Pointer{1, &classA};
+  auto classC = Class{0, Class::Kind::Class, "ClassC", 8};
   classC.members.push_back(Member(&ptrA, "a", 0));
 
   test(Flattener::createPass(), {classC}, R"(
@@ -516,9 +516,9 @@ TEST(FlattenerTest, PointerCycle) {
   //
   // Flattened:
   //   No change
-  auto classA = Class{Class::Kind::Class, "ClassA", 69};
-  auto classB = Class{Class::Kind::Class, "ClassB", 69};
-  auto ptrA = Pointer{&classA};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 69};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 69};
+  auto ptrA = Pointer{2, &classA};
   classA.members.push_back(Member(&classB, "b", 0));
   classB.members.push_back(Member(&ptrA, "a", 0));
 
@@ -539,9 +539,9 @@ TEST(FlattenerTest, Alignment) {
   //   class B { alignas(8) int b; };
   //   class A : B, C { int a; };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
   classC.setAlign(16);
 
   classC.members.push_back(Member(&myint, "c", 0));
@@ -583,9 +583,9 @@ TEST(FlattenerTest, Functions) {
   //   class C { void funcC(); };
   //   class B : C { void funcB(); };
   //   class A : B { void funcA(); };
-  auto classA = Class{Class::Kind::Class, "ClassA", 0};
-  auto classB = Class{Class::Kind::Class, "ClassB", 0};
-  auto classC = Class{Class::Kind::Class, "ClassC", 0};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 0};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 0};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 0};
 
   classA.parents.push_back(Parent(&classB, 0));
   classB.parents.push_back(Parent(&classC, 0));
@@ -608,9 +608,9 @@ TEST(FlattenerTest, Children) {
   //   class B { int b; };
   //   class A : B, C { };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 8};
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
+  auto classA = Class{1, Class::Kind::Class, "ClassA", 8};
+  auto classB = Class{0, Class::Kind::Class, "ClassB", 4};
+  auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
   classC.members.push_back(Member(&myint, "c", 0));
   classB.members.push_back(Member(&myint, "b", 0));
@@ -641,10 +641,10 @@ TEST(FlattenerTest, ChildrenTwoDeep) {
   //   class B : D { int b; };
   //   class A : B, C { int a; };
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto classA = Class{Class::Kind::Class, "ClassA", 16};
-  auto classB = Class{Class::Kind::Class, "ClassB", 8};
-  auto classC = Class{Class::Kind::Class, "ClassC", 4};
-  auto classD = Class{Class::Kind::Class, "ClassD", 4};
+  auto classA = Class{2, Class::Kind::Class, "ClassA", 16};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 8};
+  auto classC = Class{3, Class::Kind::Class, "ClassC", 4};
+  auto classD = Class{0, Class::Kind::Class, "ClassD", 4};
 
   classD.members.push_back(Member(&myint, "d", 0));
 
@@ -690,7 +690,7 @@ TEST(FlattenerTest, ParentContainer) {
   auto vector = getVector();
   vector.templateParams.push_back(TemplateParam{&myint});
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 32};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 32};
   classA.parents.push_back(Parent{&vector, 0});
   classA.members.push_back(Member{&myint, "a", 24 * 8});
 
@@ -720,7 +720,7 @@ TEST(FlattenerTest, ParentTwoContainers) {
   auto vector = getVector();
   vector.templateParams.push_back(TemplateParam{&myint});
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 48};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 48};
   classA.parents.push_back(Parent{&vector, 0});
   classA.parents.push_back(Parent{&vector, 24 * 8});
 
@@ -750,10 +750,10 @@ TEST(FlattenerTest, ParentClassAndContainer) {
   auto vector = getVector();
   vector.templateParams.push_back(TemplateParam{&myint});
 
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
   classB.members.push_back(Member{&myint, "b", 0});
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 32};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 32};
   classA.parents.push_back(Parent{&classB, 0});
   classA.parents.push_back(Parent{&vector, 8 * 8});
 
@@ -787,22 +787,23 @@ TEST(FlattenerTest, AllocatorParamInParent) {
 
   Primitive myint{Primitive::Kind::Int32};
 
-  Container pair{pairInfo, 8};
+  Container pair{3, pairInfo, 8};
   pair.templateParams.push_back(TemplateParam{&myint, {Qualifier::Const}});
   pair.templateParams.push_back(TemplateParam{&myint});
 
-  Class myallocBase{Class::Kind::Struct,
+  Class myallocBase{2, Class::Kind::Struct,
                     "MyAllocBase<std::pair<const int, int>>", 1};
   myallocBase.templateParams.push_back(TemplateParam{&pair});
   myallocBase.functions.push_back(Function{"allocate"});
   myallocBase.functions.push_back(Function{"deallocate"});
 
-  Class myalloc{Class::Kind::Struct, "MyAlloc<std::pair<const int, int>>", 1};
+  Class myalloc{1, Class::Kind::Struct, "MyAlloc<std::pair<const int, int>>",
+                1};
   myalloc.parents.push_back(Parent{&myallocBase, 0});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
 
-  Container map{mapInfo, 24};
+  Container map{0, mapInfo, 24};
   map.templateParams.push_back(TemplateParam{&myint});
   map.templateParams.push_back(TemplateParam{&myint});
   map.templateParams.push_back(TemplateParam{&myalloc});
@@ -853,12 +854,12 @@ TEST(FlattenerTest, AllocatorParamInParent) {
 
 TEST(FlattenerTest, ClassParam) {
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto mychild = Class{Class::Kind::Class, "MyChild", 4};
-  auto myparent = Class{Class::Kind::Class, "MyParent", 4};
+  auto mychild = Class{1, Class::Kind::Class, "MyChild", 4};
+  auto myparent = Class{2, Class::Kind::Class, "MyParent", 4};
   myparent.members.push_back(Member{&myint, "a", 0});
   mychild.parents.push_back(Parent{&myparent, 0});
 
-  auto myclass = Class{Class::Kind::Class, "MyClass", 4};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 4};
   myclass.templateParams.push_back(TemplateParam{&mychild});
 
   test(Flattener::createPass(), {myclass}, R"(

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -7,9 +7,9 @@
 using namespace type_graph;
 
 TEST(NameGenTest, ClassParams) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myclass = Class{Class::Kind::Struct, "MyClass<MyParam, MyParam>", 13};
+  auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
+  auto myclass = Class{2, Class::Kind::Struct, "MyClass<MyParam, MyParam>", 13};
   myclass.templateParams.push_back(&myparam1);
   myclass.templateParams.push_back(&myparam2);
 
@@ -26,7 +26,7 @@ TEST(NameGenTest, ClassContainerParam) {
   auto myparam = getVector();
   myparam.templateParams.push_back(&myint);
 
-  auto myclass = Class{Class::Kind::Struct, "MyClass", 13};
+  auto myclass = Class{0, Class::Kind::Struct, "MyClass", 13};
   myclass.templateParams.push_back(&myparam);
 
   NameGen nameGen;
@@ -37,9 +37,9 @@ TEST(NameGenTest, ClassContainerParam) {
 }
 
 TEST(NameGenTest, ClassParents) {
-  auto myparent1 = Class{Class::Kind::Struct, "MyParent", 13};
-  auto myparent2 = Class{Class::Kind::Struct, "MyParent", 13};
-  auto myclass = Class{Class::Kind::Struct, "MyClass", 13};
+  auto myparent1 = Class{0, Class::Kind::Struct, "MyParent", 13};
+  auto myparent2 = Class{1, Class::Kind::Struct, "MyParent", 13};
+  auto myclass = Class{2, Class::Kind::Struct, "MyClass", 13};
   myclass.parents.push_back(Parent{&myparent1, 0});
   myclass.parents.push_back(Parent{&myparent2, 0});
 
@@ -52,9 +52,9 @@ TEST(NameGenTest, ClassParents) {
 }
 
 TEST(NameGenTest, ClassMembers) {
-  auto mymember1 = Class{Class::Kind::Struct, "MyMember", 13};
-  auto mymember2 = Class{Class::Kind::Struct, "MyMember", 13};
-  auto myclass = Class{Class::Kind::Struct, "MyClass", 13};
+  auto mymember1 = Class{0, Class::Kind::Struct, "MyMember", 13};
+  auto mymember2 = Class{1, Class::Kind::Struct, "MyMember", 13};
+  auto myclass = Class{2, Class::Kind::Struct, "MyClass", 13};
 
   // A class may end up with members sharing a name after flattening
   myclass.members.push_back(Member{&mymember1, "mem", 0});
@@ -71,9 +71,9 @@ TEST(NameGenTest, ClassMembers) {
 }
 
 TEST(NameGenTest, ClassChildren) {
-  auto mychild1 = Class{Class::Kind::Struct, "MyChild", 13};
-  auto mychild2 = Class{Class::Kind::Struct, "MyChild", 13};
-  auto myclass = Class{Class::Kind::Struct, "MyClass", 13};
+  auto mychild1 = Class{0, Class::Kind::Struct, "MyChild", 13};
+  auto mychild2 = Class{1, Class::Kind::Struct, "MyChild", 13};
+  auto myclass = Class{2, Class::Kind::Struct, "MyClass", 13};
   myclass.children.push_back(mychild1);
   myclass.children.push_back(mychild2);
 
@@ -86,8 +86,8 @@ TEST(NameGenTest, ClassChildren) {
 }
 
 TEST(NameGenTest, ContainerParams) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(&myparam1);
   mycontainer.templateParams.push_back(&myparam2);
@@ -101,7 +101,7 @@ TEST(NameGenTest, ContainerParams) {
 }
 
 TEST(NameGenTest, ContainerParamsDuplicates) {
-  auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam = Class{0, Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(&myparam);
   mycontainer.templateParams.push_back(&myparam);
@@ -114,7 +114,7 @@ TEST(NameGenTest, ContainerParamsDuplicates) {
 }
 
 TEST(NameGenTest, ContainerParamsDuplicatesDeep) {
-  auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam = Class{0, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer1 = getVector();
   mycontainer1.templateParams.push_back(&myparam);
@@ -133,9 +133,9 @@ TEST(NameGenTest, ContainerParamsDuplicatesDeep) {
 }
 
 TEST(NameGenTest, ContainerParamsDuplicatesAcrossContainers) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myparam3 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
+  auto myparam3 = Class{2, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer1 = getVector();
   mycontainer1.templateParams.push_back(&myparam1);
@@ -156,8 +156,8 @@ TEST(NameGenTest, ContainerParamsDuplicatesAcrossContainers) {
 }
 
 TEST(NameGenTest, ContainerParamsConst) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyConstParam", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam1 = Class{0, Class::Kind::Struct, "MyConstParam", 13};
+  auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(
@@ -198,14 +198,14 @@ TEST(NameGenTest, ContainerParamsValue) {
 }
 
 TEST(NameGenTest, Array) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(&myparam1);
   mycontainer.templateParams.push_back(&myparam2);
 
-  auto myarray = Array{&mycontainer, 5};
+  auto myarray = Array{2, &mycontainer, 5};
 
   NameGen nameGen;
   nameGen.generateNames({myarray});
@@ -217,14 +217,14 @@ TEST(NameGenTest, Array) {
 }
 
 TEST(NameGenTest, Typedef) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(&myparam1);
   mycontainer.templateParams.push_back(&myparam2);
 
-  auto mytypedef = Typedef{"MyTypedef", &mycontainer};
+  auto mytypedef = Typedef{2, "MyTypedef", &mycontainer};
 
   NameGen nameGen;
   nameGen.generateNames({mytypedef});
@@ -237,7 +237,7 @@ TEST(NameGenTest, Typedef) {
 
 TEST(NameGenTest, TypedefAliasTemplate) {
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto mytypedef = Typedef{"MyTypedef<ParamA, ParamB>", &myint};
+  auto mytypedef = Typedef{0, "MyTypedef<ParamA, ParamB>", &myint};
 
   NameGen nameGen;
   nameGen.generateNames({mytypedef});
@@ -246,14 +246,14 @@ TEST(NameGenTest, TypedefAliasTemplate) {
 }
 
 TEST(NameGenTest, Pointer) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(&myparam1);
   mycontainer.templateParams.push_back(&myparam2);
 
-  auto mypointer = Pointer{&mycontainer};
+  auto mypointer = Pointer{2, &mycontainer};
 
   NameGen nameGen;
   nameGen.generateNames({mypointer});
@@ -274,8 +274,8 @@ TEST(NameGenTest, Dummy) {
 }
 
 TEST(NameGenTest, DummyAllocator) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
+  auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(&myparam1);
@@ -294,9 +294,9 @@ TEST(NameGenTest, DummyAllocator) {
 }
 
 TEST(NameGenTest, Cycle) {
-  auto classA = Class{Class::Kind::Class, "ClassA", 69};
-  auto classB = Class{Class::Kind::Class, "ClassB", 69};
-  auto ptrA = Pointer{&classA};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 69};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 69};
+  auto ptrA = Pointer{2, &classA};
   classA.members.push_back(Member(&classB, "b", 0));
   classB.members.push_back(Member(&ptrA, "a", 0));
 
@@ -309,7 +309,7 @@ TEST(NameGenTest, Cycle) {
 
 TEST(NameGenTest, ContainerCycle) {
   auto container = getVector();
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 69};
   myclass.members.push_back(Member(&container, "c", 0));
   container.templateParams.push_back(TemplateParam(&myclass));
 

--- a/test/test_remove_ignored.cpp
+++ b/test/test_remove_ignored.cpp
@@ -7,9 +7,9 @@
 using namespace type_graph;
 
 TEST(RemoveIgnoredTest, Match) {
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
   classA.members.push_back(Member(&classB, "a", 0));
   classA.members.push_back(Member(&classB, "b", 4 * 8));
   classA.members.push_back(Member(&classB, "c", 8 * 8));
@@ -40,9 +40,9 @@ TEST(RemoveIgnoredTest, Match) {
 }
 
 TEST(RemoveIgnoredTest, TypeMatchMemberMiss) {
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
   classA.members.push_back(Member(&classB, "a", 0));
   classA.members.push_back(Member(&classB, "b", 4 * 8));
   classA.members.push_back(Member(&classB, "c", 8 * 8));
@@ -63,9 +63,9 @@ TEST(RemoveIgnoredTest, TypeMatchMemberMiss) {
 }
 
 TEST(RemoveIgnoredTest, MemberMatchWrongType) {
-  auto classB = Class{Class::Kind::Class, "ClassB", 4};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
 
-  auto classA = Class{Class::Kind::Class, "ClassA", 12};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
   classA.members.push_back(Member(&classB, "a", 0));
   classA.members.push_back(Member(&classB, "b", 4 * 8));
   classA.members.push_back(Member(&classB, "c", 8 * 8));

--- a/test/test_remove_top_level_pointer.cpp
+++ b/test/test_remove_top_level_pointer.cpp
@@ -9,10 +9,10 @@ using namespace type_graph;
 TEST(RemoveTopLevelPointerTest, TopLevelPointerRemoved) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myclass = Class{Class::Kind::Class, "MyClass", 4};
+  auto myclass = Class{1, Class::Kind::Class, "MyClass", 4};
   myclass.members.push_back(Member(&myint, "n", 0));
 
-  auto ptrA = Pointer{&myclass};
+  auto ptrA = Pointer{0, &myclass};
 
   test(RemoveTopLevelPointer::createPass(), {ptrA}, R"(
 [0] Class: MyClass (size: 4)
@@ -24,7 +24,7 @@ TEST(RemoveTopLevelPointerTest, TopLevelPointerRemoved) {
 TEST(RemoveTopLevelPointerTest, TopLevelClassUntouched) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myclass = Class{Class::Kind::Class, "MyClass", 4};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 4};
   myclass.members.push_back(Member(&myint, "n", 0));
 
   test(RemoveTopLevelPointer::createPass(), {myclass}, R"(
@@ -36,9 +36,9 @@ TEST(RemoveTopLevelPointerTest, TopLevelClassUntouched) {
 
 TEST(RemoveTopLevelPointerTest, IntermediatePointerUntouched) {
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto ptrInt = Pointer{&myint};
+  auto ptrInt = Pointer{1, &myint};
 
-  auto myclass = Class{Class::Kind::Class, "MyClass", 4};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 4};
   myclass.members.push_back(Member(&ptrInt, "n", 0));
 
   test(RemoveTopLevelPointer::createPass(), {myclass}, R"(

--- a/test/test_topo_sorter.cpp
+++ b/test/test_topo_sorter.cpp
@@ -33,9 +33,9 @@ TEST(TopoSorterTest, SingleType) {
 }
 
 TEST(TopoSorterTest, UnrelatedTypes) {
-  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 13};
+  auto mystruct = Class{0, Class::Kind::Struct, "MyStruct", 13};
   auto myenum = Enum{"MyEnum", 4};
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  auto myclass = Class{1, Class::Kind::Class, "MyClass", 69};
 
   // Try the same input in a few different orders and ensure they output order
   // matches the input order
@@ -57,9 +57,9 @@ MyStruct
 }
 
 TEST(TopoSorterTest, ClassMembers) {
-  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 13};
+  auto mystruct = Class{0, Class::Kind::Struct, "MyStruct", 13};
   auto myenum = Enum{"MyEnum", 4};
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  auto myclass = Class{1, Class::Kind::Class, "MyClass", 69};
   myclass.members.push_back(Member(&mystruct, "n", 0));
   myclass.members.push_back(Member(&myenum, "e", 4));
 
@@ -71,8 +71,8 @@ MyClass
 }
 
 TEST(TopoSorterTest, Parents) {
-  auto myparent = Class{Class::Kind::Struct, "MyParent", 13};
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  auto myparent = Class{0, Class::Kind::Struct, "MyParent", 13};
+  auto myclass = Class{1, Class::Kind::Class, "MyClass", 69};
   myclass.parents.push_back(Parent(&myparent, 0));
 
   test({myclass}, R"(
@@ -82,8 +82,8 @@ MyClass
 }
 
 TEST(TopoSorterTest, TemplateParams) {
-  auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  auto myparam = Class{0, Class::Kind::Struct, "MyParam", 13};
+  auto myclass = Class{1, Class::Kind::Class, "MyClass", 69};
   myclass.templateParams.push_back(TemplateParam(&myparam));
 
   test({myclass}, R"(
@@ -93,11 +93,11 @@ MyClass
 }
 
 TEST(TopoSorterTest, Children) {
-  auto mymember = Class{Class::Kind::Struct, "MyMember", 13};
-  auto mychild = Class{Class::Kind::Struct, "MyChild", 13};
+  auto mymember = Class{0, Class::Kind::Struct, "MyMember", 13};
+  auto mychild = Class{1, Class::Kind::Struct, "MyChild", 13};
   mychild.members.push_back(Member(&mymember, "mymember", 0));
 
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  auto myclass = Class{2, Class::Kind::Class, "MyClass", 69};
   mychild.parents.push_back(Parent(&myclass, 0));
   myclass.children.push_back(mychild);
 
@@ -125,9 +125,9 @@ TEST(TopoSorterTest, ChildrenCycle) {
   // class MyChild : MyParent {
   //   A a;
   // };
-  auto myparent = Class{Class::Kind::Class, "MyParent", 69};
-  auto classA = Class{Class::Kind::Struct, "ClassA", 5};
-  auto mychild = Class{Class::Kind::Struct, "MyChild", 13};
+  auto myparent = Class{0, Class::Kind::Class, "MyParent", 69};
+  auto classA = Class{1, Class::Kind::Struct, "ClassA", 5};
+  auto mychild = Class{2, Class::Kind::Struct, "MyChild", 13};
 
   mychild.parents.push_back(Parent(&myparent, 0));
   myparent.children.push_back(mychild);
@@ -153,8 +153,8 @@ MyChild
 }
 
 TEST(TopoSorterTest, Containers) {
-  auto myparam1 = Class{Class::Kind::Struct, "MyParam1", 13};
-  auto myparam2 = Class{Class::Kind::Struct, "MyParam2", 13};
+  auto myparam1 = Class{1, Class::Kind::Struct, "MyParam1", 13};
+  auto myparam2 = Class{2, Class::Kind::Struct, "MyParam2", 13};
   auto mycontainer = getMap();
   mycontainer.templateParams.push_back((&myparam1));
   mycontainer.templateParams.push_back((&myparam2));
@@ -168,7 +168,7 @@ std::map
 
 TEST(TopoSorterTest, ContainersVector) {
   // std::vector allows forward declared template parameters
-  auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam = Class{1, Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back((&myparam));
 
@@ -180,7 +180,7 @@ MyParam
 
 TEST(TopoSorterTest, ContainersList) {
   // std::list allows forward declared template parameters
-  auto myparam = Class{Class::Kind::Struct, "MyParam", 13};
+  auto myparam = Class{1, Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getList();
   mycontainer.templateParams.push_back((&myparam));
 
@@ -191,15 +191,15 @@ MyParam
 }
 
 TEST(TopoSorterTest, Arrays) {
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
-  auto myarray = Array{&myclass, 10};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 69};
+  auto myarray = Array{1, &myclass, 10};
 
   test({myarray}, "MyClass\n");
 }
 
 TEST(TopoSorterTest, Typedef) {
-  auto classA = Class{Class::Kind::Class, "ClassA", 8};
-  auto aliasA = Typedef{"aliasA", &classA};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 8};
+  auto aliasA = Typedef{1, "aliasA", &classA};
 
   test({aliasA}, R"(
 ClassA
@@ -209,16 +209,16 @@ aliasA
 
 TEST(TopoSorterTest, Pointers) {
   // Pointers do not require pointee types to be defined first
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
-  auto mypointer = Pointer{&myclass};
+  auto myclass = Class{0, Class::Kind::Class, "MyClass", 69};
+  auto mypointer = Pointer{1, &myclass};
 
   test({mypointer}, "MyClass");
 }
 
 TEST(TopoSorterTest, PointerCycle) {
-  auto classA = Class{Class::Kind::Class, "ClassA", 69};
-  auto classB = Class{Class::Kind::Class, "ClassB", 69};
-  auto ptrA = Pointer{&classA};
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 69};
+  auto classB = Class{1, Class::Kind::Class, "ClassB", 69};
+  auto ptrA = Pointer{2, &classA};
   classA.members.push_back(Member(&classB, "b", 0));
   classB.members.push_back(Member(&ptrA, "a", 0));
 
@@ -239,9 +239,9 @@ ClassA
 }
 
 TEST(TopoSorterTest, TwoDeep) {
-  auto myunion = Class{Class::Kind::Union, "MyUnion", 7};
-  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 13};
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  auto myunion = Class{0, Class::Kind::Union, "MyUnion", 7};
+  auto mystruct = Class{1, Class::Kind::Struct, "MyStruct", 13};
+  auto myclass = Class{2, Class::Kind::Class, "MyClass", 69};
   myclass.members.push_back(Member(&mystruct, "mystruct", 0));
   mystruct.members.push_back(Member(&myunion, "myunion", 0));
 
@@ -253,9 +253,9 @@ MyClass
 }
 
 TEST(TopoSorterTest, MultiplePaths) {
-  auto myunion = Class{Class::Kind::Union, "MyUnion", 7};
-  auto mystruct = Class{Class::Kind::Struct, "MyStruct", 13};
-  auto myclass = Class{Class::Kind::Class, "MyClass", 69};
+  auto myunion = Class{0, Class::Kind::Union, "MyUnion", 7};
+  auto mystruct = Class{1, Class::Kind::Struct, "MyStruct", 13};
+  auto myclass = Class{2, Class::Kind::Class, "MyClass", 69};
   myclass.members.push_back(Member(&mystruct, "mystruct", 0));
   myclass.members.push_back(Member(&myunion, "myunion1", 0));
   mystruct.members.push_back(Member(&myunion, "myunion2", 0));

--- a/test/test_type_identifier.cpp
+++ b/test/test_type_identifier.cpp
@@ -9,7 +9,7 @@ using namespace type_graph;
 TEST(TypeIdentifierTest, StubbedParam) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myparam = Class{Class::Kind::Struct, "MyParam", 4};
+  auto myparam = Class{1, Class::Kind::Struct, "MyParam", 4};
   myparam.members.push_back(Member{&myint, "a", 0});
 
   auto container = getVector();
@@ -42,7 +42,7 @@ TEST(TypeIdentifierTest, StubbedParam) {
 TEST(TypeIdentifierTest, Allocator) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myalloc = Class{Class::Kind::Struct, "MyAlloc", 8};
+  auto myalloc = Class{1, Class::Kind::Struct, "MyAlloc", 8};
   myalloc.templateParams.push_back(TemplateParam{&myint});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
@@ -80,7 +80,7 @@ TEST(TypeIdentifierTest, Allocator) {
 TEST(TypeIdentifierTest, AllocatorSize1) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
-  auto myalloc = Class{Class::Kind::Struct, "MyAlloc", 1};
+  auto myalloc = Class{1, Class::Kind::Struct, "MyAlloc", 1};
   myalloc.templateParams.push_back(TemplateParam{&myint});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});

--- a/test/type_graph_utils.cpp
+++ b/test/type_graph_utils.cpp
@@ -8,6 +8,7 @@
 #include "oi/type_graph/TypeGraph.h"
 
 using type_graph::Container;
+using type_graph::NodeId;
 using type_graph::Pass;
 using type_graph::Type;
 using type_graph::TypeGraph;
@@ -54,20 +55,20 @@ void test(type_graph::Pass pass,
   test(pass, rootTypes, {}, expectedAfter);
 }
 
-Container getVector() {
+Container getVector(NodeId id) {
   static ContainerInfo info{"std::vector", SEQ_TYPE, "vector"};
   info.stubTemplateParams = {1};
-  return Container{info, 24};
+  return Container{id, info, 24};
 }
 
-Container getMap() {
+Container getMap(NodeId id) {
   static ContainerInfo info{"std::map", STD_MAP_TYPE, "map"};
   info.stubTemplateParams = {2, 3};
-  return Container{info, 48};
+  return Container{id, info, 48};
 }
 
-Container getList() {
+Container getList(NodeId id) {
   static ContainerInfo info{"std::list", LIST_TYPE, "list"};
   info.stubTemplateParams = {1};
-  return Container{info, 24};
+  return Container{id, info, 24};
 }

--- a/test/type_graph_utils.h
+++ b/test/type_graph_utils.h
@@ -4,10 +4,10 @@
 #include <string_view>
 #include <vector>
 
+#include "oi/type_graph/Types.h"
+
 namespace type_graph {
-class Container;
 class Pass;
-class Type;
 }  // namespace type_graph
 
 void check(const std::vector<std::reference_wrapper<type_graph::Type>>& types,
@@ -23,6 +23,6 @@ void test(type_graph::Pass pass,
           std::vector<std::reference_wrapper<type_graph::Type>> rootTypes,
           std::string_view expectedAfter);
 
-type_graph::Container getVector();
-type_graph::Container getMap();
-type_graph::Container getList();
+type_graph::Container getVector(type_graph::NodeId id = 0);
+type_graph::Container getMap(type_graph::NodeId id = 0);
+type_graph::Container getList(type_graph::NodeId id = 0);


### PR DESCRIPTION
These aren't used for anything yet, but should be useful for stable IDs when printing nodes before and after passes and for faster cycle detection than the current map of pointers.