### PR TITLE
TypeGraphParser: Fix container info lifetimes and improve error reporting

### DIFF
--- a/test/TypeGraphParser.cpp
+++ b/test/TypeGraphParser.cpp
@@ -53,23 +53,23 @@ Primitive::Kind getKind(std::string_view kindStr) {
                              std::string{kindStr}};
 }
 
-ContainerInfo getContainerInfo(std::string_view name) {
+ContainerInfo& getContainerInfo(std::string_view name) {
   if (name == "std::vector") {
-    ContainerInfo info{"std::vector", SEQ_TYPE, "vector"};
+    static ContainerInfo info{"std::vector", SEQ_TYPE, "vector"};
     info.stubTemplateParams = {1};
     return info;
   }
   if (name == "std::map") {
-    ContainerInfo info{"std::map", STD_MAP_TYPE, "utility"};
+    static ContainerInfo info{"std::map", STD_MAP_TYPE, "utility"};
     info.stubTemplateParams = {2, 3};
     return info;
   }
   if (name == "std::pair") {
-    ContainerInfo info{"std::pair", SEQ_TYPE, "utility"};
+    static ContainerInfo info{"std::pair", SEQ_TYPE, "utility"};
     return info;
   }
   if (name == "std::allocator") {
-    ContainerInfo info{"std::allocator", DUMMY_TYPE, "memory"};
+    static ContainerInfo info{"std::allocator", DUMMY_TYPE, "memory"};
     return info;
   }
   throw TypeGraphParserError{"Unsupported container: " + std::string{name}};
@@ -242,7 +242,7 @@ Type& TypeGraphParser::parseType(std::string_view& input, size_t rootIndent) {
     auto nameEndPos = line.find('(', nameStartPos + 1);
     auto name = line.substr(nameStartPos, nameEndPos - nameStartPos - 1);
 
-    auto info = getContainerInfo(name);
+    auto& info = getContainerInfo(name);
 
     auto size = parseIntAttribute(line, nodeTypeName, "size: ");
 

--- a/test/TypeGraphParser.h
+++ b/test/TypeGraphParser.h
@@ -35,3 +35,9 @@ class TypeGraphParser {
   void parseFunctions(Class& c, std::string_view& input, size_t rootIndent);
   void parseChildren(Class& c, std::string_view& input, size_t rootIndent);
 };
+
+class TypeGraphParserError : public std::runtime_error {
+ public:
+  TypeGraphParserError(const std::string& msg) : std::runtime_error{msg} {
+  }
+};

--- a/test/type_graph_utils.cpp
+++ b/test/type_graph_utils.cpp
@@ -38,10 +38,14 @@ void test(type_graph::Pass pass,
   input.remove_prefix(1);  // Remove initial '\n'
   TypeGraph typeGraph;
   TypeGraphParser parser{typeGraph};
-  parser.parse(input);
+  try {
+    parser.parse(input);
+  } catch (const TypeGraphParserError& err) {
+    FAIL() << "Error parsing input graph: " << err.what();
+  }
 
   // Validate input formatting
-  check(typeGraph.rootTypes(), input, " parsing input graph");
+  check(typeGraph.rootTypes(), input, "parsing input graph");
 
   // Run pass and check results
   test(pass, typeGraph.rootTypes(), expectedAfter);
@@ -51,10 +55,14 @@ void testNoChange(type_graph::Pass pass, std::string_view input) {
   input.remove_prefix(1);  // Remove initial '\n'
   TypeGraph typeGraph;
   TypeGraphParser parser{typeGraph};
-  parser.parse(input);
+  try {
+    parser.parse(input);
+  } catch (const TypeGraphParserError& err) {
+    FAIL() << "Error parsing input graph: " << err.what();
+  }
 
   // Validate input formatting
-  check(typeGraph.rootTypes(), input, " parsing input graph");
+  check(typeGraph.rootTypes(), input, "parsing input graph");
 
   // Run pass and check results
   test(pass, typeGraph.rootTypes(), input);


### PR DESCRIPTION
Containers store references to ContainerInfos, so the ContainerInfos must live beyond the stack they were created on. Use static variables for simplicity.



Throw custom error types which we can catch and use to print clearer failure messages.

Before:
```
      unknown file: Failure
      C++ exception with description "Invalid type for child" thrown in the test body.
```
    
After:
```
      ../test/type_graph_utils.cpp:44: Failure
      Failed
      Error parsing input graph: Invalid type for child
```