### PR TITLE
Stop stubbing tuple

### DIFF
--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -73,7 +73,6 @@ OICodeGen::OICodeGen(const Config& c, SymbolService& s)
       "McServerSession",
       "Range",
       "ReadResumableHandle",
-      "tuple",
       "CountedIntrusiveList",
       "EventBaseAtomicNotificationQueue",
       /* Temporary IOBuf ring used for scattered read/write.

--- a/test/integration/std_tuple.toml
+++ b/test/integration/std_tuple.toml
@@ -1,0 +1,36 @@
+includes = ["tuple"]
+definitions = '''
+struct Foo {
+  std::tuple<uint64_t, uint64_t> t;
+};
+struct Bar {
+  std::optional<Foo> f;
+};
+'''
+[cases]
+  [cases.uint64_uint64]
+    param_types = ["Bar&"]
+    setup = '''
+      Foo f;
+      f.t = std::make_tuple<uint64_t, uint64_t>(1,2);
+      Bar b;
+      b.f = f;
+      return b;
+    '''
+    expect_json = '''
+    [
+      {
+        "staticSize": 24,
+        "dynamicSize": 0,
+        "members": [
+          {
+            "staticSize": 24,
+            "dynamicSize": 0,
+            "length": 1,
+            "capacity": 1,
+            "elementStaticSize": 16
+          }
+        ]
+      }
+    ]
+    '''


### PR DESCRIPTION
Summary:

Stubbing tuple without alignment info can cause failures. I added a test case for this which failed before this fix but works now.

Test Plan:

Ran the test.
