### PR TITLE
Improve handling of newly created threads in initial seize code

### DIFF
--- a/oi/OIDebugger.h
+++ b/oi/OIDebugger.h
@@ -64,7 +64,7 @@ class OIDebugger {
   OIDebugger::processTrapRet processTrap(pid_t, bool = true, bool = true);
   bool contTargetThread(bool detach = true) const;
   bool isGlobalDataProbeEnabled(void) const;
-  static uint64_t singlestepInst(pid_t, struct user_regs_struct&);
+  static uint64_t singleStepInst(pid_t, struct user_regs_struct&);
   static bool singleStepFunc(pid_t, uint64_t);
   bool parseScript(std::istream& script);
   bool patchFunctions();


### PR DESCRIPTION
## Summary
Our initial thread seize code is very racy and it's super easy to end up with threads being ignored or hung for long periods waiting for stop states to be reaped. This change aims to handle the case where a thread that has been seized executes a sequence such that a new thread is created (e.g., a clone(2) syscall and the newborn thread shows up in the /proc namespace so the directory_iterator picks it up. This new thread will be traced by us already as the tracing sate is inherited from its parent thread so we can't seize it. It will however be in a signal-stop state so that should be reaped and the thread continued.

## Test plan
make 'test' returns the same failures as before the change. However, it is unlikely to show any change as this code is handling an `EPERM` return from `ptrace(2)`. Test in prod really. I have engineered highly controlled test cases to work through the failure scenarios and at a minimum I don't think we are any more exposed to failure with this code than without.
