### PR TITLE
provide common interfaces for continue and detach requests

### DIFF
--- a/oi/OIDebugger.h
+++ b/oi/OIDebugger.h
@@ -235,6 +235,7 @@ class OIDebugger {
   static bool isExtendedWait(int);
   void dumpAlltaskStates(void);
   std::optional<std::vector<uintptr_t>> findRetLocs(FuncDesc&);
+  bool contTargetThread(pid_t, unsigned long = 0) const;
 
   OICompiler::Config compilerConfig{};
   const OICodeGen::Config& generatorConfig;


### PR DESCRIPTION
## Summary
The `OIDebugger` class provides a public interface for oid to detach or continue the main target thread via `PTRACE_DETACH` and `PTRACE_CONT` requests respectively. The `OIDebugger` implementation has a number of call sites which continue a thread but it may not be the main thread (`traceePid`) and we may need to pass a signal to inject via the `data` parameter. This change simply tidies all these individual call sites under a common private implementation. The public interface has been converted to use the use the private interface for its close requests.

There are a few PTRACE_DETACH request sites in `OIDebugger.cpp` and I'll tify them up into a common interface in another change.

## Test plan
A `make test` has no new failures. 
