### PR TITLE
AddChildren: Filter out false children

### DIFF
--- a/oi/type_graph/AddChildren.h
+++ b/oi/type_graph/AddChildren.h
@@ -34,9 +34,15 @@ class TypeGraph;
 /*
  * AddChildren
  *
- * TODO
- * what about children which inherit through a typedef?  don't think that'll
- * work yet
+ * Populates the "children" field of Class types.
+ *
+ * DWARF only stores a mapping of [child -> parent], but sometimes we want the
+ * invserse: [parent -> child]. We must iterate over every single type to build
+ * up our own inverse mapping, before applying it to the relevant type nodes.
+ *
+ * This is expensive and only useful for types which make use of dynamic
+ * inheritance hierarchies (e.g. polymorphism), so is not done as part of the
+ * standard DrgnParser stage.
  */
 class AddChildren final : public RecursiveVisitor {
  public:

--- a/oi/type_graph/Flattener.cpp
+++ b/oi/type_graph/Flattener.cpp
@@ -46,15 +46,6 @@ void Flattener::accept(Type& type) {
 }
 
 namespace {
-// TODO this function is a massive hack. don't do it like this please
-Type& stripTypedefs(Type& type) {
-  Type* t = &type;
-  while (const Typedef* td = dynamic_cast<Typedef*>(t)) {
-    t = &td->underlyingType();
-  }
-  return *t;
-}
-
 void flattenParent(const Parent& parent,
                    std::vector<Member>& flattenedMembers) {
   Type& parentType = stripTypedefs(parent.type());

--- a/oi/type_graph/Types.cpp
+++ b/oi/type_graph/Types.cpp
@@ -122,4 +122,13 @@ bool Class::isDynamic() const {
   return false;
 }
 
+// TODO this function is a massive hack. don't do it like this please
+Type& stripTypedefs(Type& type) {
+  Type* t = &type;
+  while (const Typedef* td = dynamic_cast<Typedef*>(t)) {
+    t = &td->underlyingType();
+  }
+  return *t;
+}
+
 }  // namespace type_graph

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -295,8 +295,8 @@ class Container : public Type {
 
 class Enum : public Type {
  public:
-  explicit Enum(const std::string& name, size_t size)
-      : name_(name), size_(size) {
+  explicit Enum(std::string name, size_t size)
+      : name_(std::move(name)), size_(size) {
   }
 
   DECLARE_ACCEPT
@@ -395,8 +395,8 @@ class Primitive : public Type {
 
 class Typedef : public Type {
  public:
-  explicit Typedef(NodeId id, const std::string& name, Type& underlyingType)
-      : name_(name), underlyingType_(underlyingType), id_(id) {
+  explicit Typedef(NodeId id, std::string name, Type& underlyingType)
+      : name_(std::move(name)), underlyingType_(underlyingType), id_(id) {
   }
 
   DECLARE_ACCEPT
@@ -519,6 +519,8 @@ class DummyAllocator : public Type {
   size_t size_;
   uint64_t align_;
 };
+
+Type& stripTypedefs(Type& type);
 
 }  // namespace type_graph
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(integration_sleepy folly_headers)
 
 add_executable(test_type_graph
   main.cpp
+  test_add_children.cpp
   test_add_padding.cpp
   test_alignment_calc.cpp
   test_codegen.cpp

--- a/test/test_add_children.cpp
+++ b/test/test_add_children.cpp
@@ -1,0 +1,176 @@
+#include <gtest/gtest.h>
+
+#include "oi/SymbolService.h"
+#include "oi/type_graph/AddChildren.h"
+#include "oi/type_graph/Printer.h"
+#include "oi/type_graph/TypeGraph.h"
+#include "test_drgn_parser.h"
+
+using namespace type_graph;
+
+class AddChildrenTest : public DrgnParserTest {
+ protected:
+  std::string run(std::string_view function, bool chaseRawPointers) override;
+};
+
+std::string AddChildrenTest::run(std::string_view function,
+                                 bool chaseRawPointers) {
+  TypeGraph typeGraph;
+  auto drgnParser = getDrgnParser(typeGraph, chaseRawPointers);
+  auto* drgnRoot = getDrgnRoot(function);
+
+  Type& type = drgnParser.parse(drgnRoot);
+  typeGraph.addRoot(type);
+
+  auto pass = AddChildren::createPass(drgnParser, *symbols_);
+  pass.run(typeGraph);
+
+  std::stringstream out;
+  Printer printer{out, typeGraph.size()};
+  printer.print(type);
+
+  return out.str();
+}
+
+TEST_F(AddChildrenTest, SimpleStruct) {
+  // Should do nothing
+  test("oid_test_case_simple_struct", R"(
+[0] Pointer
+[1]   Struct: SimpleStruct (size: 16)
+        Member: a (offset: 0)
+          Primitive: int32_t
+        Member: b (offset: 4)
+          Primitive: int8_t
+        Member: c (offset: 8)
+          Primitive: int64_t
+)");
+}
+
+TEST_F(AddChildrenTest, InheritanceStatic) {
+  // Should do nothing
+  test("oid_test_case_inheritance_access_public", R"(
+[0] Pointer
+[1]   Class: Public (size: 8)
+        Parent (offset: 0)
+[2]       Class: Base (size: 4)
+            Member: base_int (offset: 0)
+              Primitive: int32_t
+        Member: public_int (offset: 4)
+          Primitive: int32_t
+)");
+}
+
+TEST_F(AddChildrenTest, InheritancePolymorphic) {
+  testMultiCompiler("oid_test_case_inheritance_polymorphic_a_as_a", R"(
+[0]  Pointer
+[1]    Class: A (size: 16)
+         Member: _vptr$A (offset: 0)
+[2]        Pointer
+[3]          Pointer
+               Primitive: void
+         Member: int_a (offset: 8)
+           Primitive: int32_t
+         Function: ~A (virtual)
+         Function: myfunc (virtual)
+         Function: A
+         Function: A
+         Child
+[4]        Class: B (size: 40)
+             Parent (offset: 0)
+               [1]
+             Member: vec_b (offset: 16)
+[5]            Container: std::vector (size: 24)
+                 Param
+                   Primitive: int32_t
+                 Param
+[6]                Class: allocator<int> (size: 1)
+                     Param
+                       Primitive: int32_t
+                     Parent (offset: 0)
+[7]                    Typedef: __allocator_base<int>
+[8]                      Class: new_allocator<int> (size: 1)
+                           Param
+                             Primitive: int32_t
+                           Function: new_allocator
+                           Function: new_allocator
+                           Function: allocate
+                           Function: deallocate
+                           Function: _M_max_size
+                     Function: allocator
+                     Function: allocator
+                     Function: operator=
+                     Function: ~allocator
+                     Function: allocate
+                     Function: deallocate
+             Function: ~B (virtual)
+             Function: myfunc (virtual)
+             Function: B
+             Function: B
+             Child
+[9]            Class: C (size: 48)
+                 Parent (offset: 0)
+                   [4]
+                 Member: int_c (offset: 40)
+                   Primitive: int32_t
+                 Function: ~C (virtual)
+                 Function: myfunc (virtual)
+                 Function: C
+                 Function: C
+)",
+                    R"(
+[0]  Pointer
+[1]    Class: A (size: 16)
+         Member: _vptr.A (offset: 0)
+[2]        Pointer
+[3]          Pointer
+               Primitive: void
+         Member: int_a (offset: 8)
+           Primitive: int32_t
+         Function: operator=
+         Function: A
+         Function: A
+         Function: ~A (virtual)
+         Function: myfunc (virtual)
+         Child
+[4]        Class: B (size: 40)
+             Parent (offset: 0)
+               [1]
+             Member: vec_b (offset: 16)
+[5]            Container: std::vector (size: 24)
+                 Param
+                   Primitive: int32_t
+                 Param
+[6]                Class: allocator<int> (size: 1)
+                     Parent (offset: 0)
+[7]                    Class: new_allocator<int> (size: 1)
+                         Param
+                           Primitive: int32_t
+                         Function: new_allocator
+                         Function: new_allocator
+                         Function: allocate
+                         Function: deallocate
+                         Function: _M_max_size
+                     Function: allocator
+                     Function: allocator
+                     Function: operator=
+                     Function: ~allocator
+                     Function: allocate
+                     Function: deallocate
+             Function: operator=
+             Function: B
+             Function: B
+             Function: ~B (virtual)
+             Function: myfunc (virtual)
+             Child
+[8]            Class: C (size: 48)
+                 Parent (offset: 0)
+                   [4]
+                 Member: int_c (offset: 40)
+                   Primitive: int32_t
+                 Function: operator=
+                 Function: C
+                 Function: C
+                 Function: ~C (virtual)
+                 Function: myfunc (virtual)
+)");
+}

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -1,4 +1,3 @@
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <regex>
@@ -7,10 +6,10 @@
 // TODO needed?:
 #include "oi/ContainerInfo.h"
 #include "oi/OIParser.h"
-#include "oi/type_graph/DrgnParser.h"
 #include "oi/type_graph/Printer.h"
 #include "oi/type_graph/TypeGraph.h"
 #include "oi/type_graph/Types.h"
+#include "test_drgn_parser.h"
 
 using namespace type_graph;
 using ::testing::HasSubstr;
@@ -18,52 +17,42 @@ using ::testing::HasSubstr;
 // TODO setup google logging for tests so it doesn't appear on terminal by
 // default
 
-class DrgnParserTest : public ::testing::Test {
- protected:
-  static void SetUpTestSuite() {
-    symbols_ = new SymbolService{TARGET_EXE_PATH};
-  }
-
-  static void TearDownTestSuite() {
-    delete symbols_;
-  }
-
-  std::string run(std::string_view function, bool chaseRawPointers);
-  void test(std::string_view function,
-            std::string_view expected,
-            bool chaseRawPointers = true);
-  void testContains(std::string_view function,
-                    std::string_view expected,
-                    bool chaseRawPointers = true);
-  void testMultiCompiler(std::string_view function,
-                         std::string_view expectedClang,
-                         std::string_view expectedGcc,
-                         bool chaseRawPointers = true);
-  void testMultiCompilerContains(std::string_view function,
-                                 std::string_view expectedClang,
-                                 std::string_view expectedGcc,
-                                 bool chaseRawPointers = true);
-
-  static SymbolService* symbols_;
-};
-
 SymbolService* DrgnParserTest::symbols_ = nullptr;
+
+namespace {
+const std::vector<ContainerInfo>& getContainerInfos() {
+  static auto res = []() {
+    // TODO more container types, with various template parameter options
+    ContainerInfo std_vector{"std::vector", SEQ_TYPE, "vector"};
+    std_vector.stubTemplateParams = {1};
+
+    std::vector<ContainerInfo> containers;
+    containers.emplace_back(std::move(std_vector));
+    return containers;
+  }();
+  return res;
+}
+}  // namespace
+
+DrgnParser DrgnParserTest::getDrgnParser(TypeGraph& typeGraph,
+                                         bool chaseRawPointers) {
+  DrgnParser drgnParser{typeGraph, getContainerInfos(), chaseRawPointers};
+  return drgnParser;
+}
+
+drgn_type* DrgnParserTest::getDrgnRoot(std::string_view function) {
+  irequest req{"entry", std::string{function}, "arg0"};
+  auto* drgnRoot = symbols_->getRootType(req)->type.type;
+  return drgnRoot;
+}
 
 std::string DrgnParserTest::run(std::string_view function,
                                 bool chaseRawPointers) {
-  irequest req{"entry", std::string{function}, "arg0"};
-  auto drgnRoot = symbols_->getRootType(req);
-
   TypeGraph typeGraph;
-  // TODO more container types, with various template parameter options
-  ContainerInfo std_vector{"std::vector", SEQ_TYPE, "vector"};
-  std_vector.stubTemplateParams = {1};
+  auto drgnParser = getDrgnParser(typeGraph, chaseRawPointers);
+  auto* drgnRoot = getDrgnRoot(function);
 
-  std::vector<ContainerInfo> containers;
-  containers.emplace_back(std::move(std_vector));
-
-  DrgnParser drgnParser(typeGraph, containers, chaseRawPointers);
-  Type& type = drgnParser.parse(drgnRoot->type.type);
+  Type& type = drgnParser.parse(drgnRoot);
 
   std::stringstream out;
   Printer printer{out, typeGraph.size()};

--- a/test/test_drgn_parser.h
+++ b/test/test_drgn_parser.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "oi/type_graph/DrgnParser.h"
+
+namespace type_graph {
+class TypeGraph;
+}
+class SymbolService;
+struct drgn_type;
+
+class DrgnParserTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    symbols_ = new SymbolService{TARGET_EXE_PATH};
+  }
+
+  static void TearDownTestSuite() {
+    delete symbols_;
+  }
+
+  static type_graph::DrgnParser getDrgnParser(type_graph::TypeGraph& typeGraph,
+                                              bool chaseRawPointers);
+  drgn_type* getDrgnRoot(std::string_view function);
+
+  virtual std::string run(std::string_view function, bool chaseRawPointers);
+  void test(std::string_view function,
+            std::string_view expected,
+            bool chaseRawPointers = true);
+  void testContains(std::string_view function,
+                    std::string_view expected,
+                    bool chaseRawPointers = true);
+  void testMultiCompiler(std::string_view function,
+                         std::string_view expectedClang,
+                         std::string_view expectedGcc,
+                         bool chaseRawPointers = true);
+  void testMultiCompilerContains(std::string_view function,
+                                 std::string_view expectedClang,
+                                 std::string_view expectedGcc,
+                                 bool chaseRawPointers = true);
+
+  static SymbolService* symbols_;
+};


### PR DESCRIPTION
Use fully qualified names to determine if a class is really the child of our type. It may be that it is the child of another type with an identical name in another namespace.