### PR TITLE
googletest: change to FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,16 @@ target_compile_options(stl_logging_unittest PRIVATE "-w")
 target_compile_options(symbolize_unittest PRIVATE "-w")
 target_compile_options(utilities_unittest PRIVATE "-w")
 
+### googletest
+# Do this in the main file so it can be fetched before setting project warnings.
+# After this is fixed with FetchContent, move to test/CMakeLists.txt.
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        1ed6a8c67a0bd675149ece27bbec0ef1759854cf
+)
+FetchContent_MakeAvailable(googletest)
+
 ### rocksdb
 FetchContent_Declare(
     rocksdb

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,3 @@
-find_package(GTest REQUIRED)
-if (TARGET GTest::gmock_main)
-  # Only modern version of GTest defines the gmock_main target
-  set(GMOCK_MAIN_LIBS GTest::gmock_main)
-else()
-  # To support older version of the lib,
-  # We manually locate the lib and its dependencies instead
-  find_library(GMOCK_MAIN_LIB NAMES libgmock_main.a REQUIRED)
-  find_library(GMOCK_LIB NAMES libgmock.a REQUIRED)
-  set(GMOCK_MAIN_LIBS ${GMOCK_MAIN_LIB} ${GMOCK_LIB} GTest::GTest)
-endif()
-message(STATUS "Using GMockMain: ${GMOCK_MAIN_LIBS}")
-
 enable_testing()
 include(GoogleTest)
 
@@ -28,7 +15,7 @@ function(cpp_unittest)
 
   target_link_libraries(
     ${TEST_NAME}
-    ${GMOCK_MAIN_LIBS} glog
+    GTest::gmock_main glog
     ${TEST_DEPS}
   )
 
@@ -73,7 +60,7 @@ target_link_libraries(test_type_graph
   container_info
   type_graph
 
-  ${GMOCK_MAIN_LIBS}
+  GTest::gmock_main
 )
 include(GoogleTest)
 gtest_discover_tests(test_type_graph)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -54,9 +54,8 @@ target_link_libraries(integration_test_target PRIVATE oil Boost::headers ${Boost
 
 add_executable(integration_test_runner ${INTEGRATION_TEST_RUNNER_SRC} runner_common.cpp)
 target_include_directories(integration_test_runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-# GMOCK_MAIN_LIBS is set in test/CMakeLists.txt
 target_link_libraries(integration_test_runner PRIVATE
-  ${GMOCK_MAIN_LIBS}
+  GTest::gmock_main
   Boost::headers
   ${Boost_LIBRARIES}
   toml


### PR DESCRIPTION
## Summary

The internal version of GoogleTest we were using has disappeared and the CentOS version is old. Vendor it with FetchContent.

## Test plan

- CI
- `make clobber; make configure-devel && make test`
- `make clobber; make configure-static && make test`
Static is a complete mess, and there are a tonne of test failures on it too. I think this is pre-existing though?
