### PR TITLE
disciplined includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,8 @@ set(CMAKE_BUILD_RPATH
 )
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-include_directories(SYSTEM "${DRGN_PATH}")
+include_directories(SYSTEM "${PROJECT_SOURCE_DIR}/extern/drgn/libdrgn/velfutils")
+include_directories(SYSTEM "${DRGN_PATH}" "${DRGN_PATH}/include")
 
 if (STATIC_LINK)
   # glog links against the `gflags` target, which is an alias for `gflags_shared`

--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -16,14 +16,34 @@
 #include "CodeGen.h"
 
 #include <glog/logging.h>
+#include <glog/vlog_is_on.h>
 
+#include <bitset>
 #include <boost/format.hpp>
+#include <boost/format/alt_sstream.hpp>
+#include <boost/format/format_class.hpp>
+#include <boost/format/format_fwd.hpp>
+#include <boost/format/format_implementation.hpp>
+#include <boost/optional/optional.hpp>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <ext/alloc_traits.h>
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <set>
+#include <stdexcept>
 #include <string_view>
+#include <utility>
 
+#include "oi/ContainerInfo.h"
+#include "oi/ContainerTypeEnum.h"
+#include "oi/Features.h"
 #include "oi/FuncGen.h"
 #include "oi/Headers.h"
+#include "oi/OICodeGen.h"
 #include "oi/SymbolService.h"
 #include "type_graph/AddChildren.h"
 #include "type_graph/AddPadding.h"
@@ -31,6 +51,7 @@
 #include "type_graph/DrgnParser.h"
 #include "type_graph/Flattener.h"
 #include "type_graph/NameGen.h"
+#include "type_graph/PassManager.h"
 #include "type_graph/RemoveMembers.h"
 #include "type_graph/RemoveTopLevelPointer.h"
 #include "type_graph/TopoSorter.h"

--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <filesystem>
-#include <functional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -45,16 +45,15 @@ class CodeGen {
    * Helper function to perform all the steps required for code generation for a
    * single drgn_type.
    */
-  bool codegenFromDrgn(struct drgn_type* drgnType, std::string& code);
+  bool codegenFromDrgn(drgn_type* drgnType, std::string& code);
 
   void registerContainer(const std::filesystem::path& path);
-  void addDrgnRoot(struct drgn_type* drgnType,
-                   type_graph::TypeGraph& typeGraph);
+  void addDrgnRoot(drgn_type* drgnType, type_graph::TypeGraph& typeGraph);
   void transform(type_graph::TypeGraph& typeGraph);
