### PR TITLE
Increase verbosity of size static asserts

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -277,24 +277,23 @@ void genDefs(const TypeGraph& typeGraph, std::string& code) {
 }
 
 void genStaticAssertsClass(const Class& c, std::string& code) {
-  code += "static_assert(sizeof(" + c.name() +
-          ") == " + std::to_string(c.size()) +
-          ", \"Unexpected size of struct " + c.name() + "\");\n";
+  code += "static_assert(validate_size<" + c.name() + ", " +
+          std::to_string(c.size()) + ">::value);\n";
   for (const auto& member : c.members) {
     if (member.bitsize > 0)
       continue;
-    code += "static_assert(offsetof(" + c.name() + ", " + member.name +
-            ") == " + std::to_string(member.bitOffset / 8) +
-            ", \"Unexpected offset of " + c.name() + "::" + member.name +
-            "\");\n";
+
+    code += "static_assert(validate_offset<offsetof(" + c.name() + ", " +
+            member.name + "), " + std::to_string(member.bitOffset / 8) +
+            ">::value, \"Unexpected offset of " + c.name() +
+            "::" + member.name + "\");\n";
   }
   code.push_back('\n');
 }
 
 void genStaticAssertsContainer(const Container& c, std::string& code) {
-  code += "static_assert(sizeof(" + c.name() +
-          ") == " + std::to_string(c.size()) +
-          ", \"Unexpected size of container " + c.name() + "\");\n";
+  code += "static_assert(validate_size<" + c.name() + ", " +
+          std::to_string(c.size()) + ">::value);\n";
   code.push_back('\n');
 }
 

--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -148,3 +148,17 @@ struct alignas(Align) DummyAllocator
 
 template <typename T>
 struct DummyAllocator<T, 0> : DummyAllocatorBase<DummyAllocator, T, 0, 0> {};
+
+template <typename Type, size_t ExpectedSize, size_t ActualSize = 0>
+struct validate_size : std::true_type {
+  static_assert(ExpectedSize == ActualSize);
+};
+
+template <typename Type, size_t ExpectedSize>
+struct validate_size<Type, ExpectedSize>
+    : validate_size<Type, ExpectedSize, sizeof(Type)> {};
+
+template <size_t ExpectedOffset, size_t ActualOffset>
+struct validate_offset : std::true_type {
+  static_assert(ExpectedOffset == ActualOffset);
+};


### PR DESCRIPTION
## Summary

Size static asserts currently tell you the type and the expected size in the log. This is a bit limited as the only bit of invisible information there is the actual size. Layer the static assert behind a struct so the error message is more descriptive.

Annoyingly this does make the message more verbose (3 "lines" of errors rather than 1). I think we can get it back down to 1 if a macro is used to construct a custom static assert message, but this way seemed more C++ friendly.

## Test plan

- CI

New example:
```
/tmp/oid-cache/981275032686841092.cc:154:5: error: static_assert failed due to requirement '24UL == 32UL'
    static_assert(ExpectedSize == ActualSize);
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/oid-cache/981275032686841092.cc:159:5: note: in instantiation of template class 'validate_size<folly::sorted_vector_map<unsigned int, std::vector<long>, OIInternal::(anonymous namespace)::less_24>, 24, 32>' requested here
  : validate_size< Type, ExpectedSize, sizeof( Type ) > {};
    ^
/tmp/oid-cache/981275032686841092.cc:4760:15: note: in instantiation of template class 'validate_size<folly::sorted_vector_map<unsigned int, std::vector<long>, OIInternal::(anonymous namespace)::less_24>, 24, 0>' requested here
static_assert(validate_size<folly::sorted_vector_map<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>, less_24, std::allocator<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>>, void, std::vector<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>, std::allocator<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>>>>, 24>::value);
```

Shows the two numbers in the first static assert. The middle "note" gives all of the information in one place (name, actual size, expected size). The bottom one is useless.

Old example:
```
/tmp/oid-cache/981275032686841092.cc:4751:1: error: static_assert failed due to requirement 'sizeof(folly::sorted_vector_map<unsigned int, std::vector<long, std::allocator<long>>, OIInternal::(anonymous namespace)::less_24, std::allocator<std::pair<unsigned int, std::vector<long, std::allocator<long>>>>, void, std::vector<std::pair<unsigned int, std::vector<long, std::allocator<long>>>, std::allocator<std::pair<unsigned int, std::vector<long, std::allocator<long>>>>>>) == 2
4' "Unexpected size of container folly::sorted_vector_map<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>, less_24, std::allocator<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>>, void, std::vector<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>, std::allocator<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>>>>"
static_assert(sizeof(folly::sorted_vector_map<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>, less_24, std::allocator<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>>, void, std::vector<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>, std::allocator<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>>>>) == 24, "Unexpected size of container folly::sorted_vector_map<ClusterType_23, std::vec
tor<int64_t, std::allocator<int64_t>>, less_24, std::allocator<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>>, void, std::vector<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>, std::allocator<std::pair<ClusterType_23, std::vector<int64_t, std::allocator<int64_t>>>>>>");
^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
