### PR TITLE
TypeGraph: Rename visit(Type) functions to accept(Type)

### DIFF
--- a/oi/type_graph/AddChildren.cpp
+++ b/oi/type_graph/AddChildren.cpp
@@ -36,14 +36,14 @@ Pass AddChildren::createPass(DrgnParser& drgnParser, SymbolService& symbols) {
     AddChildren pass(typeGraph, drgnParser);
     pass.enumerateChildClasses(symbols);
     for (auto& type : typeGraph.rootTypes()) {
-      pass.visit(type);
+      pass.accept(type);
     }
   };
 
   return Pass("AddChildren", fn);
 }
 
-void AddChildren::visit(Type& type) {
+void AddChildren::accept(Type& type) {
   if (visited_.count(&type) != 0)
     return;
 
@@ -53,10 +53,10 @@ void AddChildren::visit(Type& type) {
 
 void AddChildren::visit(Class& c) {
   for (auto& param : c.templateParams) {
-    visit(param.type());
+    accept(param.type());
   }
   for (auto& member : c.members) {
-    visit(member.type());
+    accept(member.type());
   }
 
   if (!c.isDynamic()) {
@@ -82,8 +82,8 @@ void AddChildren::visit(Class& c) {
   }
 
   // Recurse to find children-of-children
-  for (auto& child : c.children) {
-    visit(child);
+  for (const auto& child : c.children) {
+    accept(child);
   }
 }
 

--- a/oi/type_graph/AddChildren.h
+++ b/oi/type_graph/AddChildren.h
@@ -46,9 +46,9 @@ class AddChildren final : public RecursiveVisitor {
       : typeGraph_(typeGraph), drgnParser_(drgnParser) {
   }
 
-  using RecursiveVisitor::visit;
+  using RecursiveVisitor::accept;
 
-  void visit(Type& type) override;
+  void accept(Type& type) override;
   void visit(Class& c) override;
 
  private:

--- a/oi/type_graph/AddPadding.cpp
+++ b/oi/type_graph/AddPadding.cpp
@@ -32,14 +32,14 @@ Pass AddPadding::createPass(FeatureSet features) {
   auto fn = [features](TypeGraph& typeGraph) {
     AddPadding pass(typeGraph, features);
     for (auto& type : typeGraph.rootTypes()) {
-      pass.visit(type);
+      pass.accept(type);
     }
   };
 
   return Pass("AddPadding", fn);
 }
 
-void AddPadding::visit(Type& type) {
+void AddPadding::accept(Type& type) {
   if (visited_.count(&type) != 0)
     return;
 
@@ -54,10 +54,10 @@ void AddPadding::visit(Class& c) {
   assert(c.parents.empty());
 
   for (auto& param : c.templateParams) {
-    visit(param.type());
+    accept(param.type());
   }
   for (auto& member : c.members) {
-    visit(member.type());
+    accept(member.type());
   }
 
   if (c.kind() == Class::Kind::Union) {
@@ -94,7 +94,7 @@ void AddPadding::visit(Class& c) {
   c.members = std::move(paddedMembers);
 
   for (const auto& child : c.children) {
-    visit(child);
+    accept(child);
   }
 }
 

--- a/oi/type_graph/AddPadding.h
+++ b/oi/type_graph/AddPadding.h
@@ -43,9 +43,9 @@ class AddPadding final : public RecursiveVisitor {
       : typeGraph_(typeGraph), features_(features) {
   }
 
-  using RecursiveVisitor::visit;
+  using RecursiveVisitor::accept;
 
-  void visit(Type& type) override;
+  void accept(Type& type) override;
   void visit(Class& c) override;
 
   static const inline std::string MemberPrefix = "__oi_padding";

--- a/oi/type_graph/AlignmentCalc.cpp
+++ b/oi/type_graph/AlignmentCalc.cpp
@@ -35,11 +35,11 @@ Pass AlignmentCalc::createPass() {
 
 void AlignmentCalc::calculateAlignments(const std::vector<ref<Type>>& types) {
   for (auto& type : types) {
-    visit(type);
+    accept(type);
   }
 };
 
-void AlignmentCalc::visit(Type& type) {
+void AlignmentCalc::accept(Type& type) {
   if (visited_.count(&type) != 0)
     return;
 
@@ -58,7 +58,7 @@ void AlignmentCalc::visit(Class& c) {
     if (member.align == 0) {
       // If the member does not have an explicit alignment, calculate it from
       // the member's type.
-      visit(member.type());
+      accept(member.type());
       member.align = member.type().align();
     }
     alignment = std::max(alignment, member.align);

--- a/oi/type_graph/AlignmentCalc.h
+++ b/oi/type_graph/AlignmentCalc.h
@@ -37,9 +37,9 @@ class AlignmentCalc final : public RecursiveVisitor {
   void calculateAlignments(
       const std::vector<std::reference_wrapper<Type>>& types);
 
-  using RecursiveVisitor::visit;
+  using RecursiveVisitor::accept;
 
-  void visit(Type& type) override;
+  void accept(Type& type) override;
   void visit(Class& c) override;
 
  private:

--- a/oi/type_graph/Flattener.cpp
+++ b/oi/type_graph/Flattener.cpp
@@ -33,11 +33,11 @@ Pass Flattener::createPass() {
 
 void Flattener::flatten(std::vector<std::reference_wrapper<Type>>& types) {
   for (auto& type : types) {
-    visit(type);
+    accept(type);
   }
 }
 
-void Flattener::visit(Type& type) {
+void Flattener::accept(Type& type) {
   if (visited_.count(&type) != 0)
     return;
 
@@ -146,13 +146,13 @@ void Flattener::visit(Class& c) {
 
   // Flatten types referenced by template params, parents and members
   for (const auto& param : c.templateParams) {
-    visit(param.type());
+    accept(param.type());
   }
   for (const auto& parent : c.parents) {
-    visit(parent.type());
+    accept(parent.type());
   }
   for (const auto& member : c.members) {
-    visit(member.type());
+    accept(member.type());
   }
 
   // Pull in functions from flattened parents
@@ -203,7 +203,7 @@ void Flattener::visit(Class& c) {
   // This must be run after flattening the current class in order to respect
   // the changes we have made here.
   for (const auto& child : c.children) {
-    visit(child);
+    accept(child);
   }
 }
 
@@ -211,7 +211,7 @@ void Flattener::visit(Container& c) {
   // Containers themselves don't need to be flattened, but their template
   // parameters might need to be
   for (const auto& templateParam : c.templateParams) {
-    visit(templateParam.type());
+    accept(templateParam.type());
   }
 }
 

--- a/oi/type_graph/Flattener.h
+++ b/oi/type_graph/Flattener.h
@@ -37,9 +37,9 @@ class Flattener : public RecursiveVisitor {
 
   void flatten(std::vector<std::reference_wrapper<Type>>& types);
 
-  using RecursiveVisitor::visit;
+  using RecursiveVisitor::accept;
 
-  void visit(Type& type) override;
+  void accept(Type& type) override;
   void visit(Class& c) override;
   void visit(Container& c) override;
 

--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -33,11 +33,11 @@ Pass NameGen::createPass() {
 
 void NameGen::generateNames(const std::vector<ref<Type>>& types) {
   for (auto& type : types) {
-    visit(type);
+    accept(type);
   }
 };
 
-void NameGen::visit(Type& type) {
+void NameGen::accept(Type& type) {
   if (visited_.count(&type) != 0)
     return;
 
@@ -69,16 +69,16 @@ void NameGen::visit(Class& c) {
   }
 
   for (const auto& param : c.templateParams) {
-    visit(param.type());
+    accept(param.type());
   }
   for (const auto& parent : c.parents) {
-    visit(parent.type());
+    accept(parent.type());
   }
   for (const auto& member : c.members) {
-    visit(member.type());
+    accept(member.type());
   }
   for (const auto& child : c.children) {
-    visit(child);
+    accept(child);
   }
 }
 
@@ -88,7 +88,7 @@ void NameGen::visit(Container& c) {
   }
 
   for (const auto& template_param : c.templateParams) {
-    visit(template_param.type());
+    accept(template_param.type());
   }
 
   std::string name = c.name();
@@ -130,7 +130,7 @@ void NameGen::visit(Typedef& td) {
   // Append an incrementing number to ensure we don't get duplicates
   td.setName(name + "_" + std::to_string(n++));
 
-  visit(td.underlyingType());
+  accept(td.underlyingType());
 }
 
 }  // namespace type_graph

--- a/oi/type_graph/NameGen.h
+++ b/oi/type_graph/NameGen.h
@@ -32,14 +32,14 @@ class NameGen final : public RecursiveVisitor {
 
   void generateNames(const std::vector<std::reference_wrapper<Type>>& types);
 
-  using RecursiveVisitor::visit;
+  using RecursiveVisitor::accept;
 
   void visit(Class& c) override;
   void visit(Container& c) override;
   void visit(Typedef& td) override;
 
  private:
-  void visit(Type& type) override;
+  void accept(Type& type) override;
   void removeTemplateParams(std::string& name);
 
   std::unordered_set<Type*> visited_;

--- a/oi/type_graph/RemoveIgnored.cpp
+++ b/oi/type_graph/RemoveIgnored.cpp
@@ -24,14 +24,14 @@ Pass RemoveIgnored::createPass(
   auto fn = [&membersToIgnore](TypeGraph& typeGraph) {
     RemoveIgnored removeIgnored{typeGraph, membersToIgnore};
     for (auto& type : typeGraph.rootTypes()) {
-      removeIgnored.visit(type);
+      removeIgnored.accept(type);
     }
   };
 
   return Pass("RemoveIgnored", fn);
 }
 
-void RemoveIgnored::visit(Type& type) {
+void RemoveIgnored::accept(Type& type) {
   if (visited_.count(&type) != 0)
     return;
 

--- a/oi/type_graph/RemoveIgnored.h
+++ b/oi/type_graph/RemoveIgnored.h
@@ -42,9 +42,9 @@ class RemoveIgnored : public RecursiveVisitor {
       : typeGraph_(typeGraph), membersToIgnore_(membersToIgnore) {
   }
 
-  using RecursiveVisitor::visit;
+  using RecursiveVisitor::accept;
 
-  void visit(Type& type) override;
+  void accept(Type& type) override;
   void visit(Class& c) override;
 
  private:

--- a/oi/type_graph/TopoSorter.cpp
+++ b/oi/type_graph/TopoSorter.cpp
@@ -37,7 +37,7 @@ void TopoSorter::sort(const std::vector<ref<Type>>& types) {
     typesToSort_.push(type);
   }
   while (!typesToSort_.empty()) {
-    visit(typesToSort_.front());
+    accept(typesToSort_.front());
     typesToSort_.pop();
   }
 }
@@ -46,7 +46,7 @@ const std::vector<ref<Type>>& TopoSorter::sortedTypes() const {
   return sortedTypes_;
 }
 
-void TopoSorter::visit(Type& type) {
+void TopoSorter::accept(Type& type) {
   if (visited_.count(&type) != 0)
     return;
 
@@ -56,13 +56,13 @@ void TopoSorter::visit(Type& type) {
 
 void TopoSorter::visit(Class& c) {
   for (const auto& parent : c.parents) {
-    visit(parent.type());
+    accept(parent.type());
   }
   for (const auto& mem : c.members) {
-    visit(mem.type());
+    accept(mem.type());
   }
   for (const auto& param : c.templateParams) {
-    visit(param.type());
+    accept(param.type());
   }
   sortedTypes_.push_back(c);
 
@@ -97,7 +97,7 @@ bool containerAllowsIncompleteParams(const Container& c) {
 void TopoSorter::visit(Container& c) {
   if (!containerAllowsIncompleteParams(c)) {
     for (const auto& param : c.templateParams) {
-      visit(param.type());
+      accept(param.type());
     }
   }
   sortedTypes_.push_back(c);
@@ -113,7 +113,7 @@ void TopoSorter::visit(Enum& e) {
 }
 
 void TopoSorter::visit(Typedef& td) {
-  visit(td.underlyingType());
+  accept(td.underlyingType());
   sortedTypes_.push_back(td);
 }
 

--- a/oi/type_graph/TopoSorter.h
+++ b/oi/type_graph/TopoSorter.h
@@ -38,9 +38,9 @@ class TopoSorter : public RecursiveVisitor {
   void sort(const std::vector<std::reference_wrapper<Type>>& types);
   const std::vector<std::reference_wrapper<Type>>& sortedTypes() const;
 
-  using RecursiveVisitor::visit;
+  using RecursiveVisitor::accept;
 
-  void visit(Type& type) override;
+  void accept(Type& type) override;
   void visit(Class& c) override;
   void visit(Container& c) override;
   void visit(Enum& e) override;

--- a/oi/type_graph/TypeIdentifier.cpp
+++ b/oi/type_graph/TypeIdentifier.cpp
@@ -25,7 +25,7 @@ Pass TypeIdentifier::createPass(
   auto fn = [&passThroughTypes](TypeGraph& typeGraph) {
     TypeIdentifier typeId{typeGraph, passThroughTypes};
     for (auto& type : typeGraph.rootTypes()) {
-      typeId.visit(type);
+      typeId.accept(type);
     }
   };
 
@@ -47,7 +47,7 @@ bool TypeIdentifier::isAllocator(Type& t) {
   return false;
 }
 
-void TypeIdentifier::visit(Type& type) {
+void TypeIdentifier::accept(Type& type) {
   if (visited_.count(&type) != 0)
     return;
 
@@ -111,7 +111,7 @@ void TypeIdentifier::visit(Container& c) {
   }
 
   for (const auto& param : c.templateParams) {
-    visit(param.type());
+    accept(param.type());
   }
 }
 

--- a/oi/type_graph/TypeIdentifier.h
+++ b/oi/type_graph/TypeIdentifier.h
@@ -43,9 +43,9 @@ class TypeIdentifier : public RecursiveVisitor {
       : typeGraph_(typeGraph), passThroughTypes_(passThroughTypes) {
   }
 
-  using RecursiveVisitor::visit;
+  using RecursiveVisitor::accept;
 
-  void visit(Type& type) override;
+  void accept(Type& type) override;
   void visit(Container& c) override;
 
  private:

--- a/oi/type_graph/Visitor.h
+++ b/oi/type_graph/Visitor.h
@@ -57,28 +57,28 @@ class LazyVisitor : public Visitor {
 class RecursiveVisitor : public Visitor {
  public:
   virtual ~RecursiveVisitor() = default;
-  virtual void visit(Type&) = 0;
-  virtual void visit(Type* type) {
+  virtual void accept(Type&) = 0;
+  virtual void accept(Type* type) {
     if (type)
-      visit(*type);
+      accept(*type);
   }
   virtual void visit(Class& c) {
     for (const auto& param : c.templateParams) {
-      visit(param.type());
+      accept(param.type());
     }
     for (const auto& parent : c.parents) {
-      visit(parent.type());
+      accept(parent.type());
     }
     for (const auto& mem : c.members) {
-      visit(mem.type());
+      accept(mem.type());
     }
     for (const auto& child : c.children) {
-      visit(child);
+      accept(child);
     }
   }
   virtual void visit(Container& c) {
     for (const auto& param : c.templateParams) {
-      visit(param.type());
+      accept(param.type());
     }
   }
   virtual void visit(Primitive&) {
@@ -86,18 +86,18 @@ class RecursiveVisitor : public Visitor {
   virtual void visit(Enum&) {
   }
   virtual void visit(Array& a) {
-    visit(a.elementType());
+    accept(a.elementType());
   }
   virtual void visit(Typedef& td) {
-    visit(td.underlyingType());
+    accept(td.underlyingType());
   }
   virtual void visit(Pointer& p) {
-    visit(p.pointeeType());
+    accept(p.pointeeType());
   }
   virtual void visit(Dummy&) {
   }
   virtual void visit(DummyAllocator& d) {
-    visit(d.allocType());
+    accept(d.allocType());
   }
 };
 


### PR DESCRIPTION
`visit(Type&)` and `visit(Type*)` were helper functions than did cycle detection and provided nicer syntax for the `type.accept(*this)` calls.

However, because they overloaded the `visit()` function, it was easy to accidentally call a concrete visit method (e.g. `visit(Class&)`) instead of the virtual-dispatching `visit(Type&)`.

By changing the name of this wrapper, it will make it much more obvious when code is introduced which bypasses the cycle detection.