### PR TITLE
TypeIdentifier: Preserve container types

### DIFF
--- a/oi/type_graph/TypeIdentifier.cpp
+++ b/oi/type_graph/TypeIdentifier.cpp
@@ -61,7 +61,8 @@ void TypeIdentifier::visit(Container& c) {
   for (size_t i = 0; i < c.templateParams.size(); i++) {
     const auto& param = c.templateParams[i];
     if (dynamic_cast<Dummy*>(param.type()) ||
-        dynamic_cast<DummyAllocator*>(param.type())) {
+        dynamic_cast<DummyAllocator*>(param.type()) ||
+        dynamic_cast<Container*>(param.type())) {
       // In case the TypeIdentifier pass is run multiple times, we don't want to
       // replace dummies again as the context of the original replacement has
       // been lost.

--- a/test/test_type_identifier.cpp
+++ b/test/test_type_identifier.cpp
@@ -114,3 +114,121 @@ TEST(TypeIdentifierTest, AllocatorSize1) {
         Primitive: int32_t
 )");
 }
+
+TEST(TypeIdentifierTest, PassThroughTypes) {
+  auto myint = Primitive{Primitive::Kind::Int32};
+
+  auto myalloc = Class{1, Class::Kind::Class, "std::allocator", 1};
+  myalloc.templateParams.push_back(TemplateParam{myint});
+  myalloc.functions.push_back(Function{"allocate"});
+  myalloc.functions.push_back(Function{"deallocate"});
+
+  auto container = getVector();
+  container.templateParams.push_back(TemplateParam{myint});
+  container.templateParams.push_back(TemplateParam{myalloc});
+
+  std::vector<ContainerInfo> passThroughTypes;
+  passThroughTypes.emplace_back("std::allocator", DUMMY_TYPE, "memory");
+
+  test(TypeIdentifier::createPass(passThroughTypes), {container}, R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+[1]     Class: std::allocator (size: 1)
+          Param
+            Primitive: int32_t
+          Function: allocate
+          Function: deallocate
+)",
+       R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+[1]     Container: std::allocator (size: 1)
+          Param
+            Primitive: int32_t
+)");
+}
+
+TEST(TypeIdentifierTest, ContainerNotReplaced) {
+  auto myint = Primitive{Primitive::Kind::Int32};
+
+  ContainerInfo allocatorInfo{"std::allocator", DUMMY_TYPE, "memory"};
+  auto myalloc = Container{1, allocatorInfo, 1};
+  myalloc.templateParams.push_back(TemplateParam{myint});
+
+  auto container = getVector();
+  container.templateParams.push_back(TemplateParam{myint});
+  container.templateParams.push_back(TemplateParam{myalloc});
+
+  test(TypeIdentifier::createPass({}), {container}, R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+[1]     Container: std::allocator (size: 1)
+          Param
+            Primitive: int32_t
+)",
+       R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+        Dummy (size: 0, align: 8)
+)");
+}
+
+TEST(TypeIdentifierTest, DummyNotReplaced) {
+  auto myint = Primitive{Primitive::Kind::Int32};
+
+  auto dummy = Dummy{22, 0};
+
+  auto container = getVector();
+  container.templateParams.push_back(TemplateParam{myint});
+  container.templateParams.push_back(TemplateParam{dummy});
+
+  test(TypeIdentifier::createPass({}), {container}, R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+        Dummy (size: 22)
+)",
+       R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+        Dummy (size: 22)
+)");
+}
+
+TEST(TypeIdentifierTest, DummyAllocatorNotReplaced) {
+  auto myint = Primitive{Primitive::Kind::Int32};
+
+  auto dummy = DummyAllocator{myint, 22, 0};
+
+  auto container = getVector();
+  container.templateParams.push_back(TemplateParam{myint});
+  container.templateParams.push_back(TemplateParam{dummy});
+
+  test(TypeIdentifier::createPass({}), {container}, R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+        DummyAllocator (size: 22)
+          Primitive: int32_t
+)",
+       R"(
+[0] Container: std::vector (size: 24)
+      Param
+        Primitive: int32_t
+      Param
+        DummyAllocator (size: 22)
+          Primitive: int32_t
+)");
+}

--- a/test/test_type_identifier.cpp
+++ b/test/test_type_identifier.cpp
@@ -177,7 +177,9 @@ TEST(TypeIdentifierTest, ContainerNotReplaced) {
       Param
         Primitive: int32_t
       Param
-        Dummy (size: 0, align: 8)
+[1]     Container: std::allocator (size: 1)
+          Param
+            Primitive: int32_t
 )");
 }
 


### PR DESCRIPTION
Pass-through-types represent classes to be turned into containers. We don't want these to turn these containers into Dummy's on a second run of TypeIdentifier.