### PR TITLE
ci: order coverage jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,14 +43,17 @@ workflows:
           name: coverage-type-graph
           requires:
             - test-type-graph-gcc
+            - coverage
       - coverage:
           name: coverage-typed-data-segment
           requires:
             - test-typed-data-segment-gcc
+            - coverage-type-graph
       - coverage:
           name: coverage-tree-builder-type-checking
           requires:
             - test-tree-builder-type-checking-gcc
+            - coverage-typed-data-segment
 
       - build:
           name: build-clang


### PR DESCRIPTION
## Summary

Places ordering constraints on the four coverage jobs that run in CI. Recently I've seen a lot of 502 errors where codecov requests you try again in 30 seconds. Hopefully making sure these jobs aren't concurrent will help with that.

## Test plan

- CI
