### PR TITLE
Add container without template params to container map

### DIFF
--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -720,6 +720,11 @@ bool OICodeGen::enumerateTemplateParamIdxs(drgn_type* type,
                                            const std::vector<size_t>& paramIdxs,
                                            bool& ifStub) {
   if (paramIdxs.empty()) {
+    // Containers such as IOBuf and IOBufQueue don't have template params, but
+    // still should be added to containerTypeMap
+    containerTypeMapDrgn.emplace(
+        type,
+        std::pair(std::ref(containerInfo), std::vector<drgn_qualified_type>()));
     return true;
   }
 


### PR DESCRIPTION
Summary:

If a container has 0 template params (e.g. IOBuf, IOBufQueue), it wasn't being added to containerTypeMap. This causes the deserialization to go wrong as TreeBuilder doesn't treat the types as container

Test Plan:

make test