### PR TITLE
type_graph: deduplicate has_node_id

### DIFF
--- a/oi/type_graph/TypeGraph.h
+++ b/oi/type_graph/TypeGraph.h
@@ -57,10 +57,7 @@ class TypeGraph {
 
   template <typename T, typename... Args>
   T& makeType(NodeId id, Args&&... args) {
-    static_assert(std::is_same_v<T, Class> || std::is_same_v<T, Container> ||
-                      std::is_same_v<T, Array> || std::is_same_v<T, Typedef> ||
-                      std::is_same_v<T, Pointer>,
-                  "Unnecessary node ID provided");
+    static_assert(T::has_node_id, "Unnecessary node ID provided");
     auto type_unique_ptr = std::make_unique<T>(id, std::forward<Args>(args)...);
     auto type_raw_ptr = type_unique_ptr.get();
     types_.push_back(std::move(type_unique_ptr));
@@ -71,9 +68,7 @@ class TypeGraph {
   T& makeType(Args&&... args) {
     static_assert(!std::is_same_v<T, Primitive>,
                   "Primitive singleton override should be used");
-    if constexpr (std::is_same_v<T, Class> || std::is_same_v<T, Container> ||
-                  std::is_same_v<T, Array> || std::is_same_v<T, Typedef> ||
-                  std::is_same_v<T, Pointer>) {
+    if constexpr (T::has_node_id) {
       // Node ID required
       return makeType<T>(next_id_++, std::forward<Args>(args)...);
     } else {

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -202,6 +202,8 @@ class Class : public Type {
       : Class(id, kind, name, name, size, virtuality) {
   }
 
+  static inline constexpr bool has_node_id = true;
+
   DECLARE_ACCEPT
 
   Kind kind() const {
@@ -277,6 +279,8 @@ class Container : public Type {
         id_(id) {
   }
 
+  static inline constexpr bool has_node_id = true;
+
   DECLARE_ACCEPT
 
   const std::string& containerName() const {
@@ -318,6 +322,8 @@ class Enum : public Type {
       : name_(std::move(name)), size_(size) {
   }
 
+  static inline constexpr bool has_node_id = false;
+
   DECLARE_ACCEPT
 
   virtual std::string name() const override {
@@ -350,6 +356,8 @@ class Array : public Type {
   Array(NodeId id, Type& elementType, size_t len)
       : elementType_(elementType), len_(len), id_(id) {
   }
+
+  static inline constexpr bool has_node_id = true;
 
   DECLARE_ACCEPT
 
@@ -408,6 +416,8 @@ class Primitive : public Type {
   explicit Primitive(Kind kind) : kind_(kind) {
   }
 
+  static inline constexpr bool has_node_id = false;
+
   DECLARE_ACCEPT
 
   virtual std::string name() const override;
@@ -428,6 +438,8 @@ class Typedef : public Type {
   explicit Typedef(NodeId id, std::string name, Type& underlyingType)
       : name_(std::move(name)), underlyingType_(underlyingType), id_(id) {
   }
+
+  static inline constexpr bool has_node_id = true;
 
   DECLARE_ACCEPT
 
@@ -467,6 +479,8 @@ class Pointer : public Type {
       : pointeeType_(pointeeType), id_(id) {
   }
 
+  static inline constexpr bool has_node_id = true;
+
   DECLARE_ACCEPT
 
   virtual std::string name() const override {
@@ -504,6 +518,8 @@ class Dummy : public Type {
   explicit Dummy(size_t size, uint64_t align) : size_(size), align_(align) {
   }
 
+  static inline constexpr bool has_node_id = false;
+
   DECLARE_ACCEPT
 
   virtual std::string name() const override {
@@ -539,6 +555,8 @@ class DummyAllocator : public Type {
   explicit DummyAllocator(Type& type, size_t size, uint64_t align)
       : type_(type), size_(size), align_(align) {
   }
+
+  static inline constexpr bool has_node_id = false;
 
   DECLARE_ACCEPT
 


### PR DESCRIPTION
## Summary

The check for whether to require a node ID is completed in two places, neither of which are at the type which describes whether it needs a node ID. Move this boolean to within the types for clarity/deduplication.

## Test plan

- CI
