### PR TITLE
RemoveIgnored: Set names for removed members to AddPadding::MemberPrefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,14 @@ workflows:
             - build-gcc
           oid_test_args: "-ftype-graph"
           tests_regex: "OidIntegration\\..*"
-          exclude_regex: ".*inheritance_polymorphic.*|.*pointers_incomplete_containing_struct|.*ignored_a|.*arrays_member_int0"
+          exclude_regex: ".*inheritance_polymorphic.*|.*pointers_incomplete_containing_struct|.*arrays_member_int0"
       - test:
           name: test-typed-data-segment-gcc
           requires:
             - build-gcc
           oid_test_args: "-ftyped-data-segment"
           tests_regex: "OidIntegration\\..*"
-          exclude_regex: ".*inheritance_polymorphic.*|.*pointers.*|.*ignored_a|.*arrays_member_int0|.*cycles_.*"
+          exclude_regex: ".*inheritance_polymorphic.*|.*pointers.*|.*arrays_member_int0|.*cycles_.*"
       - coverage:
           name: coverage
           requires:

--- a/oi/type_graph/RemoveIgnored.cpp
+++ b/oi/type_graph/RemoveIgnored.cpp
@@ -15,6 +15,7 @@
  */
 #include "RemoveIgnored.h"
 
+#include "AddPadding.h"
 #include "TypeGraph.h"
 
 namespace type_graph {
@@ -48,7 +49,7 @@ void RemoveIgnored::visit(Class& c) {
     auto& paddingArray =
         typeGraph_.makeType<Array>(primitive, c.members[i].type().size());
     c.members[i] =
-        Member{paddingArray, c.members[i].name, c.members[i].bitOffset};
+        Member{paddingArray, AddPadding::MemberPrefix, c.members[i].bitOffset};
   }
 }
 

--- a/test/test_remove_ignored.cpp
+++ b/test/test_remove_ignored.cpp
@@ -31,7 +31,7 @@ TEST(RemoveIgnoredTest, Match) {
 [0] Class: ClassA (size: 12)
       Member: a (offset: 0)
 [1]     Class: ClassB (size: 4)
-      Member: b (offset: 4)
+      Member: __oi_padding (offset: 4)
 [2]     Array: (length: 4)
           Primitive: int8_t
       Member: c (offset: 8)


### PR DESCRIPTION
This means they will be treated as padding, so CodeGen will not try to store any data for them.