### PR TITLE
TypeGraph: Add "--tree-builder-v2" flag

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -778,7 +778,7 @@ void CodeGen::transform(type_graph::TypeGraph& typeGraph) {
         type_graph::TypeIdentifier::createPass(config_.passThroughTypes));
   }
   pm.addPass(type_graph::RemoveIgnored::createPass(config_.membersToStub));
-  pm.addPass(type_graph::AddPadding::createPass());
+  pm.addPass(type_graph::AddPadding::createPass(config_.features));
   pm.addPass(type_graph::NameGen::createPass());
   pm.addPass(type_graph::AlignmentCalc::createPass());
   pm.addPass(type_graph::RemoveTopLevelPointer::createPass());

--- a/oi/Features.cpp
+++ b/oi/Features.cpp
@@ -33,9 +33,11 @@ std::string_view featureHelp(Feature f) {
     case Feature::CaptureThriftIsset:
       return "Capture isset data for Thrift object.";
     case Feature::TypeGraph:
-      return "Use Type Graph for code generation (CodeGen V2).";
+      return "Use Type Graph for code generation (CodeGen v2).";
     case Feature::TypedDataSegment:
       return "Use Typed Data Segment in generated code.";
+    case Feature::TreeBuilderV2:
+      return "Use Tree Builder v2 for reading the data segment";
     case Feature::GenJitDebug:
       return "Generate debug information for the JIT object.";
     case Feature::JitLogging:

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -28,6 +28,7 @@
   X(CaptureThriftIsset, "capture-thrift-isset") \
   X(TypeGraph, "type-graph")                    \
   X(TypedDataSegment, "typed-data-segment")     \
+  X(TreeBuilderV2, "tree-builder-v2")           \
   X(GenJitDebug, "gen-jit-debug")               \
   X(JitLogging, "jit-logging")                  \
   X(JitTiming, "jit-timing")                    \

--- a/oi/type_graph/AddPadding.h
+++ b/oi/type_graph/AddPadding.h
@@ -15,12 +15,13 @@
  */
 #pragma once
 
-#include <functional>
+#include <string>
 #include <unordered_set>
 
 #include "PassManager.h"
 #include "Types.h"
 #include "Visitor.h"
+#include "oi/Features.h"
 
 namespace type_graph {
 
@@ -35,9 +36,11 @@ class TypeGraph;
  */
 class AddPadding final : public RecursiveVisitor {
  public:
-  static Pass createPass();
+  static Pass createPass(ObjectIntrospection::FeatureSet features);
 
-  explicit AddPadding(TypeGraph& typeGraph) : typeGraph_(typeGraph) {
+  explicit AddPadding(TypeGraph& typeGraph,
+                      ObjectIntrospection::FeatureSet features)
+      : typeGraph_(typeGraph), features_(features) {
   }
 
   using RecursiveVisitor::visit;
@@ -50,6 +53,7 @@ class AddPadding final : public RecursiveVisitor {
  private:
   std::unordered_set<Type*> visited_;
   TypeGraph& typeGraph_;
+  ObjectIntrospection::FeatureSet features_;
 
   void addPadding(const Member& prevMember,
                   uint64_t paddingEndBits,

--- a/oi/type_graph/Flattener.cpp
+++ b/oi/type_graph/Flattener.cpp
@@ -71,7 +71,7 @@ void flattenParent(const Parent& parent,
   } else if (Container* parentContainer =
                  dynamic_cast<Container*>(&parentType)) {
     // Create a new member to represent this parent container
-    flattenedMembers.emplace_back(*parentContainer, "__parent",
+    flattenedMembers.emplace_back(*parentContainer, Flattener::ParentPrefix,
                                   parent.bitOffset);
   } else {
     throw std::runtime_error("Invalid type for parent");

--- a/oi/type_graph/Flattener.h
+++ b/oi/type_graph/Flattener.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -41,6 +42,8 @@ class Flattener : public RecursiveVisitor {
   void visit(Type& type) override;
   void visit(Class& c) override;
   void visit(Container& c) override;
+
+  static const inline std::string ParentPrefix = "__oi_parent";
 
  private:
   std::unordered_set<Type*> visited_;

--- a/test/test_flattener.cpp
+++ b/test/test_flattener.cpp
@@ -705,7 +705,7 @@ TEST(FlattenerTest, ParentContainer) {
 )",
        R"(
 [0] Class: ClassA (size: 32)
-      Member: __parent (offset: 0)
+      Member: __oi_parent (offset: 0)
 [1]     Container: std::vector (size: 24)
           Param
             Primitive: int32_t
@@ -735,11 +735,11 @@ TEST(FlattenerTest, ParentTwoContainers) {
 )",
        R"(
 [0] Class: ClassA (size: 48)
-      Member: __parent (offset: 0)
+      Member: __oi_parent (offset: 0)
 [1]     Container: std::vector (size: 24)
           Param
             Primitive: int32_t
-      Member: __parent (offset: 24)
+      Member: __oi_parent (offset: 24)
         [1]
 )");
 }
@@ -772,7 +772,7 @@ TEST(FlattenerTest, ParentClassAndContainer) {
 [0] Class: ClassA (size: 32)
       Member: b (offset: 0)
         Primitive: int32_t
-      Member: __parent (offset: 8)
+      Member: __oi_parent (offset: 8)
 [1]     Container: std::vector (size: 24)
           Param
             Primitive: int32_t


### PR DESCRIPTION
This will eventually be used to enable running with Tree Builder v2.

For now, when it is disabled it puts CodeGen v2 into compatibility mode, disabling features which weren't present in CodeGen v1 so that its output can be understood by Tree Builder v1.