### PR TITLE
NameGen: Remove invalid characters from member names

### DIFF
--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -66,6 +66,10 @@ void NameGen::visit(Class& c) {
   // Deduplicate member names. Duplicates may be present after flattening.
   for (size_t i = 0; i < c.members.size(); i++) {
     c.members[i].name += "_" + std::to_string(i);
+
+    // GCC includes dots in vptr member names, e.g. "_vptr.MyClass"
+    // These aren't valid in C++, so we must replace them
+    std::replace(c.members[i].name.begin(), c.members[i].name.end(), '.', '$');
   }
 
   for (const auto& param : c.templateParams) {

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -70,6 +70,19 @@ TEST(NameGenTest, ClassMembers) {
   EXPECT_EQ(mymember2.name(), "MyMember_2");
 }
 
+TEST(NameGenTest, ClassMemberInvalidChar) {
+  auto myclass = Class{2, Class::Kind::Struct, "MyClass", 13};
+
+  auto myint = Primitive{Primitive::Kind::Int32};
+  myclass.members.push_back(Member{myint, "mem.Nope", 0});
+
+  NameGen nameGen;
+  nameGen.generateNames({myclass});
+
+  EXPECT_EQ(myclass.name(), "MyClass_0");
+  EXPECT_EQ(myclass.members[0].name, "mem$Nope_0");
+}
+
 TEST(NameGenTest, ClassChildren) {
   auto mychild1 = Class{0, Class::Kind::Struct, "MyChild", 13};
   auto mychild2 = Class{1, Class::Kind::Struct, "MyChild", 13};


### PR DESCRIPTION
GCC includes dots in vptr member names, e.g. "_vptr.MyClass". These aren't valid in C++, so we must replace them.