### PR TITLE
TypeGraph: Switch from pointers to references

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -219,7 +219,8 @@ void CodeGen::genDefsThrift(const TypeGraph& typeGraph, std::string& code) {
     if (const auto* c = dynamic_cast<const Class*>(&t)) {
       const Member* issetMember = nullptr;
       for (const auto& member : c->members) {
-        if (const auto* container = dynamic_cast<const Container*>(member.type);
+        if (const auto* container =
+                dynamic_cast<const Container*>(&member.type());
             container && container->containerInfo_.ctype == THRIFT_ISSET_TYPE) {
           issetMember = &member;
           break;
@@ -247,7 +248,7 @@ void genDefsClass(const Class& c, std::string& code) {
 
   code += c.name() + " {\n";
   for (const auto& mem : c.members) {
-    code += "  " + mem.type->name() + " " + mem.name;
+    code += "  " + mem.type().name() + " " + mem.name;
     if (mem.bitsize) {
       code += " : " + std::to_string(mem.bitsize);
     }
@@ -257,7 +258,7 @@ void genDefsClass(const Class& c, std::string& code) {
 }
 
 void genDefsTypedef(const Typedef& td, std::string& code) {
-  code += "using " + td.name() + " = " + td.underlyingType()->name() + ";\n";
+  code += "using " + td.name() + " = " + td.underlyingType().name() + ";\n";
 }
 
 void genDefs(const TypeGraph& typeGraph, std::string& code) {
@@ -758,8 +759,8 @@ void CodeGen::addDrgnRoot(struct drgn_type* drgnType,
                           type_graph::TypeGraph& typeGraph) {
   type_graph::DrgnParser drgnParser{
       typeGraph, containerInfos_, config_.features[Feature::ChaseRawPointers]};
-  Type* parsedRoot = drgnParser.parse(drgnType);
-  typeGraph.addRoot(*parsedRoot);
+  Type& parsedRoot = drgnParser.parse(drgnType);
+  typeGraph.addRoot(parsedRoot);
 }
 
 void CodeGen::transform(type_graph::TypeGraph& typeGraph) {

--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -31,7 +31,7 @@ class SymbolService;
 
 namespace type_graph {
 class Class;
-struct Member;
+class Member;
 class TypeGraph;
 }  // namespace type_graph
 

--- a/oi/type_graph/AddChildren.cpp
+++ b/oi/type_graph/AddChildren.cpp
@@ -53,10 +53,10 @@ void AddChildren::visit(Type& type) {
 
 void AddChildren::visit(Class& c) {
   for (auto& param : c.templateParams) {
-    visit(param.type);
+    visit(param.type());
   }
   for (auto& member : c.members) {
-    visit(*member.type);
+    visit(member.type());
   }
 
   if (!c.isDynamic()) {
@@ -70,10 +70,10 @@ void AddChildren::visit(Class& c) {
 
   const auto& drgnChildren = it->second;
   for (drgn_type* drgnChild : drgnChildren) {
-    Type* childType = drgnParser_.parse(drgnChild);
+    Type& childType = drgnParser_.parse(drgnChild);
     auto* childClass =
-        dynamic_cast<Class*>(childType);  // TODO don't use dynamic_cast
-    if (!childClass)                      // TODO dodgy error handling
+        dynamic_cast<Class*>(&childType);  // TODO don't use dynamic_cast
+    if (!childClass)                       // TODO dodgy error handling
       abort();
     c.children.push_back(*childClass);
 

--- a/oi/type_graph/AddPadding.cpp
+++ b/oi/type_graph/AddPadding.cpp
@@ -50,10 +50,10 @@ void AddPadding::visit(Class& c) {
   assert(c.parents.empty());
 
   for (auto& param : c.templateParams) {
-    visit(param.type);
+    visit(param.type());
   }
   for (auto& member : c.members) {
-    visit(*member.type);
+    visit(member.type());
   }
 
   if (c.kind() == Class::Kind::Union) {
@@ -86,7 +86,7 @@ void AddPadding::addPadding(const Member& prevMember,
                             std::vector<Member>& paddedMembers) {
   uint64_t prevMemberSizeBits;
   if (prevMember.bitsize == 0) {
-    prevMemberSizeBits = prevMember.type->size() * 8;
+    prevMemberSizeBits = prevMember.type().size() * 8;
   } else {
     prevMemberSizeBits = prevMember.bitsize;
   }
@@ -98,12 +98,12 @@ void AddPadding::addPadding(const Member& prevMember,
 
   if (paddingBits % 8 == 0) {
     // Pad with an array of bytes
-    auto* primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int8);
-    auto* paddingArray = typeGraph_.makeType<Array>(primitive, paddingBits / 8);
+    auto& primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int8);
+    auto& paddingArray = typeGraph_.makeType<Array>(primitive, paddingBits / 8);
     paddedMembers.emplace_back(paddingArray, MemberPrefix, prevMemberEndBits);
   } else {
     // Pad with a bitfield
-    auto* primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int64);
+    auto& primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int64);
     paddedMembers.emplace_back(primitive, MemberPrefix, prevMemberEndBits,
                                paddingBits);
   }

--- a/oi/type_graph/AlignmentCalc.cpp
+++ b/oi/type_graph/AlignmentCalc.cpp
@@ -58,8 +58,8 @@ void AlignmentCalc::visit(Class& c) {
     if (member.align == 0) {
       // If the member does not have an explicit alignment, calculate it from
       // the member's type.
-      visit(*member.type);
-      member.align = member.type->align();
+      visit(member.type());
+      member.align = member.type().align();
     }
     alignment = std::max(alignment, member.align);
   }

--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -38,18 +38,18 @@ class DrgnParser {
         containers_(containers),
         chaseRawPointers_(chaseRawPointers) {
   }
-  Type* parse(struct drgn_type* root);
+  Type& parse(struct drgn_type* root);
 
  private:
-  Type* enumerateType(struct drgn_type* type);
+  Type& enumerateType(struct drgn_type* type);
   Container* enumerateContainer(struct drgn_type* type,
                                 const std::string& fqName);
-  Type* enumerateClass(struct drgn_type* type);
-  Enum* enumerateEnum(struct drgn_type* type);
-  Typedef* enumerateTypedef(struct drgn_type* type);
-  Type* enumeratePointer(struct drgn_type* type);
-  Array* enumerateArray(struct drgn_type* type);
-  Primitive* enumeratePrimitive(struct drgn_type* type);
+  Type& enumerateClass(struct drgn_type* type);
+  Enum& enumerateEnum(struct drgn_type* type);
+  Typedef& enumerateTypedef(struct drgn_type* type);
+  Type& enumeratePointer(struct drgn_type* type);
+  Array& enumerateArray(struct drgn_type* type);
+  Primitive& enumeratePrimitive(struct drgn_type* type);
 
   void enumerateTemplateParam(drgn_type_template_parameter* tparams,
                               size_t i,
@@ -65,13 +65,14 @@ class DrgnParser {
 
   // Store a mapping of drgn types to type graph nodes for deduplication during
   // parsing. This stops us getting caught in cycles.
-  std::unordered_map<struct drgn_type*, Type*> drgn_types_;
+  std::unordered_map<struct drgn_type*, std::reference_wrapper<Type>>
+      drgn_types_;
 
   template <typename T, typename... Args>
-  T* makeType(struct drgn_type* type, Args&&... args) {
-    auto* type_raw_ptr = typeGraph_.makeType<T>(std::forward<Args>(args)...);
-    drgn_types_.insert({type, type_raw_ptr});
-    return type_raw_ptr;
+  T& makeType(struct drgn_type* drgnType, Args&&... args) {
+    auto& newType = typeGraph_.makeType<T>(std::forward<Args>(args)...);
+    drgn_types_.insert({drgnType, newType});
+    return newType;
   }
   bool chasePointer() const;
 

--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -69,13 +69,13 @@ void NameGen::visit(Class& c) {
   }
 
   for (const auto& param : c.templateParams) {
-    visit(param.type);
+    visit(param.type());
   }
   for (const auto& parent : c.parents) {
-    visit(*parent.type);
+    visit(parent.type());
   }
   for (const auto& member : c.members) {
-    visit(*member.type);
+    visit(member.type());
   }
   for (const auto& child : c.children) {
     visit(child);
@@ -88,7 +88,7 @@ void NameGen::visit(Container& c) {
   }
 
   for (const auto& template_param : c.templateParams) {
-    visit(template_param.type);
+    visit(template_param.type());
   }
 
   std::string name = c.name();
@@ -102,7 +102,7 @@ void NameGen::visit(Container& c) {
       if (param.qualifiers[Qualifier::Const]) {
         name += "const ";
       }
-      name += param.type->name();
+      name += param.type()->name();
     }
     name += ", ";
   }
@@ -130,7 +130,7 @@ void NameGen::visit(Typedef& td) {
   // Append an incrementing number to ensure we don't get duplicates
   td.setName(name + "_" + std::to_string(n++));
 
-  visit(*td.underlyingType());
+  visit(td.underlyingType());
 }
 
 }  // namespace type_graph

--- a/oi/type_graph/Printer.cpp
+++ b/oi/type_graph/Printer.cpp
@@ -100,7 +100,7 @@ void Printer::visit(const Array& a) {
     return;
 
   out_ << "Array: (length: " << a.len() << ")" << std::endl;
-  print(*a.elementType());
+  print(a.elementType());
 }
 
 void Printer::visit(const Typedef& td) {
@@ -108,7 +108,7 @@ void Printer::visit(const Typedef& td) {
     return;
 
   out_ << "Typedef: " << td.name() << std::endl;
-  print(*td.underlyingType());
+  print(td.underlyingType());
 }
 
 void Printer::visit(const Pointer& p) {
@@ -116,7 +116,7 @@ void Printer::visit(const Pointer& p) {
     return;
 
   out_ << "Pointer" << std::endl;
-  print(*p.pointeeType());
+  print(p.pointeeType());
 }
 
 void Printer::visit(const Dummy& d) {
@@ -162,7 +162,7 @@ void Printer::print_param(const TemplateParam& param) {
   if (param.value) {
     print_value(*param.value);
   } else {
-    print(*param.type);
+    print(*param.type());
   }
   print_qualifiers(param.qualifiers);
   depth_--;
@@ -173,7 +173,7 @@ void Printer::print_parent(const Parent& parent) {
   prefix();
   out_ << "Parent (offset: " << static_cast<double>(parent.bitOffset) / 8 << ")"
        << std::endl;
-  print(*parent.type);
+  print(parent.type());
   depth_--;
 }
 
@@ -187,7 +187,7 @@ void Printer::print_member(const Member& member) {
     out_ << ", bitsize: " << member.bitsize;
   }
   out_ << ")" << std::endl;
-  print(*member.type);
+  print(member.type());
   depth_--;
 }
 

--- a/oi/type_graph/RemoveIgnored.cpp
+++ b/oi/type_graph/RemoveIgnored.cpp
@@ -44,9 +44,9 @@ void RemoveIgnored::visit(Class& c) {
     if (!ignoreMember(c.name(), c.members[i].name)) {
       continue;
     }
-    auto* primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int8);
-    auto* paddingArray =
-        typeGraph_.makeType<Array>(primitive, c.members[i].type->size());
+    auto& primitive = typeGraph_.makeType<Primitive>(Primitive::Kind::Int8);
+    auto& paddingArray =
+        typeGraph_.makeType<Array>(primitive, c.members[i].type().size());
     c.members[i] =
         Member{paddingArray, c.members[i].name, c.members[i].bitOffset};
   }

--- a/oi/type_graph/RemoveTopLevelPointer.cpp
+++ b/oi/type_graph/RemoveTopLevelPointer.cpp
@@ -39,7 +39,7 @@ void RemoveTopLevelPointer::removeTopLevelPointers(
 }
 
 void RemoveTopLevelPointer::visit(Pointer& p) {
-  topLevelType_ = p.pointeeType();
+  topLevelType_ = &p.pointeeType();
 }
 
 }  // namespace type_graph

--- a/oi/type_graph/TopoSorter.cpp
+++ b/oi/type_graph/TopoSorter.cpp
@@ -56,13 +56,13 @@ void TopoSorter::visit(Type& type) {
 
 void TopoSorter::visit(Class& c) {
   for (const auto& parent : c.parents) {
-    visit(*parent.type);
+    visit(parent.type());
   }
   for (const auto& mem : c.members) {
-    visit(*mem.type);
+    visit(mem.type());
   }
   for (const auto& param : c.templateParams) {
-    visit(param.type);
+    visit(param.type());
   }
   sortedTypes_.push_back(c);
 
@@ -97,13 +97,13 @@ bool containerAllowsIncompleteParams(const Container& c) {
 void TopoSorter::visit(Container& c) {
   if (!containerAllowsIncompleteParams(c)) {
     for (const auto& param : c.templateParams) {
-      visit(param.type);
+      visit(param.type());
     }
   }
   sortedTypes_.push_back(c);
   if (containerAllowsIncompleteParams(c)) {
     for (const auto& param : c.templateParams) {
-      visitAfter(param.type);
+      visitAfter(param.type());
     }
   }
 }
@@ -113,14 +113,14 @@ void TopoSorter::visit(Enum& e) {
 }
 
 void TopoSorter::visit(Typedef& td) {
-  visit(*td.underlyingType());
+  visit(td.underlyingType());
   sortedTypes_.push_back(td);
 }
 
 void TopoSorter::visit(Pointer& p) {
   // Pointers do not create a dependency, but we do still care about the types
   // they point to, so delay them until the end.
-  visitAfter(*p.pointeeType());
+  visitAfter(p.pointeeType());
 }
 
 /*

--- a/oi/type_graph/TypeGraph.cpp
+++ b/oi/type_graph/TypeGraph.cpp
@@ -18,53 +18,53 @@
 namespace type_graph {
 
 template <>
-Primitive* TypeGraph::makeType<Primitive>(Primitive::Kind kind) {
+Primitive& TypeGraph::makeType<Primitive>(Primitive::Kind kind) {
   switch (kind) {
     case Primitive::Kind::Int8:
       static Primitive pInt8{kind};
-      return &pInt8;
+      return pInt8;
     case Primitive::Kind::Int16:
       static Primitive pInt16{kind};
-      return &pInt16;
+      return pInt16;
     case Primitive::Kind::Int32:
       static Primitive pInt32{kind};
-      return &pInt32;
+      return pInt32;
     case Primitive::Kind::Int64:
       static Primitive pInt64{kind};
-      return &pInt64;
+      return pInt64;
     case Primitive::Kind::UInt8:
       static Primitive pUInt8{kind};
-      return &pUInt8;
+      return pUInt8;
     case Primitive::Kind::UInt16:
       static Primitive pUInt16{kind};
-      return &pUInt16;
+      return pUInt16;
     case Primitive::Kind::UInt32:
       static Primitive pUInt32{kind};
-      return &pUInt32;
+      return pUInt32;
     case Primitive::Kind::UInt64:
       static Primitive pUInt64{kind};
-      return &pUInt64;
+      return pUInt64;
     case Primitive::Kind::Float32:
       static Primitive pFloat32{kind};
-      return &pFloat32;
+      return pFloat32;
     case Primitive::Kind::Float64:
       static Primitive pFloat64{kind};
-      return &pFloat64;
+      return pFloat64;
     case Primitive::Kind::Float80:
       static Primitive pFloat80{kind};
-      return &pFloat80;
+      return pFloat80;
     case Primitive::Kind::Float128:
       static Primitive pFloat128{kind};
-      return &pFloat128;
+      return pFloat128;
     case Primitive::Kind::Bool:
       static Primitive pBool{kind};
-      return &pBool;
+      return pBool;
     case Primitive::Kind::UIntPtr:
       static Primitive pUIntPtr{kind};
-      return &pUIntPtr;
+      return pUIntPtr;
     case Primitive::Kind::Void:
       static Primitive pVoid{kind};
-      return &pVoid;
+      return pVoid;
   }
 }
 

--- a/oi/type_graph/TypeGraph.h
+++ b/oi/type_graph/TypeGraph.h
@@ -50,10 +50,10 @@ class TypeGraph {
   // Override of the generic makeType function that returns singleton Primitive
   // objects
   template <typename T>
-  Primitive* makeType(Primitive::Kind kind);
+  Primitive& makeType(Primitive::Kind kind);
 
   template <typename T, typename... Args>
-  T* makeType(Args&&... args) {
+  T& makeType(Args&&... args) {
     static_assert(!std::is_same<T, Primitive>::value,
                   "Primitive singleton override should be used");
     if constexpr (std::is_same<T, Class>::value ||
@@ -66,13 +66,13 @@ class TypeGraph {
           std::make_unique<T>(next_id_++, std::forward<Args>(args)...);
       auto type_raw_ptr = type_unique_ptr.get();
       types_.push_back(std::move(type_unique_ptr));
-      return type_raw_ptr;
+      return *type_raw_ptr;
     } else {
       // No Node ID
       auto type_unique_ptr = std::make_unique<T>(std::forward<Args>(args)...);
       auto type_raw_ptr = type_unique_ptr.get();
       types_.push_back(std::move(type_unique_ptr));
-      return type_raw_ptr;
+      return *type_raw_ptr;
     }
   }
 

--- a/oi/type_graph/Visitor.h
+++ b/oi/type_graph/Visitor.h
@@ -64,13 +64,13 @@ class RecursiveVisitor : public Visitor {
   }
   virtual void visit(Class& c) {
     for (const auto& param : c.templateParams) {
-      visit(param.type);
+      visit(param.type());
     }
     for (const auto& parent : c.parents) {
-      visit(*parent.type);
+      visit(parent.type());
     }
     for (const auto& mem : c.members) {
-      visit(*mem.type);
+      visit(mem.type());
     }
     for (const auto& child : c.children) {
       visit(child);
@@ -78,7 +78,7 @@ class RecursiveVisitor : public Visitor {
   }
   virtual void visit(Container& c) {
     for (const auto& param : c.templateParams) {
-      visit(param.type);
+      visit(param.type());
     }
   }
   virtual void visit(Primitive&) {
@@ -86,13 +86,13 @@ class RecursiveVisitor : public Visitor {
   virtual void visit(Enum&) {
   }
   virtual void visit(Array& a) {
-    visit(*a.elementType());
+    visit(a.elementType());
   }
   virtual void visit(Typedef& td) {
-    visit(*td.underlyingType());
+    visit(td.underlyingType());
   }
   virtual void visit(Pointer& p) {
-    visit(*p.pointeeType());
+    visit(p.pointeeType());
   }
   virtual void visit(Dummy&) {
   }

--- a/test/test_add_padding.cpp
+++ b/test/test_add_padding.cpp
@@ -10,8 +10,8 @@ TEST(AddPaddingTest, BetweenMembers) {
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
-  myclass.members.push_back(Member(&myint8, "n1", 0));
-  myclass.members.push_back(Member(&myint64, "n2", 8 * 8));
+  myclass.members.push_back(Member{myint8, "n1", 0});
+  myclass.members.push_back(Member{myint64, "n2", 8 * 8});
 
   test(AddPadding::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 16)
@@ -29,8 +29,8 @@ TEST(AddPaddingTest, AtEnd) {
   auto myclass = Class{0, Class::Kind::Struct, "MyStruct", 16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
-  myclass.members.push_back(Member(&myint64, "n1", 0));
-  myclass.members.push_back(Member(&myint8, "n2", 8 * 8));
+  myclass.members.push_back(Member{myint64, "n1", 0});
+  myclass.members.push_back(Member{myint8, "n2", 8 * 8});
 
   test(AddPadding::createPass(), {myclass}, R"(
 [0] Struct: MyStruct (size: 16)
@@ -48,8 +48,8 @@ TEST(AddPaddingTest, UnionNotPadded) {
   auto myclass = Class{0, Class::Kind::Union, "MyUnion", 8};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
-  myclass.members.push_back(Member(&myint64, "n1", 0));
-  myclass.members.push_back(Member(&myint8, "n2", 0));
+  myclass.members.push_back(Member{myint64, "n1", 0});
+  myclass.members.push_back(Member{myint8, "n2", 0});
 
   test(AddPadding::createPass(), {myclass}, R"(
 [0] Union: MyUnion (size: 8)
@@ -66,19 +66,19 @@ TEST(AddPaddingTest, Bitfields) {
   auto myint16 = Primitive{Primitive::Kind::Int16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
 
-  Member b1{&myint64, "b1", 0};
+  Member b1{myint64, "b1", 0};
   b1.bitsize = 3;
-  Member b2{&myint8, "b2", 3};
+  Member b2{myint8, "b2", 3};
   b2.bitsize = 2;
   // There may be a 0-sized bitfield between these two that does not appear
   // in the DWARF. This would add padding and push b3 to the next byte.
-  Member b3{&myint8, "b3", 8};
+  Member b3{myint8, "b3", 8};
   b3.bitsize = 1;
 
-  Member b4{&myint64, "b4", 8 * 8};
+  Member b4{myint64, "b4", 8 * 8};
   b4.bitsize = 24;
 
-  Member n{&myint16, "n", 12 * 8};
+  Member n{myint16, "n", 12 * 8};
 
   myclass.members.push_back(b1);
   myclass.members.push_back(b2);

--- a/test/test_alignment_calc.cpp
+++ b/test/test_alignment_calc.cpp
@@ -9,8 +9,8 @@ TEST(AlignmentCalcTest, PrimitiveMembers) {
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
-  myclass.members.push_back(Member(&myint8, "n", 0));
-  myclass.members.push_back(Member(&myint64, "n", 8 * 8));
+  myclass.members.push_back(Member{myint8, "n", 0});
+  myclass.members.push_back(Member{myint64, "n", 8 * 8});
 
   test(AlignmentCalc::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 16, align: 8)
@@ -24,13 +24,13 @@ TEST(AlignmentCalcTest, PrimitiveMembers) {
 TEST(AlignmentCalcTest, StructMembers) {
   auto mystruct = Class{1, Class::Kind::Struct, "MyStruct", 8};
   auto myint32 = Primitive{Primitive::Kind::Int32};
-  mystruct.members.push_back(Member(&myint32, "n1", 0));
-  mystruct.members.push_back(Member(&myint32, "n2", 4 * 8));
+  mystruct.members.push_back(Member{myint32, "n1", 0});
+  mystruct.members.push_back(Member{myint32, "n2", 4 * 8});
 
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 12};
   auto myint8 = Primitive{Primitive::Kind::Int8};
-  myclass.members.push_back(Member(&myint8, "n", 0));
-  myclass.members.push_back(Member(&mystruct, "s", 4 * 8));
+  myclass.members.push_back(Member{myint8, "n", 0});
+  myclass.members.push_back(Member{mystruct, "s", 4 * 8});
 
   test(AlignmentCalc::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 12, align: 4)
@@ -49,11 +49,11 @@ TEST(AlignmentCalcTest, StructInContainer) {
   auto myclass = Class{1, Class::Kind::Class, "MyClass", 16};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
-  myclass.members.push_back(Member(&myint8, "n", 0));
-  myclass.members.push_back(Member(&myint64, "n", 8 * 8));
+  myclass.members.push_back(Member{myint8, "n", 0});
+  myclass.members.push_back(Member{myint64, "n", 8 * 8});
 
   auto mycontainer = Container{0, ContainerInfo{}, 8};
-  mycontainer.templateParams.push_back(&myclass);
+  mycontainer.templateParams.push_back(myclass);
 
   test(AlignmentCalc::createPass(), {mycontainer}, R"(
 [0] Container:  (size: 8)
@@ -70,8 +70,8 @@ TEST(AlignmentCalcTest, Packed) {
   auto mystruct = Class{0, Class::Kind::Struct, "MyStruct", 9};
   auto myint8 = Primitive{Primitive::Kind::Int8};
   auto myint64 = Primitive{Primitive::Kind::Int64};
-  mystruct.members.push_back(Member(&myint8, "n1", 0));
-  mystruct.members.push_back(Member(&myint64, "n2", 1 * 8));
+  mystruct.members.push_back(Member{myint8, "n1", 0});
+  mystruct.members.push_back(Member{myint64, "n2", 1 * 8});
 
   test(AlignmentCalc::createPass(), {mystruct}, R"(
 [0] Struct: MyStruct (size: 9, align: 8, packed)

--- a/test/test_codegen.cpp
+++ b/test/test_codegen.cpp
@@ -39,13 +39,13 @@ TEST(CodeGenTest, TransformContainerAllocator) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto myalloc = Class{1, Class::Kind::Struct, "MyAlloc", 8};
-  myalloc.templateParams.push_back(TemplateParam{&myint});
+  myalloc.templateParams.push_back(TemplateParam{myint});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
 
   auto container = getVector();
-  container.templateParams.push_back(TemplateParam{&myint});
-  container.templateParams.push_back(TemplateParam{&myalloc});
+  container.templateParams.push_back(TemplateParam{myint});
+  container.templateParams.push_back(TemplateParam{myalloc});
 
   testTransform(container, R"(
 [0] Container: std::vector (size: 24)
@@ -77,25 +77,25 @@ TEST(CodeGenTest, TransformContainerAllocatorParamInParent) {
   Primitive myint{Primitive::Kind::Int32};
 
   Container pair{3, pairInfo, 8};
-  pair.templateParams.push_back(TemplateParam{&myint, {Qualifier::Const}});
-  pair.templateParams.push_back(TemplateParam{&myint});
+  pair.templateParams.push_back(TemplateParam{myint, {Qualifier::Const}});
+  pair.templateParams.push_back(TemplateParam{myint});
 
   Class myallocBase{2, Class::Kind::Struct,
                     "MyAllocBase<std::pair<const int, int>>", 1};
-  myallocBase.templateParams.push_back(TemplateParam{&pair});
+  myallocBase.templateParams.push_back(TemplateParam{pair});
   myallocBase.functions.push_back(Function{"allocate"});
   myallocBase.functions.push_back(Function{"deallocate"});
 
   Class myalloc{1, Class::Kind::Struct, "MyAlloc<std::pair<const int, int>>",
                 1};
-  myalloc.parents.push_back(Parent{&myallocBase, 0});
+  myalloc.parents.push_back(Parent{myallocBase, 0});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
 
   Container map{0, mapInfo, 24};
-  map.templateParams.push_back(TemplateParam{&myint});
-  map.templateParams.push_back(TemplateParam{&myint});
-  map.templateParams.push_back(TemplateParam{&myalloc});
+  map.templateParams.push_back(TemplateParam{myint});
+  map.templateParams.push_back(TemplateParam{myint});
+  map.templateParams.push_back(TemplateParam{myalloc});
 
   testTransform(map, R"(
 [0] Container: std::map (size: 24)

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -63,11 +63,11 @@ std::string DrgnParserTest::run(std::string_view function,
   containers.emplace_back(std::move(std_vector));
 
   DrgnParser drgnParser(typeGraph, containers, chaseRawPointers);
-  Type* type = drgnParser.parse(drgnRoot->type.type);
+  Type& type = drgnParser.parse(drgnRoot->type.type);
 
   std::stringstream out;
   Printer printer{out, typeGraph.size()};
-  printer.print(*type);
+  printer.print(type);
 
   return out.str();
 }

--- a/test/test_flattener.cpp
+++ b/test/test_flattener.cpp
@@ -19,11 +19,11 @@ TEST(FlattenerTest, NoParents) {
   auto mystruct = Class{1, Class::Kind::Struct, "MyStruct", 4};
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 12};
 
-  mystruct.members.push_back(Member(&myint, "n0", 0));
+  mystruct.members.push_back(Member{myint, "n0", 0});
 
-  myclass.members.push_back(Member(&myint, "n", 0));
-  myclass.members.push_back(Member(&myenum, "e", 4 * 8));
-  myclass.members.push_back(Member(&mystruct, "mystruct", 8 * 8));
+  myclass.members.push_back(Member{myint, "n", 0});
+  myclass.members.push_back(Member{myenum, "e", 4 * 8});
+  myclass.members.push_back(Member{mystruct, "mystruct", 8 * 8});
 
   test(Flattener::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 12)
@@ -54,11 +54,11 @@ TEST(FlattenerTest, OnlyParents) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
-  classB.members.push_back(Member(&myint, "b", 0));
+  classC.members.push_back(Member{myint, "c", 0});
+  classB.members.push_back(Member{myint, "b", 0});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.parents.push_back(Parent(&classC, 4 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{classC, 4 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 8)
@@ -86,12 +86,12 @@ TEST(FlattenerTest, ParentsFirst) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
-  classB.members.push_back(Member(&myint, "b", 0));
+  classC.members.push_back(Member{myint, "c", 0});
+  classB.members.push_back(Member{myint, "b", 0});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.parents.push_back(Parent(&classC, 4 * 8));
-  classA.members.push_back(Member(&myint, "a", 8 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{classC, 4 * 8});
+  classA.members.push_back(Member{myint, "a", 8 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
@@ -121,13 +121,13 @@ TEST(FlattenerTest, MembersFirst) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  classB.members.push_back(Member(&myint, "b", 0));
+  classB.members.push_back(Member{myint, "b", 0});
 
-  classA.members.push_back(Member(&myint, "a", 0));
-  classA.parents.push_back(Parent(&classB, 4 * 8));
-  classA.parents.push_back(Parent(&classC, 8 * 8));
+  classA.members.push_back(Member{myint, "a", 0});
+  classA.parents.push_back(Parent{classB, 4 * 8});
+  classA.parents.push_back(Parent{classC, 8 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
@@ -158,14 +158,14 @@ TEST(FlattenerTest, MixedMembersAndParents) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  classB.members.push_back(Member(&myint, "b", 0));
+  classB.members.push_back(Member{myint, "b", 0});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.members.push_back(Member(&myint, "a1", 4 * 8));
-  classA.members.push_back(Member(&myint, "a2", 8 * 8));
-  classA.parents.push_back(Parent(&classC, 12 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.members.push_back(Member{myint, "a1", 4 * 8});
+  classA.members.push_back(Member{myint, "a2", 8 * 8});
+  classA.parents.push_back(Parent{classC, 12 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 16)
@@ -197,12 +197,12 @@ TEST(FlattenerTest, EmptyParent) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 0};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  classA.members.push_back(Member(&myint, "a1", 4 * 8));
-  classA.members.push_back(Member(&myint, "a2", 8 * 8));
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.parents.push_back(Parent(&classC, 0));
+  classA.members.push_back(Member{myint, "a1", 4 * 8});
+  classA.members.push_back(Member{myint, "a2", 8 * 8});
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{classC, 0});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
@@ -235,16 +235,16 @@ TEST(FlattenerTest, TwoDeep) {
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
   auto classD = Class{3, Class::Kind::Class, "ClassD", 4};
 
-  classD.members.push_back(Member(&myint, "d", 0));
+  classD.members.push_back(Member{myint, "d", 0});
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  classB.parents.push_back(Parent(&classD, 0));
-  classB.members.push_back(Member(&myint, "b", 4 * 8));
+  classB.parents.push_back(Parent{classD, 0});
+  classB.members.push_back(Member{myint, "b", 4 * 8});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.parents.push_back(Parent(&classC, 8 * 8));
-  classA.members.push_back(Member(&myint, "a", 12 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{classC, 8 * 8});
+  classA.members.push_back(Member{myint, "a", 12 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 16)
@@ -277,14 +277,14 @@ TEST(FlattenerTest, DiamondInheritance) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 8};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  classB.parents.push_back(Parent(&classC, 0));
-  classB.members.push_back(Member(&myint, "b", 4 * 8));
+  classB.parents.push_back(Parent{classC, 0});
+  classB.members.push_back(Member{myint, "b", 4 * 8});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.parents.push_back(Parent(&classC, 8 * 8));
-  classA.members.push_back(Member(&myint, "a", 12 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{classC, 8 * 8});
+  classA.members.push_back(Member{myint, "a", 12 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 16)
@@ -313,13 +313,13 @@ TEST(FlattenerTest, Member) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 8};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  classB.parents.push_back(Parent(&classC, 0));
-  classB.members.push_back(Member(&myint, "b", 4 * 8));
+  classB.parents.push_back(Parent{classC, 0});
+  classB.members.push_back(Member{myint, "b", 4 * 8});
 
-  classA.members.push_back(Member(&myint, "a", 0));
-  classA.members.push_back(Member(&classB, "b", 4 * 8));
+  classA.members.push_back(Member{myint, "a", 0});
+  classA.members.push_back(Member{classB, "b", 4 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
@@ -348,13 +348,13 @@ TEST(FlattenerTest, MemberOfParent) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 8};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  classB.members.push_back(Member(&myint, "b", 0));
-  classB.members.push_back(Member(&classC, "c", 4 * 8));
+  classB.members.push_back(Member{myint, "b", 0});
+  classB.members.push_back(Member{classC, "c", 4 * 8});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.members.push_back(Member(&myint, "a", 8 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.members.push_back(Member{myint, "a", 8 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
@@ -383,13 +383,13 @@ TEST(FlattenerTest, ContainerParam) {
   auto classB = Class{2, Class::Kind::Class, "ClassB", 4};
   auto container = getVector();
 
-  classB.members.push_back(Member(&myint, "b", 0));
+  classB.members.push_back(Member{myint, "b", 0});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.members.push_back(Member(&myint, "a", 4 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.members.push_back(Member{myint, "a", 4 * 8});
 
-  container.templateParams.push_back(TemplateParam(&classA));
-  container.templateParams.push_back(TemplateParam(&myint));
+  container.templateParams.push_back(TemplateParam{classA});
+  container.templateParams.push_back(TemplateParam{myint});
 
   test(Flattener::createPass(), {container}, R"(
 [0] Container: std::vector (size: 24)
@@ -412,13 +412,13 @@ TEST(FlattenerTest, Array) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto classB = Class{2, Class::Kind::Class, "ClassB", 4};
-  classB.members.push_back(Member(&myint, "b", 0));
+  classB.members.push_back(Member{myint, "b", 0});
 
   auto classA = Class{1, Class::Kind::Class, "ClassA", 8};
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.members.push_back(Member(&myint, "a", 4 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.members.push_back(Member{myint, "a", 4 * 8});
 
-  auto arrayA = Array{0, &classA, 5};
+  auto arrayA = Array{0, classA, 5};
 
   test(Flattener::createPass(), {arrayA}, R"(
 [0] Array: (length: 5)
@@ -437,13 +437,13 @@ TEST(FlattenerTest, Typedef) {
   //   using aliasA = A;
   auto myint = Primitive{Primitive::Kind::Int32};
   auto classB = Class{2, Class::Kind::Class, "ClassB", 4};
-  classB.members.push_back(Member(&myint, "b", 0));
+  classB.members.push_back(Member{myint, "b", 0});
 
   auto classA = Class{1, Class::Kind::Class, "ClassA", 8};
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.members.push_back(Member(&myint, "a", 4 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.members.push_back(Member{myint, "a", 4 * 8});
 
-  auto aliasA = Typedef{0, "aliasA", &classA};
+  auto aliasA = Typedef{0, "aliasA", classA};
 
   test(Flattener::createPass(), {aliasA}, R"(
 [0] Typedef: aliasA
@@ -462,13 +462,13 @@ TEST(FlattenerTest, TypedefParent) {
   //   class A : aliasB { int a; };
   auto myint = Primitive{Primitive::Kind::Int32};
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
-  classB.members.push_back(Member(&myint, "b", 0));
+  classB.members.push_back(Member{myint, "b", 0});
 
-  auto aliasB = Typedef{2, "aliasB", &classB};
+  auto aliasB = Typedef{2, "aliasB", classB};
 
   auto classA = Class{0, Class::Kind::Class, "ClassA", 8};
-  classA.parents.push_back(Parent(&aliasB, 0));
-  classA.members.push_back(Member(&myint, "a", 4 * 8));
+  classA.parents.push_back(Parent{aliasB, 0});
+  classA.members.push_back(Member{myint, "a", 4 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 8)
@@ -487,15 +487,15 @@ TEST(FlattenerTest, Pointer) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto classB = Class{3, Class::Kind::Class, "ClassB", 4};
-  classB.members.push_back(Member(&myint, "b", 0));
+  classB.members.push_back(Member{myint, "b", 0});
 
   auto classA = Class{2, Class::Kind::Class, "ClassA", 8};
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.members.push_back(Member(&myint, "a", 4 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.members.push_back(Member{myint, "a", 4 * 8});
 
-  auto ptrA = Pointer{1, &classA};
+  auto ptrA = Pointer{1, classA};
   auto classC = Class{0, Class::Kind::Class, "ClassC", 8};
-  classC.members.push_back(Member(&ptrA, "a", 0));
+  classC.members.push_back(Member{ptrA, "a", 0});
 
   test(Flattener::createPass(), {classC}, R"(
 [0] Class: ClassC (size: 8)
@@ -518,9 +518,9 @@ TEST(FlattenerTest, PointerCycle) {
   //   No change
   auto classA = Class{0, Class::Kind::Class, "ClassA", 69};
   auto classB = Class{1, Class::Kind::Class, "ClassB", 69};
-  auto ptrA = Pointer{2, &classA};
-  classA.members.push_back(Member(&classB, "b", 0));
-  classB.members.push_back(Member(&ptrA, "a", 0));
+  auto ptrA = Pointer{2, classA};
+  classA.members.push_back(Member{classB, "b", 0});
+  classB.members.push_back(Member{ptrA, "a", 0});
 
   test(Flattener::createPass(), {classA, classB}, R"(
 [0] Class: ClassA (size: 69)
@@ -544,15 +544,15 @@ TEST(FlattenerTest, Alignment) {
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
   classC.setAlign(16);
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  Member memberB{&myint, "b", 0};
+  Member memberB{myint, "b", 0};
   memberB.align = 8;
   classB.members.push_back(memberB);
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.parents.push_back(Parent(&classC, 4 * 8));
-  classA.members.push_back(Member(&myint, "a", 8 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{classC, 4 * 8});
+  classA.members.push_back(Member{myint, "a", 8 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 12)
@@ -587,8 +587,8 @@ TEST(FlattenerTest, Functions) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 0};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 0};
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classB.parents.push_back(Parent(&classC, 0));
+  classA.parents.push_back(Parent{classB, 0});
+  classB.parents.push_back(Parent{classC, 0});
 
   classA.functions.push_back(Function{"funcA"});
   classB.functions.push_back(Function{"funcB"});
@@ -612,11 +612,11 @@ TEST(FlattenerTest, Children) {
   auto classB = Class{0, Class::Kind::Class, "ClassB", 4};
   auto classC = Class{2, Class::Kind::Class, "ClassC", 4};
 
-  classC.members.push_back(Member(&myint, "c", 0));
-  classB.members.push_back(Member(&myint, "b", 0));
+  classC.members.push_back(Member{myint, "c", 0});
+  classB.members.push_back(Member{myint, "b", 0});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.parents.push_back(Parent(&classC, 4 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{classC, 4 * 8});
 
   classB.children.push_back(classA);
   classC.children.push_back(classA);
@@ -646,16 +646,16 @@ TEST(FlattenerTest, ChildrenTwoDeep) {
   auto classC = Class{3, Class::Kind::Class, "ClassC", 4};
   auto classD = Class{0, Class::Kind::Class, "ClassD", 4};
 
-  classD.members.push_back(Member(&myint, "d", 0));
+  classD.members.push_back(Member{myint, "d", 0});
 
-  classC.members.push_back(Member(&myint, "c", 0));
+  classC.members.push_back(Member{myint, "c", 0});
 
-  classB.parents.push_back(Parent(&classD, 0));
-  classB.members.push_back(Member(&myint, "b", 4 * 8));
+  classB.parents.push_back(Parent{classD, 0});
+  classB.members.push_back(Member{myint, "b", 4 * 8});
 
-  classA.parents.push_back(Parent(&classB, 0));
-  classA.parents.push_back(Parent(&classC, 8 * 8));
-  classA.members.push_back(Member(&myint, "a", 12 * 8));
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{classC, 8 * 8});
+  classA.members.push_back(Member{myint, "a", 12 * 8});
 
   classD.children.push_back(classB);
   classB.children.push_back(classA);
@@ -688,11 +688,11 @@ TEST(FlattenerTest, ParentContainer) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto vector = getVector();
-  vector.templateParams.push_back(TemplateParam{&myint});
+  vector.templateParams.push_back(TemplateParam{myint});
 
   auto classA = Class{0, Class::Kind::Class, "ClassA", 32};
-  classA.parents.push_back(Parent{&vector, 0});
-  classA.members.push_back(Member{&myint, "a", 24 * 8});
+  classA.parents.push_back(Parent{vector, 0});
+  classA.members.push_back(Member{myint, "a", 24 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 32)
@@ -718,11 +718,11 @@ TEST(FlattenerTest, ParentTwoContainers) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto vector = getVector();
-  vector.templateParams.push_back(TemplateParam{&myint});
+  vector.templateParams.push_back(TemplateParam{myint});
 
   auto classA = Class{0, Class::Kind::Class, "ClassA", 48};
-  classA.parents.push_back(Parent{&vector, 0});
-  classA.parents.push_back(Parent{&vector, 24 * 8});
+  classA.parents.push_back(Parent{vector, 0});
+  classA.parents.push_back(Parent{vector, 24 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 48)
@@ -748,14 +748,14 @@ TEST(FlattenerTest, ParentClassAndContainer) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto vector = getVector();
-  vector.templateParams.push_back(TemplateParam{&myint});
+  vector.templateParams.push_back(TemplateParam{myint});
 
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
-  classB.members.push_back(Member{&myint, "b", 0});
+  classB.members.push_back(Member{myint, "b", 0});
 
   auto classA = Class{0, Class::Kind::Class, "ClassA", 32};
-  classA.parents.push_back(Parent{&classB, 0});
-  classA.parents.push_back(Parent{&vector, 8 * 8});
+  classA.parents.push_back(Parent{classB, 0});
+  classA.parents.push_back(Parent{vector, 8 * 8});
 
   test(Flattener::createPass(), {classA}, R"(
 [0] Class: ClassA (size: 32)
@@ -788,25 +788,25 @@ TEST(FlattenerTest, AllocatorParamInParent) {
   Primitive myint{Primitive::Kind::Int32};
 
   Container pair{3, pairInfo, 8};
-  pair.templateParams.push_back(TemplateParam{&myint, {Qualifier::Const}});
-  pair.templateParams.push_back(TemplateParam{&myint});
+  pair.templateParams.push_back(TemplateParam{myint, {Qualifier::Const}});
+  pair.templateParams.push_back(TemplateParam{myint});
 
   Class myallocBase{2, Class::Kind::Struct,
                     "MyAllocBase<std::pair<const int, int>>", 1};
-  myallocBase.templateParams.push_back(TemplateParam{&pair});
+  myallocBase.templateParams.push_back(TemplateParam{pair});
   myallocBase.functions.push_back(Function{"allocate"});
   myallocBase.functions.push_back(Function{"deallocate"});
 
   Class myalloc{1, Class::Kind::Struct, "MyAlloc<std::pair<const int, int>>",
                 1};
-  myalloc.parents.push_back(Parent{&myallocBase, 0});
+  myalloc.parents.push_back(Parent{myallocBase, 0});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
 
   Container map{0, mapInfo, 24};
-  map.templateParams.push_back(TemplateParam{&myint});
-  map.templateParams.push_back(TemplateParam{&myint});
-  map.templateParams.push_back(TemplateParam{&myalloc});
+  map.templateParams.push_back(TemplateParam{myint});
+  map.templateParams.push_back(TemplateParam{myint});
+  map.templateParams.push_back(TemplateParam{myalloc});
 
   test(Flattener::createPass(), {map}, R"(
 [0] Container: std::map (size: 24)
@@ -856,11 +856,11 @@ TEST(FlattenerTest, ClassParam) {
   auto myint = Primitive{Primitive::Kind::Int32};
   auto mychild = Class{1, Class::Kind::Class, "MyChild", 4};
   auto myparent = Class{2, Class::Kind::Class, "MyParent", 4};
-  myparent.members.push_back(Member{&myint, "a", 0});
-  mychild.parents.push_back(Parent{&myparent, 0});
+  myparent.members.push_back(Member{myint, "a", 0});
+  mychild.parents.push_back(Parent{myparent, 0});
 
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 4};
-  myclass.templateParams.push_back(TemplateParam{&mychild});
+  myclass.templateParams.push_back(TemplateParam{mychild});
 
   test(Flattener::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 4)

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -10,8 +10,8 @@ TEST(NameGenTest, ClassParams) {
   auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
   auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
   auto myclass = Class{2, Class::Kind::Struct, "MyClass<MyParam, MyParam>", 13};
-  myclass.templateParams.push_back(&myparam1);
-  myclass.templateParams.push_back(&myparam2);
+  myclass.templateParams.push_back(myparam1);
+  myclass.templateParams.push_back(myparam2);
 
   NameGen nameGen;
   nameGen.generateNames({myclass});
@@ -24,10 +24,10 @@ TEST(NameGenTest, ClassParams) {
 TEST(NameGenTest, ClassContainerParam) {
   auto myint = Primitive{Primitive::Kind::Int32};
   auto myparam = getVector();
-  myparam.templateParams.push_back(&myint);
+  myparam.templateParams.push_back(myint);
 
   auto myclass = Class{0, Class::Kind::Struct, "MyClass", 13};
-  myclass.templateParams.push_back(&myparam);
+  myclass.templateParams.push_back(myparam);
 
   NameGen nameGen;
   nameGen.generateNames({myclass});
@@ -40,8 +40,8 @@ TEST(NameGenTest, ClassParents) {
   auto myparent1 = Class{0, Class::Kind::Struct, "MyParent", 13};
   auto myparent2 = Class{1, Class::Kind::Struct, "MyParent", 13};
   auto myclass = Class{2, Class::Kind::Struct, "MyClass", 13};
-  myclass.parents.push_back(Parent{&myparent1, 0});
-  myclass.parents.push_back(Parent{&myparent2, 0});
+  myclass.parents.push_back(Parent{myparent1, 0});
+  myclass.parents.push_back(Parent{myparent2, 0});
 
   NameGen nameGen;
   nameGen.generateNames({myclass});
@@ -57,8 +57,8 @@ TEST(NameGenTest, ClassMembers) {
   auto myclass = Class{2, Class::Kind::Struct, "MyClass", 13};
 
   // A class may end up with members sharing a name after flattening
-  myclass.members.push_back(Member{&mymember1, "mem", 0});
-  myclass.members.push_back(Member{&mymember2, "mem", 0});
+  myclass.members.push_back(Member{mymember1, "mem", 0});
+  myclass.members.push_back(Member{mymember2, "mem", 0});
 
   NameGen nameGen;
   nameGen.generateNames({myclass});
@@ -89,8 +89,8 @@ TEST(NameGenTest, ContainerParams) {
   auto myparam1 = Class{0, Class::Kind::Struct, "MyParam", 13};
   auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(&myparam1);
-  mycontainer.templateParams.push_back(&myparam2);
+  mycontainer.templateParams.push_back(myparam1);
+  mycontainer.templateParams.push_back(myparam2);
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer});
@@ -103,8 +103,8 @@ TEST(NameGenTest, ContainerParams) {
 TEST(NameGenTest, ContainerParamsDuplicates) {
   auto myparam = Class{0, Class::Kind::Struct, "MyParam", 13};
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(&myparam);
-  mycontainer.templateParams.push_back(&myparam);
+  mycontainer.templateParams.push_back(myparam);
+  mycontainer.templateParams.push_back(myparam);
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer});
@@ -117,11 +117,11 @@ TEST(NameGenTest, ContainerParamsDuplicatesDeep) {
   auto myparam = Class{0, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer1 = getVector();
-  mycontainer1.templateParams.push_back(&myparam);
+  mycontainer1.templateParams.push_back(myparam);
 
   auto mycontainer2 = getVector();
-  mycontainer2.templateParams.push_back(&myparam);
-  mycontainer2.templateParams.push_back(&mycontainer1);
+  mycontainer2.templateParams.push_back(myparam);
+  mycontainer2.templateParams.push_back(mycontainer1);
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer2});
@@ -138,12 +138,12 @@ TEST(NameGenTest, ContainerParamsDuplicatesAcrossContainers) {
   auto myparam3 = Class{2, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer1 = getVector();
-  mycontainer1.templateParams.push_back(&myparam1);
-  mycontainer1.templateParams.push_back(&myparam2);
+  mycontainer1.templateParams.push_back(myparam1);
+  mycontainer1.templateParams.push_back(myparam2);
 
   auto mycontainer2 = getVector();
-  mycontainer2.templateParams.push_back(&myparam2);
-  mycontainer2.templateParams.push_back(&myparam3);
+  mycontainer2.templateParams.push_back(myparam2);
+  mycontainer2.templateParams.push_back(myparam3);
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer1, mycontainer2});
@@ -161,8 +161,8 @@ TEST(NameGenTest, ContainerParamsConst) {
 
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(
-      TemplateParam{&myparam1, {Qualifier::Const}});
-  mycontainer.templateParams.push_back(TemplateParam{&myparam2});
+      TemplateParam{myparam1, {Qualifier::Const}});
+  mycontainer.templateParams.push_back(TemplateParam{myparam2});
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer});
@@ -202,10 +202,10 @@ TEST(NameGenTest, Array) {
   auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(&myparam1);
-  mycontainer.templateParams.push_back(&myparam2);
+  mycontainer.templateParams.push_back(myparam1);
+  mycontainer.templateParams.push_back(myparam2);
 
-  auto myarray = Array{2, &mycontainer, 5};
+  auto myarray = Array{2, mycontainer, 5};
 
   NameGen nameGen;
   nameGen.generateNames({myarray});
@@ -221,10 +221,10 @@ TEST(NameGenTest, Typedef) {
   auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(&myparam1);
-  mycontainer.templateParams.push_back(&myparam2);
+  mycontainer.templateParams.push_back(myparam1);
+  mycontainer.templateParams.push_back(myparam2);
 
-  auto mytypedef = Typedef{2, "MyTypedef", &mycontainer};
+  auto mytypedef = Typedef{2, "MyTypedef", mycontainer};
 
   NameGen nameGen;
   nameGen.generateNames({mytypedef});
@@ -237,7 +237,7 @@ TEST(NameGenTest, Typedef) {
 
 TEST(NameGenTest, TypedefAliasTemplate) {
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto mytypedef = Typedef{0, "MyTypedef<ParamA, ParamB>", &myint};
+  auto mytypedef = Typedef{0, "MyTypedef<ParamA, ParamB>", myint};
 
   NameGen nameGen;
   nameGen.generateNames({mytypedef});
@@ -250,10 +250,10 @@ TEST(NameGenTest, Pointer) {
   auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(&myparam1);
-  mycontainer.templateParams.push_back(&myparam2);
+  mycontainer.templateParams.push_back(myparam1);
+  mycontainer.templateParams.push_back(myparam2);
 
-  auto mypointer = Pointer{2, &mycontainer};
+  auto mypointer = Pointer{2, mycontainer};
 
   NameGen nameGen;
   nameGen.generateNames({mypointer});
@@ -278,8 +278,8 @@ TEST(NameGenTest, DummyAllocator) {
   auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
 
   auto mycontainer = getVector();
-  mycontainer.templateParams.push_back(&myparam1);
-  mycontainer.templateParams.push_back(&myparam2);
+  mycontainer.templateParams.push_back(myparam1);
+  mycontainer.templateParams.push_back(myparam2);
 
   auto myalloc = DummyAllocator{mycontainer, 12, 34};
 
@@ -296,9 +296,9 @@ TEST(NameGenTest, DummyAllocator) {
 TEST(NameGenTest, Cycle) {
   auto classA = Class{0, Class::Kind::Class, "ClassA", 69};
   auto classB = Class{1, Class::Kind::Class, "ClassB", 69};
-  auto ptrA = Pointer{2, &classA};
-  classA.members.push_back(Member(&classB, "b", 0));
-  classB.members.push_back(Member(&ptrA, "a", 0));
+  auto ptrA = Pointer{2, classA};
+  classA.members.push_back(Member{classB, "b", 0});
+  classB.members.push_back(Member{ptrA, "a", 0});
 
   NameGen nameGen;
   nameGen.generateNames({classA});
@@ -310,8 +310,8 @@ TEST(NameGenTest, Cycle) {
 TEST(NameGenTest, ContainerCycle) {
   auto container = getVector();
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 69};
-  myclass.members.push_back(Member(&container, "c", 0));
-  container.templateParams.push_back(TemplateParam(&myclass));
+  myclass.members.push_back(Member{container, "c", 0});
+  container.templateParams.push_back(TemplateParam{myclass});
 
   NameGen nameGen;
   nameGen.generateNames({myclass});

--- a/test/test_remove_ignored.cpp
+++ b/test/test_remove_ignored.cpp
@@ -10,9 +10,9 @@ TEST(RemoveIgnoredTest, Match) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
 
   auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
-  classA.members.push_back(Member(&classB, "a", 0));
-  classA.members.push_back(Member(&classB, "b", 4 * 8));
-  classA.members.push_back(Member(&classB, "c", 8 * 8));
+  classA.members.push_back(Member{classB, "a", 0});
+  classA.members.push_back(Member{classB, "b", 4 * 8});
+  classA.members.push_back(Member{classB, "c", 8 * 8});
 
   const std::vector<std::pair<std::string, std::string>>& membersToIgnore = {
       {"ClassA", "b"},
@@ -43,9 +43,9 @@ TEST(RemoveIgnoredTest, TypeMatchMemberMiss) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
 
   auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
-  classA.members.push_back(Member(&classB, "a", 0));
-  classA.members.push_back(Member(&classB, "b", 4 * 8));
-  classA.members.push_back(Member(&classB, "c", 8 * 8));
+  classA.members.push_back(Member{classB, "a", 0});
+  classA.members.push_back(Member{classB, "b", 4 * 8});
+  classA.members.push_back(Member{classB, "c", 8 * 8});
 
   const std::vector<std::pair<std::string, std::string>>& membersToIgnore = {
       {"ClassA", "x"},
@@ -66,9 +66,9 @@ TEST(RemoveIgnoredTest, MemberMatchWrongType) {
   auto classB = Class{1, Class::Kind::Class, "ClassB", 4};
 
   auto classA = Class{0, Class::Kind::Class, "ClassA", 12};
-  classA.members.push_back(Member(&classB, "a", 0));
-  classA.members.push_back(Member(&classB, "b", 4 * 8));
-  classA.members.push_back(Member(&classB, "c", 8 * 8));
+  classA.members.push_back(Member{classB, "a", 0});
+  classA.members.push_back(Member{classB, "b", 4 * 8});
+  classA.members.push_back(Member{classB, "c", 8 * 8});
 
   const std::vector<std::pair<std::string, std::string>>& membersToIgnore = {
       {"ClassB", "b"},

--- a/test/test_remove_top_level_pointer.cpp
+++ b/test/test_remove_top_level_pointer.cpp
@@ -10,9 +10,9 @@ TEST(RemoveTopLevelPointerTest, TopLevelPointerRemoved) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto myclass = Class{1, Class::Kind::Class, "MyClass", 4};
-  myclass.members.push_back(Member(&myint, "n", 0));
+  myclass.members.push_back(Member{myint, "n", 0});
 
-  auto ptrA = Pointer{0, &myclass};
+  auto ptrA = Pointer{0, myclass};
 
   test(RemoveTopLevelPointer::createPass(), {ptrA}, R"(
 [0] Class: MyClass (size: 4)
@@ -25,7 +25,7 @@ TEST(RemoveTopLevelPointerTest, TopLevelClassUntouched) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 4};
-  myclass.members.push_back(Member(&myint, "n", 0));
+  myclass.members.push_back(Member{myint, "n", 0});
 
   test(RemoveTopLevelPointer::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 4)
@@ -36,10 +36,10 @@ TEST(RemoveTopLevelPointerTest, TopLevelClassUntouched) {
 
 TEST(RemoveTopLevelPointerTest, IntermediatePointerUntouched) {
   auto myint = Primitive{Primitive::Kind::Int32};
-  auto ptrInt = Pointer{1, &myint};
+  auto ptrInt = Pointer{1, myint};
 
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 4};
-  myclass.members.push_back(Member(&ptrInt, "n", 0));
+  myclass.members.push_back(Member{ptrInt, "n", 0});
 
   test(RemoveTopLevelPointer::createPass(), {myclass}, R"(
 [0] Class: MyClass (size: 4)

--- a/test/test_type_identifier.cpp
+++ b/test/test_type_identifier.cpp
@@ -10,12 +10,12 @@ TEST(TypeIdentifierTest, StubbedParam) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto myparam = Class{1, Class::Kind::Struct, "MyParam", 4};
-  myparam.members.push_back(Member{&myint, "a", 0});
+  myparam.members.push_back(Member{myint, "a", 0});
 
   auto container = getVector();
-  container.templateParams.push_back(TemplateParam{&myint});
-  container.templateParams.push_back(TemplateParam{&myparam});
-  container.templateParams.push_back(TemplateParam{&myint});
+  container.templateParams.push_back(TemplateParam{myint});
+  container.templateParams.push_back(TemplateParam{myparam});
+  container.templateParams.push_back(TemplateParam{myint});
 
   test(TypeIdentifier::createPass({}), {container}, R"(
 [0] Container: std::vector (size: 24)
@@ -43,14 +43,14 @@ TEST(TypeIdentifierTest, Allocator) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto myalloc = Class{1, Class::Kind::Struct, "MyAlloc", 8};
-  myalloc.templateParams.push_back(TemplateParam{&myint});
+  myalloc.templateParams.push_back(TemplateParam{myint});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
 
   auto container = getVector();
-  container.templateParams.push_back(TemplateParam{&myint});
-  container.templateParams.push_back(TemplateParam{&myalloc});
-  container.templateParams.push_back(TemplateParam{&myint});
+  container.templateParams.push_back(TemplateParam{myint});
+  container.templateParams.push_back(TemplateParam{myalloc});
+  container.templateParams.push_back(TemplateParam{myint});
 
   test(TypeIdentifier::createPass({}), {container}, R"(
 [0] Container: std::vector (size: 24)
@@ -81,14 +81,14 @@ TEST(TypeIdentifierTest, AllocatorSize1) {
   auto myint = Primitive{Primitive::Kind::Int32};
 
   auto myalloc = Class{1, Class::Kind::Struct, "MyAlloc", 1};
-  myalloc.templateParams.push_back(TemplateParam{&myint});
+  myalloc.templateParams.push_back(TemplateParam{myint});
   myalloc.functions.push_back(Function{"allocate"});
   myalloc.functions.push_back(Function{"deallocate"});
 
   auto container = getVector();
-  container.templateParams.push_back(TemplateParam{&myint});
-  container.templateParams.push_back(TemplateParam{&myalloc});
-  container.templateParams.push_back(TemplateParam{&myint});
+  container.templateParams.push_back(TemplateParam{myint});
+  container.templateParams.push_back(TemplateParam{myalloc});
+  container.templateParams.push_back(TemplateParam{myint});
 
   test(TypeIdentifier::createPass({}), {container}, R"(
 [0] Container: std::vector (size: 24)


### PR DESCRIPTION
References must always have a value, so are semantically clearer than pointers for variables which must always be set.

No functional changes.