-  void generate(type_graph::TypeGraph& typeGraph,
-                std::string& code,
-                struct drgn_type*
-                    drgnType /* TODO: this argument should not be required */
+  void generate(
+      type_graph::TypeGraph& typeGraph,
+      std::string& code,
+      drgn_type* drgnType /* TODO: this argument should not be required */
   );
 
  private:

--- a/oi/ContainerInfo.cpp
+++ b/oi/ContainerInfo.cpp
@@ -17,7 +17,10 @@
 
 #include <glog/logging.h>
 
+#include <chrono>
 #include <map>
+#include <sstream>
+#include <string_view>
 
 #include "oi/support/Toml.h"
 

--- a/oi/ContainerInfo.h
+++ b/oi/ContainerInfo.h
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 #pragma once
+#include <compare>
+#include <cstddef>
 #include <filesystem>
+#include <functional>
+#include <memory>
 #include <optional>
 #include <regex>
 #include <set>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "oi/ContainerTypeEnum.h"

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -46,6 +46,7 @@ extern "C" {
 
 #include "oi/CodeGen.h"
 #include "oi/ContainerInfo.h"
+#include "oi/Descs.h"
 #include "oi/Headers.h"
 #include "oi/Metrics.h"
 #include "oi/OILexer.h"

--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -18,15 +18,30 @@
 
 #include <glog/logging.h>
 
+#include <array>
 #include <boost/core/demangle.hpp>
 #include <fstream>
 #include <iostream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <type_traits>
 #include <unordered_map>
-#include <variant>
 
 #include "oi/DrgnUtils.h"
+#include "oi/Features.h"
 #include "oi/Headers.h"
 #include "oi/OIUtils.h"
+
+extern "C" {
+#include <drgn.h>
+}
+
+class SymbolService;
+struct drgn_symbol;
 
 namespace ObjectIntrospection {
 

--- a/oi/OIGenerator.h
+++ b/oi/OIGenerator.h
@@ -17,10 +17,20 @@
 #pragma once
 
 #include <filesystem>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include "oi/DrgnUtils.h"
 #include "oi/OICodeGen.h"
 #include "oi/OICompiler.h"
+
+class SymbolService;
+struct drgn_qualified_type;
+namespace drgnplusplus {
+class program;
+}
 
 namespace ObjectIntrospection {
 

--- a/oi/OILibrary.cpp
+++ b/oi/OILibrary.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "ObjectIntrospection.h"  // IWYU pragma: associated
 #include "oi/OILibraryImpl.h"
 
 bool debug = false;

--- a/oi/OILibraryImpl.cpp
+++ b/oi/OILibraryImpl.cpp
@@ -15,22 +15,34 @@
  */
 #include "oi/OILibraryImpl.h"
 
-#include <fcntl.h>
 #include <glog/logging.h>
-#include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
 #include <boost/format.hpp>
+#include <cstdio>
+#include <filesystem>
 #include <fstream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
 
+#include "ObjectIntrospection.h"
+#include "glog/vlog_is_on.h"
+#include "oi/Features.h"
 #include "oi/Headers.h"
 #include "oi/OIParser.h"
 #include "oi/OIUtils.h"
+#include "oi/SymbolService.h"
+#include "oi/TypeHierarchy.h"
 
 extern "C" {
-#include <libelf.h>
+#include <drgn.h>
+#include <sys/mman.h>
 }
 
 namespace ObjectIntrospection {

--- a/oi/OILibraryImpl.h
+++ b/oi/OILibraryImpl.h
@@ -15,10 +15,16 @@
  */
 #pragma once
 
-#include "ObjectIntrospection.h"
+#include <cstddef>
+#include <memory>
+
 #include "oi/OICodeGen.h"
 #include "oi/OICompiler.h"
-#include "oi/SymbolService.h"
+
+class SymbolService;
+namespace ObjectIntrospection {
+class OILibrary;
+}
 
 namespace ObjectIntrospection {
 

--- a/oi/OIUtils.cpp
+++ b/oi/OIUtils.cpp
@@ -17,12 +17,17 @@
 
 #include <glog/logging.h>
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/property_tree/ini_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
+#include <bitset>
+#include <chrono>
 #include <filesystem>
+#include <ostream>
+#include <set>
+#include <string_view>
+#include <utility>
+#include <vector>
 
+#include "oi/ContainerInfo.h"
+#include "oi/ContainerTypeEnum.h"
 #include "oi/support/Toml.h"
 
 namespace fs = std::filesystem;

--- a/oi/OIUtils.h
+++ b/oi/OIUtils.h
@@ -15,8 +15,9 @@
  */
 #pragma once
 
+#include <map>
 #include <optional>
-#include <set>
+#include <string>
 
 #include "oi/Features.h"
 #include "oi/OICodeGen.h"

--- a/oi/PaddingHunter.cpp
+++ b/oi/PaddingHunter.cpp
@@ -16,7 +16,9 @@
 #include "oi/PaddingHunter.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
+#include <utility>
 
 void PaddingHunter::processLocalPaddingInfo() {
   for (auto& lPS : localPaddedStructs) {

--- a/oi/PaddingHunter.h
+++ b/oi/PaddingHunter.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <cstddef>
 #include <map>
 #include <string>
 #include <vector>

--- a/oi/Serialize.cpp
+++ b/oi/Serialize.cpp
@@ -18,9 +18,20 @@
 #include <boost/format.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/version.hpp>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <ostream>
 #include <stdexcept>
+#include <string>
+#include <typeinfo>
 
 #include "oi/DrgnUtils.h"
+#include "oi/SymbolService.h"
+
+extern "C" {
+#include <drgn.h>
+}
 
 namespace boost::serialization {
 

--- a/oi/Serialize.h
+++ b/oi/Serialize.h
@@ -17,16 +17,22 @@
 
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
+#include <boost/mpl/assert.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/set.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/vector.hpp>
+#include <boost/serialization/version.hpp>
 
+#include "oi/Descs.h"
 #include "oi/PaddingHunter.h"
-#include "oi/SymbolService.h"
 #include "oi/TypeHierarchy.h"
+
+extern "C" {
+#include "drgn.h"
+}
 
 #define DEFINE_TYPE_VERSION(Type, size, version)                             \
   static_assert(                                                             \

--- a/oi/SymbolService.h
+++ b/oi/SymbolService.h
@@ -15,21 +15,28 @@
  */
 #pragma once
 
+#include <sys/types.h>
+
+#include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
-#include "oi/Descs.h"
-#include "oi/TypeHierarchy.h"
+class GlobalDesc;
+struct FuncDesc;
+struct RootInfo;
 
 namespace fs = std::filesystem;
 
 struct Dwfl;
 struct drgn_program;
+struct drgn_type;
 struct irequest;
 
 struct SymbolInfo {
@@ -45,7 +52,7 @@ class SymbolService {
   SymbolService& operator=(const SymbolService&) = delete;
   ~SymbolService();
 
-  struct drgn_program* getDrgnProgram();
+  drgn_program* getDrgnProgram();
 
   std::optional<std::string> locateBuildID();
   std::optional<SymbolInfo> locateSymbol(const std::string&,
@@ -53,7 +60,7 @@ class SymbolService {
 
   std::shared_ptr<FuncDesc> findFuncDesc(const irequest&);
   std::shared_ptr<GlobalDesc> findGlobalDesc(const std::string&);
-  static std::string getTypeName(struct drgn_type*);
+  static std::string getTypeName(drgn_type*);
   std::optional<RootInfo> getRootType(const irequest&);
 
   std::unordered_map<std::string, std::shared_ptr<FuncDesc>> funcDescs;
@@ -65,8 +72,8 @@ class SymbolService {
 
  private:
   std::variant<pid_t, fs::path> target;
-  struct Dwfl* dwfl{nullptr};
-  struct drgn_program* prog{nullptr};
+  Dwfl* dwfl{nullptr};
+  drgn_program* prog{nullptr};
 
   bool loadModules();
   bool loadModulesFromPid(pid_t);

--- a/oi/TrapInfo.h
+++ b/oi/TrapInfo.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <string>
 
+#include "oi/Descs.h"
 #include "oi/Metrics.h"
 #include "oi/OICompiler.h"
 

--- a/oi/TreeBuilder.cpp
+++ b/oi/TreeBuilder.cpp
@@ -16,27 +16,37 @@
 #include "oi/TreeBuilder.h"
 
 #include <glog/logging.h>
+#include <rocksdb/compression_type.h>
+#include <rocksdb/status.h>
+#include <unistd.h>
 
-#include <boost/algorithm/string/regex.hpp>
+#include <algorithm>
+#include <boost/algorithm/string/regex.hpp>  // IWYU pragma: keep
 #include <boost/scope_exit.hpp>
+#include <cassert>
+#include <cstddef>
 #include <fstream>
-#include <iostream>
+#include <functional>
+#include <iterator>
 #include <limits>
-#include <msgpack.hpp>
+#include <msgpack.hpp>  // IWYU pragma: keep
+#include <set>
 #include <stdexcept>
+#include <type_traits>
+#include <utility>
 
-#include "oi/ContainerInfo.h"
+#include "oi/ContainerTypeEnum.h"
 #include "oi/DrgnUtils.h"
 #include "oi/Metrics.h"
 #include "oi/OICodeGen.h"
 #include "oi/PaddingHunter.h"
+#include "oi/TypeHierarchy.h"
 #include "rocksdb/db.h"
 #include "rocksdb/options.h"
 #include "rocksdb/statistics.h"
 
 extern "C" {
 #include <drgn.h>
-#include <sys/types.h>
 }
 
 /* Tag indicating if the pointer has  been followed or skipped */

--- a/oi/TreeBuilder.h
+++ b/oi/TreeBuilder.h
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 #pragma once
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
 #include <map>
 #include <memory>
-#include <msgpack/sbuffer_decl.hpp>
+#include <msgpack/sbuffer_decl.hpp>  // IWYU pragma: keep
 #include <optional>
-#include <set>
 #include <string>
-#include <unordered_set>
+#include <string_view>
 #include <vector>
+// IWYU pragma: no_forward_declare msgpack::v1::sbuffer
 
 #include "oi/Features.h"
-#include "oi/TypeHierarchy.h"
 
-// The rocksdb includes are extremely heavy and bloat compile times,
-// so we just forward-declare `DB` to avoid making other compile units
-// pay the cost of including the relevant headers.
 namespace rocksdb {
 class DB;
 }
+struct TypeHierarchy;
 
 // Forward declared, comes from PaddingInfo.h
 struct PaddingInfo;

--- a/oi/exporters/TypeCheckingWalker.cpp
+++ b/oi/exporters/TypeCheckingWalker.cpp
@@ -15,6 +15,8 @@
  */
 #include "TypeCheckingWalker.h"
 
+#include <cstddef>
+#include <string>
 #include <type_traits>
 
 template <class>

--- a/oi/exporters/test/TypeCheckingWalkerTest.cpp
+++ b/oi/exporters/test/TypeCheckingWalkerTest.cpp
@@ -1,6 +1,15 @@
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <variant>
+#include <vector>
+
 #include "oi/exporters/TypeCheckingWalker.h"
+#include "oi/types/dy.h"
 
 using namespace ObjectIntrospection;
 using exporters::TypeCheckingWalker;

--- a/oi/support/Toml.h
+++ b/oi/support/Toml.h
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 #define TOML_HEADER_ONLY 0
-#include <toml++/toml.h>
+#include <toml++/toml.h>  // IWYU pragma: export

--- a/oi/type_graph/AddChildren.cpp
+++ b/oi/type_graph/AddChildren.cpp
@@ -15,9 +15,11 @@
  */
 #include "AddChildren.h"
 
-#include <cassert>
+#include <cstdlib>
+#include <utility>
 
 #include "DrgnParser.h"
+#include "PassManager.h"
 #include "TypeGraph.h"
 #include "oi/DrgnUtils.h"
 #include "oi/SymbolService.h"
@@ -25,6 +27,8 @@
 extern "C" {
 #include <drgn.h>
 }
+
+struct drgn_type_iterator;
 
 template <typename T>
 using ref = std::reference_wrapper<T>;

--- a/oi/type_graph/AddChildren.h
+++ b/oi/type_graph/AddChildren.h
@@ -16,11 +16,12 @@
 #pragma once
 
 #include <functional>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
 
 class SymbolService;

--- a/oi/type_graph/AddPadding.cpp
+++ b/oi/type_graph/AddPadding.cpp
@@ -15,9 +15,15 @@
  */
 #include "AddPadding.h"
 
+#include <bitset>
 #include <cassert>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <utility>
 
 #include "Flattener.h"
+#include "PassManager.h"
 #include "TypeGraph.h"
 
 template <typename T>

--- a/oi/type_graph/AddPadding.h
+++ b/oi/type_graph/AddPadding.h
@@ -15,11 +15,12 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
 #include "oi/Features.h"
 

--- a/oi/type_graph/AlignmentCalc.cpp
+++ b/oi/type_graph/AlignmentCalc.cpp
@@ -15,8 +15,11 @@
  */
 #include "AlignmentCalc.h"
 
-#include <cassert>
+#include <algorithm>
+#include <cstdint>
+#include <string>
 
+#include "PassManager.h"
 #include "TypeGraph.h"
 
 template <typename T>

--- a/oi/type_graph/AlignmentCalc.h
+++ b/oi/type_graph/AlignmentCalc.h
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
 
 namespace type_graph {

--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -17,14 +17,18 @@
 
 #include <glog/logging.h>
 
+#include "Types.h"
 #include "oi/ContainerInfo.h"
 #include "oi/DrgnUtils.h"
-#include "oi/SymbolService.h"
 
 extern "C" {
 #include <drgn.h>
 }
 
+#include <algorithm>
+#include <bitset>
+#include <cassert>
+#include <ostream>
 #include <regex>
 
 namespace type_graph {

--- a/oi/type_graph/Flattener.cpp
+++ b/oi/type_graph/Flattener.cpp
@@ -15,6 +15,15 @@
  */
 #include "Flattener.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include "NodeTracker.h"
+#include "PassManager.h"
 #include "TypeGraph.h"
 #include "TypeIdentifier.h"
 

--- a/oi/type_graph/Flattener.h
+++ b/oi/type_graph/Flattener.h
@@ -15,15 +15,16 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
-#include "NodeTracker.h"
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
 
 namespace type_graph {
+
+class NodeTracker;
 
 /*
  * Flattener

--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -15,6 +15,12 @@
  */
 #include "NameGen.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <optional>
+
+#include "PassManager.h"
 #include "TypeGraph.h"
 
 template <typename T>

--- a/oi/type_graph/NameGen.h
+++ b/oi/type_graph/NameGen.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
 
 namespace type_graph {

--- a/oi/type_graph/PassManager.cpp
+++ b/oi/type_graph/PassManager.cpp
@@ -16,9 +16,10 @@
 #include "PassManager.h"
 
 #include <glog/logging.h>
+#include <glog/vlog_is_on.h>
 
+#include <cstddef>
 #include <iostream>
-#include <sstream>
 
 #include "Printer.h"
 #include "TypeGraph.h"

--- a/oi/type_graph/PassManager.h
+++ b/oi/type_graph/PassManager.h
@@ -17,12 +17,12 @@
 
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace type_graph {
 
 class TypeGraph;
-class Type;
 
 /*
  * Pass

--- a/oi/type_graph/Printer.cpp
+++ b/oi/type_graph/Printer.cpp
@@ -16,6 +16,10 @@
 #include "Printer.h"
 
 #include <cmath>
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
 
 namespace type_graph {
 

--- a/oi/type_graph/Printer.h
+++ b/oi/type_graph/Printer.h
@@ -15,10 +15,12 @@
  */
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <ostream>
+#include <string>
 #include <unordered_map>
 
-#include "Types.h"
 #include "Visitor.h"
 
 namespace type_graph {

--- a/oi/type_graph/RemoveMembers.cpp
+++ b/oi/type_graph/RemoveMembers.cpp
@@ -15,7 +15,9 @@
  */
 #include "RemoveMembers.h"
 
-#include "AddPadding.h"
+#include <functional>
+
+#include "PassManager.h"
 #include "TypeGraph.h"
 
 namespace type_graph {

--- a/oi/type_graph/RemoveMembers.h
+++ b/oi/type_graph/RemoveMembers.h
@@ -15,10 +15,12 @@
  */
 #pragma once
 
+#include <string>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
 
 namespace type_graph {

--- a/oi/type_graph/RemoveTopLevelPointer.cpp
+++ b/oi/type_graph/RemoveTopLevelPointer.cpp
@@ -15,6 +15,12 @@
  */
 #include "RemoveTopLevelPointer.h"
 
+#include <cstddef>
+#include <ext/alloc_traits.h>
+#include <memory>
+#include <string>
+
+#include "PassManager.h"
 #include "TypeGraph.h"
 
 namespace type_graph {

--- a/oi/type_graph/RemoveTopLevelPointer.h
+++ b/oi/type_graph/RemoveTopLevelPointer.h
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
 
 namespace type_graph {

--- a/oi/type_graph/TopoSorter.cpp
+++ b/oi/type_graph/TopoSorter.cpp
@@ -15,7 +15,15 @@
  */
 #include "TopoSorter.h"
 
+#include <ext/alloc_traits.h>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "PassManager.h"
 #include "TypeGraph.h"
+#include "oi/ContainerInfo.h"
+#include "oi/ContainerTypeEnum.h"
 
 template <typename T>
 using ref = std::reference_wrapper<T>;

--- a/oi/type_graph/TopoSorter.h
+++ b/oi/type_graph/TopoSorter.h
@@ -15,12 +15,12 @@
  */
 #pragma once
 
+#include <functional>
 #include <queue>
 #include <unordered_set>
 #include <vector>
 
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
 
 namespace type_graph {

--- a/oi/type_graph/TypeGraph.cpp
+++ b/oi/type_graph/TypeGraph.cpp
@@ -15,6 +15,9 @@
  */
 #include "TypeGraph.h"
 
+#include "NodeTracker.h"
+#include "Types.h"
+
 namespace type_graph {
 
 NodeTracker& TypeGraph::resetTracker() noexcept {

--- a/oi/type_graph/TypeGraph.h
+++ b/oi/type_graph/TypeGraph.h
@@ -15,8 +15,10 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "NodeTracker.h"

--- a/oi/type_graph/TypeIdentifier.cpp
+++ b/oi/type_graph/TypeIdentifier.cpp
@@ -15,6 +15,17 @@
  */
 #include "TypeIdentifier.h"
 
+#include <stddef.h>
+
+#include <algorithm>
+#include <ext/alloc_traits.h>
+#include <functional>
+#include <memory>
+#include <regex>
+#include <string>
+
+#include "NodeTracker.h"
+#include "PassManager.h"
 #include "TypeGraph.h"
 #include "oi/ContainerInfo.h"
 

--- a/oi/type_graph/TypeIdentifier.h
+++ b/oi/type_graph/TypeIdentifier.h
@@ -17,15 +17,15 @@
 
 #include <vector>
 
-#include "NodeTracker.h"
 #include "PassManager.h"
-#include "Types.h"
 #include "Visitor.h"
-#include "oi/ContainerInfo.h"
+
+struct ContainerInfo;
 
 namespace type_graph {
 
 class TypeGraph;
+class NodeTracker;
 
 /*
  * TODO Pass Name

--- a/oi/type_graph/Types.cpp
+++ b/oi/type_graph/Types.cpp
@@ -15,6 +15,8 @@
  */
 #include "Types.h"
 
+#include <cstdlib>
+
 #include "Visitor.h"
 
 namespace type_graph {

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -30,8 +30,12 @@
  */
 
 #include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "oi/ContainerInfo.h"
@@ -48,9 +52,20 @@
   X(Dummy)           \
   X(DummyAllocator)
 
-struct ContainerInfo;
-
 namespace type_graph {
+
+class Array;
+class Class;
+class Container;
+class Dummy;
+class DummyAllocator;
+class Enum;
+class Pointer;
+class Primitive;
+class Typedef;
+
+class ConstVisitor;
+class Visitor;
 
 // Must be signed. "-1" represents "leaf node"
 using NodeId = int32_t;
@@ -61,8 +76,6 @@ enum class Qualifier {
 };
 using QualifierSet = EnumBitset<Qualifier, static_cast<size_t>(Qualifier::Max)>;
 
-class Visitor;
-class ConstVisitor;
 #define DECLARE_ACCEPT              \
   void accept(Visitor& v) override; \
   void accept(ConstVisitor& v) const override;
@@ -124,7 +137,6 @@ struct Function {
   int virtuality;
 };
 
-class Class;
 struct Parent {
   Parent(Type& type, uint64_t bitOffset) : type_(type), bitOffset(bitOffset) {
   }

--- a/oi/types/test/StaticTest.cpp
+++ b/oi/types/test/StaticTest.cpp
@@ -1,5 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <functional>
+#include <span>
+#include <string>
+#include <variant>
+
 #define DEFINE_DESCRIBE 1
 #include "oi/types/dy.h"
 #include "oi/types/st.h"

--- a/test/TypeGraphParser.cpp
+++ b/test/TypeGraphParser.cpp
@@ -1,7 +1,15 @@
 #include "TypeGraphParser.h"
 
+#include <bitset>
+#include <cstdint>
+#include <cstdlib>
+#include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "oi/ContainerInfo.h"
+#include "oi/ContainerTypeEnum.h"
 #include "oi/type_graph/TypeGraph.h"
 
 namespace {

--- a/test/TypeGraphParser.h
+++ b/test/TypeGraphParser.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <cstddef>
 #include <functional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "oi/type_graph/Types.h"

--- a/test/integration/folly_shims.cpp
+++ b/test/integration/folly_shims.cpp
@@ -1,5 +1,10 @@
 #include <folly/ScopeGuard.h>
-#include <folly/lang/SafeAssert.h>
+
+#include <cstdlib>
+
+namespace folly::detail {
+struct safe_assert_arg;
+}  // namespace folly::detail
 
 namespace folly {
 namespace detail {

--- a/test/integration/runner_common.cpp
+++ b/test/integration/runner_common.cpp
@@ -1,15 +1,27 @@
 #include "runner_common.h"
 
+#include <getopt.h>
+#include <gtest/gtest.h>
+
 #include <algorithm>
+#include <array>
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
 #include <boost/process.hpp>
+#include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <ios>
 #include <iostream>
+#include <iterator>
+#include <memory>
+#include <sstream>
 #include <string>
+#include <string_view>
+#include <type_traits>
 #include <utility>
 
 #include "oi/OIOpts.h"

--- a/test/integration/runner_common.h
+++ b/test/integration/runner_common.h
@@ -6,9 +6,8 @@
 #include <boost/process.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <filesystem>
-#include <future>
-#include <iostream>
 #include <string>
+#include <vector>
 
 struct OidOpts {
   boost::asio::io_context& ctx;

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -1,15 +1,25 @@
+#include "test_drgn_parser.h"
+
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <regex>
+#include <sstream>
+#include <utility>
+#include <vector>
 
-#include "oi/SymbolService.h"
-// TODO needed?:
 #include "oi/ContainerInfo.h"
+#include "oi/ContainerTypeEnum.h"
 #include "oi/OIParser.h"
+#include "oi/SymbolService.h"
+#include "oi/TypeHierarchy.h"
 #include "oi/type_graph/Printer.h"
 #include "oi/type_graph/TypeGraph.h"
 #include "oi/type_graph/Types.h"
-#include "test_drgn_parser.h"
+
+extern "C" {
+#include <drgn.h>
+}
 
 using namespace type_graph;
 using ::testing::HasSubstr;

--- a/test/test_drgn_parser.h
+++ b/test/test_drgn_parser.h
@@ -1,7 +1,11 @@
 #pragma once
-
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
+#include <string>
+#include <string_view>
+
+#include "oi/SymbolService.h"
 #include "oi/type_graph/DrgnParser.h"
 
 namespace type_graph {


### PR DESCRIPTION
## Summary

I got Include What You Use (IWYU) working on our repo in CI. It still has too many positives (both true and false) left to enable, so this is a (large) first round of fixes. IWYU ensures that every source file includes exactly what it uses, nothing more and nothing less. This gives you more freedom to move things around/forward declare things in other files as you know nothing is transitively including things.

## Test plan

- `make clobber; make configure-devel && make test`
- CI
- Will import this PR and check the internal build.
