### PR TITLE
TypeGraph: Change Type::name() to return a reference instead of a copy

### DIFF
--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -139,6 +139,11 @@ void NameGen::visit(Enum& e) {
   e.setName(name);
 }
 
+void NameGen::visit(Array& a) {
+  accept(a.elementType());
+  a.regenerateName();
+}
+
 void NameGen::visit(Typedef& td) {
   /*
    * Treat like class names.
@@ -156,6 +161,16 @@ void NameGen::visit(Typedef& td) {
   td.setName(name);
 
   accept(td.underlyingType());
+}
+
+void NameGen::visit(Pointer& p) {
+  accept(p.pointeeType());
+  p.regenerateName();
+}
+
+void NameGen::visit(DummyAllocator& d) {
+  accept(d.allocType());
+  d.regenerateName();
 }
 
 }  // namespace oi::detail::type_graph

--- a/oi/type_graph/NameGen.h
+++ b/oi/type_graph/NameGen.h
@@ -43,7 +43,10 @@ class NameGen final : public RecursiveVisitor {
   void visit(Class& c) override;
   void visit(Container& c) override;
   void visit(Enum& e) override;
+  void visit(Array& a) override;
   void visit(Typedef& td) override;
+  void visit(Pointer& p) override;
+  void visit(DummyAllocator& d) override;
 
   static const inline std::string AnonPrefix = "__oi_anon";
 

--- a/oi/type_graph/Types.cpp
+++ b/oi/type_graph/Types.cpp
@@ -29,8 +29,8 @@ namespace oi::detail::type_graph {
 OI_TYPE_LIST
 #undef X
 
-std::string Primitive::name() const {
-  switch (kind_) {
+std::string Primitive::getName(Kind kind) {
+  switch (kind) {
     case Kind::Int8:
       return "int8_t";
     case Kind::Int16:


### PR DESCRIPTION
Names which were generated on-demand are now stored in member variables, which are set during the ctor and can be regenerated when required (by NameGen).