### PR TITLE
AddPadding: Always pad bitfields with "int8_t"s

### DIFF
--- a/test/test_add_padding.cpp
+++ b/test/test_add_padding.cpp
@@ -124,20 +124,23 @@ TEST(AddPaddingTest, Bitfields) {
       Member: b2 (offset: 0.375, bitsize: 2)
         Primitive: int8_t
       Member: __oi_padding (offset: 0.625, bitsize: 3)
-        Primitive: int64_t
+        Primitive: int8_t
       Member: b3 (offset: 1, bitsize: 1)
         Primitive: int8_t
-      Member: __oi_padding (offset: 1.125, bitsize: 55)
-        Primitive: int64_t
+      Member: __oi_padding (offset: 1.125, bitsize: 7)
+        Primitive: int8_t
+      Member: __oi_padding (offset: 2)
+[1]     Array: (length: 6)
+          Primitive: int8_t
       Member: b4 (offset: 8, bitsize: 24)
         Primitive: int64_t
       Member: __oi_padding (offset: 11)
-[1]     Array: (length: 1)
+[2]     Array: (length: 1)
           Primitive: int8_t
       Member: n (offset: 12)
         Primitive: int16_t
       Member: __oi_padding (offset: 14)
-[2]     Array: (length: 2)
+[3]     Array: (length: 2)
           Primitive: int8_t
 )");
 }


### PR DESCRIPTION
The underlying type of bitfield is important to the size of a struct:
    
```
struct Foo { int64_t bitfield : 1; };
struct Bar { int8_t bitfield : 1; };
    
sizeof(Foo) = 8;
sizeof(Bar) = 1;
```