### PR TITLE
move all internal logic to oi::detail namespace

### DIFF
--- a/include/oi/types/dy.h
+++ b/include/oi/types/dy.h
@@ -29,9 +29,9 @@
  * translating these types to OID/OITB they cannot be compiled in, so we
  * represent the template arguments with member fields instead.
  *
- * Each type in this namespace corresponds 1-1 with a type in
- * ObjectIntrospection::types::st, except Dynamic which references them all. See
- * the types in st.h for the description of what each type contains.
+ * Each type in this namespace corresponds 1-1 with a type in oi::types::st,
+ * except Dynamic which references them all. See the types in st.h for the
+ * description of what each type contains.
  *
  * All types in this file include a constexpr constructor. This allows a single
  * extern const variable in the JIT code to include pointer references to other
@@ -43,7 +43,7 @@
 #include <span>
 #include <variant>
 
-namespace ObjectIntrospection::types::dy {
+namespace oi::types::dy {
 
 class Unit;
 class VarInt;
@@ -93,6 +93,6 @@ class List {
   Dynamic element;
 };
 
-}  // namespace ObjectIntrospection::types::dy
+}  // namespace oi::types::dy
 
 #endif

--- a/include/oi/types/st.h
+++ b/include/oi/types/st.h
@@ -55,7 +55,7 @@
  * dynamic description of their type as the constexpr field `describe`. Compound
  * types compose appropriately.
  */
-namespace ObjectIntrospection::types::st {
+namespace oi::types::st {
 
 #ifdef DEFINE_DESCRIBE
 #include "oi/types/dy.h"
@@ -280,6 +280,6 @@ class List
 #endif
 };
 
-}  // namespace ObjectIntrospection::types::st
+}  // namespace oi::types::st
 
 #endif

--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -40,6 +40,8 @@
 #include "type_graph/TypeIdentifier.h"
 #include "type_graph/Types.h"
 
+namespace oi::detail {
+
 using type_graph::AddChildren;
 using type_graph::AddPadding;
 using type_graph::AlignmentCalc;
@@ -861,7 +863,8 @@ void CodeGen::generate(
 
   if (config_.features[Feature::TypedDataSegment]) {
     FuncGen::DefineDataSegmentDataBuffer(code);
-    code += "using namespace ObjectIntrospection;\n";
+    code += "using namespace oi;\n";
+    code += "using namespace oi::detail;\n";
 
     code += "namespace OIInternal {\nnamespace {\n";
     FuncGen::DefineBasicTypeHandlers(code);
@@ -927,3 +930,5 @@ void CodeGen::generate(
     std::cout << code;
   }
 }
+
+}  // namespace oi::detail

--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -26,14 +26,16 @@
 #include "OICodeGen.h"
 
 struct drgn_type;
-
+namespace oi::detail {
 class SymbolService;
-
-namespace type_graph {
+}
+namespace oi::detail::type_graph {
 class Class;
 class Member;
 class TypeGraph;
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph
+
+namespace oi::detail {
 
 class CodeGen {
  public:
@@ -76,3 +78,5 @@ class CodeGen {
                        std::string& code);
   void getClassTypeHandler(const type_graph::Class& c, std::string& code);
 };
+
+}  // namespace oi::detail

--- a/oi/Features.cpp
+++ b/oi/Features.cpp
@@ -19,7 +19,7 @@
 #include <numeric>
 #include <stdexcept>
 
-namespace ObjectIntrospection {
+namespace oi::detail {
 namespace {
 
 std::string_view featureHelp(Feature f) {
@@ -101,4 +101,4 @@ void featuresHelp(std::ostream& out) {
   }
 }
 
-}  // namespace ObjectIntrospection
+}  // namespace oi::detail

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -36,7 +36,7 @@
   X(JitTiming, "jit-timing")                               \
   X(PolymorphicInheritance, "polymorphic-inheritance")
 
-namespace ObjectIntrospection {
+namespace oi::detail {
 
 enum class Feature {
   UnknownFeature,
@@ -58,4 +58,4 @@ constexpr std::array allFeatures = {
 // Use "size+1" to account for UnknownFeature"
 using FeatureSet = EnumBitset<Feature, allFeatures.size() + 1>;
 
-}  // namespace ObjectIntrospection
+}  // namespace oi::detail

--- a/oi/FuncGen.cpp
+++ b/oi/FuncGen.cpp
@@ -22,9 +22,7 @@
 
 #include "oi/ContainerInfo.h"
 
-using ObjectIntrospection::Feature;
-using ObjectIntrospection::FeatureSet;
-
+namespace oi::detail {
 namespace {
 
 const std::string typedValueFunc = R"(
@@ -538,7 +536,7 @@ void FuncGen::DeclareGetContainer(std::string& testCode) {
  */
 void FuncGen::DefineDataSegmentDataBuffer(std::string& testCode) {
   constexpr std::string_view func = R"(
-    namespace ObjectIntrospection::DataBuffer {
+    namespace oi::detail::DataBuffer {
 
     class DataSegment {
       public:
@@ -560,7 +558,7 @@ void FuncGen::DefineDataSegmentDataBuffer(std::string& testCode) {
         uint8_t* buf;
     };
 
-    } // namespace ObjectIntrospection::DataBuffer
+    } // namespace oi::detail::DataBuffer
   )";
 
   testCode.append(func);
@@ -632,3 +630,5 @@ void FuncGen::DefineBasicTypeHandlers(std::string& testCode) {
   testCode.append(tHandler);
   testCode.append(voidHandler);
 }
+
+}  // namespace oi::detail

--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -24,6 +24,8 @@
 
 namespace fs = std::filesystem;
 
+namespace oi::detail {
+
 class FuncGen {
  public:
   static void DeclareStoreData(std::string& testCode);
@@ -40,10 +42,10 @@ class FuncGen {
 
   bool DeclareGetSizeFuncs(std::string& testCode,
                            const ContainerInfoRefSet& containerInfo,
-                           ObjectIntrospection::FeatureSet features);
+                           FeatureSet features);
   bool DefineGetSizeFuncs(std::string& testCode,
                           const ContainerInfoRefSet& containerInfo,
-                          ObjectIntrospection::FeatureSet features);
+                          FeatureSet features);
 
   static void DeclareGetContainer(std::string& testCode);
 
@@ -55,24 +57,21 @@ class FuncGen {
                                           const std::string& type,
                                           const std::string& linkageName);
 
-  static void DefineTopLevelGetSizeRef(
-      std::string& testCode,
-      const std::string& rawType,
-      ObjectIntrospection::FeatureSet features);
-  static void DefineTopLevelGetSizeRefTyped(
-      std::string& testCode,
-      const std::string& rawType,
-      ObjectIntrospection::FeatureSet features);
+  static void DefineTopLevelGetSizeRef(std::string& testCode,
+                                       const std::string& rawType,
+                                       FeatureSet features);
+  static void DefineTopLevelGetSizeRefTyped(std::string& testCode,
+                                            const std::string& rawType,
+                                            FeatureSet features);
   static void DefineOutputType(std::string& testCode,
                                const std::string& rawType);
 
   static void DefineTopLevelGetSizeRefRet(std::string& testCode,
                                           const std::string& type);
 
-  static void DefineTopLevelGetSizeSmartPtr(
-      std::string& testCode,
-      const std::string& rawType,
-      ObjectIntrospection::FeatureSet features);
+  static void DefineTopLevelGetSizeSmartPtr(std::string& testCode,
+                                            const std::string& rawType,
+                                            FeatureSet features);
 
   static void DefineGetSizeTypedValueFunc(std::string& testCode,
                                           const std::string& ctype);
@@ -80,3 +79,5 @@ class FuncGen {
   static void DefineDataSegmentDataBuffer(std::string& testCode);
   static void DefineBasicTypeHandlers(std::string& testCode);
 };
+
+}  // namespace oi::detail

--- a/oi/Headers.h
+++ b/oi/Headers.h
@@ -15,13 +15,11 @@
  */
 #include <string_view>
 
-namespace ObjectIntrospection {
-namespace headers {
+namespace oi::detail::headers {
 
 // These externs are provided by our build system. See resources/CMakeLists.txt
 extern const std::string_view oi_OITraceCode_cpp;
 extern const std::string_view oi_types_st_h;
 extern const std::string_view oi_types_dy_h;
 
-}  // namespace headers
-}  // namespace ObjectIntrospection
+}  // namespace oi::detail::headers

--- a/oi/Metrics.cpp
+++ b/oi/Metrics.cpp
@@ -29,7 +29,7 @@
  *
  * You can instrument some code with:
  * ```
- * auto t = Metrics::Tracing("name_of_your_trace");
+ * auto t = metrics::Tracing("name_of_your_trace");
  * [... some code ...]
  * t.stop();
  * ```
@@ -40,13 +40,13 @@
  * Alternatively, you can use automatically deal with this in every return
  * point thanks to C++'s RAII:
  * ```
- * Metrics::Tracing unused_var("name_of_your_trace");
+ * metrics::Tracing unused_var("name_of_your_trace");
  * ```
  *
  * When you want to collect the data, `::showTraces()` to print the data to
  * stdout, and `::saveTraces(file)` to save it to disk using JSON.
  */
-namespace ObjectIntrospection::Metrics {
+namespace oi::detail::metrics {
 
 static inline TraceFlags parseTraceFlags(const char* flags) {
   if (flags == nullptr) {
@@ -204,4 +204,4 @@ std::ostream& operator<<(std::ostream& out, const std::vector<Span>& spans) {
   return out;
 }
 
-}  // namespace ObjectIntrospection::Metrics
+}  // namespace oi::detail::metrics

--- a/oi/Metrics.h
+++ b/oi/Metrics.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace ObjectIntrospection::Metrics {
+namespace oi::detail::metrics {
 
 constexpr auto traceEnvKey = "OID_METRICS_TRACE";
 constexpr auto outputEnvKey = "OID_METRICS_OUTPUT";
@@ -75,9 +75,9 @@ class Tracing final {
 
  public:
   /*
-   *   Metrics::Tracing("bad");
+   *   metrics::Tracing("bad");
    *
-   * Usage is Metrics::Tracing __varname_(...) The code above is an improper
+   * Usage is metrics::Tracing __varname_(...) The code above is an improper
    * use of the Tracing library. The tracing object above is not stored in a
    * variable. So it is immediately destroyed and won't record the expected
    * results. [[nodiscard]] flags the code above with a warning, which we
@@ -170,4 +170,4 @@ std::ostream& operator<<(std::ostream&, const TraceFlags&);
 std::ostream& operator<<(std::ostream&, const Span&);
 std::ostream& operator<<(std::ostream&, const std::vector<Span>&);
 
-}  // namespace ObjectIntrospection::Metrics
+}  // namespace oi::detail::metrics

--- a/oi/OICache.cpp
+++ b/oi/OICache.cpp
@@ -30,6 +30,8 @@
 #include "cea/object-introspection/internal/ManifoldCache.h"
 #endif
 
+namespace oi::detail {
+
 static std::optional<std::reference_wrapper<const std::string>> getEntName(
     SymbolService& symbols, const irequest& req, OICache::Entity ent) {
   if (ent == OICache::Entity::FuncDescs ||
@@ -250,3 +252,5 @@ std::string OICache::generateRemoteHash(const irequest& req) {
   LOG(INFO) << "generating remote hash from: " << remote_cache_id;
   return std::to_string(std::hash<std::string>{}(remote_cache_id));
 }
+
+}  // namespace oi::detail

--- a/oi/OICache.h
+++ b/oi/OICache.h
@@ -24,7 +24,7 @@
 #include "oi/OIParser.h"
 #include "oi/SymbolService.h"
 
-namespace fs = std::filesystem;
+namespace oi::detail {
 
 class OICache {
  public:
@@ -32,7 +32,7 @@ class OICache {
       : generatorConfig(generatorConfig) {
   }
 
-  fs::path basePath{};
+  std::filesystem::path basePath{};
   std::shared_ptr<SymbolService> symbols{};
   bool downloadedRemote = false;
   bool enableUpload = false;
@@ -60,7 +60,7 @@ class OICache {
   bool isEnabled() const {
     return !basePath.empty();
   }
-  std::optional<fs::path> getPath(const irequest&, Entity) const;
+  std::optional<std::filesystem::path> getPath(const irequest&, Entity) const;
   template <typename T>
   bool store(const irequest&, Entity, const T&);
   template <typename T>
@@ -72,3 +72,5 @@ class OICache {
  private:
   std::string generateRemoteHash(const irequest&);
 };
+
+}  // namespace oi::detail

--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -40,6 +40,8 @@
 
 namespace fs = std::filesystem;
 
+namespace oi::detail {
+
 static size_t g_level = 0;
 
 #undef VLOG
@@ -3773,3 +3775,5 @@ std::vector<std::string> OICodeGen::Config::toOptions() const {
 void OICodeGen::initializeCodeGen() {
   LOG(WARNING) << "OICodeGen::initializeCodeGen is no longer necessary";
 };
+
+}  // namespace oi::detail

--- a/oi/OICodeGen.h
+++ b/oi/OICodeGen.h
@@ -23,7 +23,6 @@
 #include <unordered_map>
 #include <vector>
 
-class SymbolService;
 struct irequest;
 
 #include "oi/ContainerInfo.h"
@@ -36,8 +35,11 @@ extern "C" {
 #include <drgn.h>
 }
 
-using namespace ObjectIntrospection;
-namespace fs = std::filesystem;
+namespace oi::detail {
+class SymbolService;
+}
+
+namespace oi::detail {
 
 struct ParentMember {
   drgn_type* type;
@@ -59,7 +61,7 @@ class OICodeGen {
 
     bool useDataSegment;
     FeatureSet features;
-    std::set<fs::path> containerConfigPaths;
+    std::set<std::filesystem::path> containerConfigPaths;
     std::set<std::string> defaultHeaders;
     std::set<std::string> defaultNamespaces;
     std::vector<std::pair<std::string, std::string>> membersToStub;
@@ -360,3 +362,5 @@ class OICodeGen {
       std::vector<std::string>& template_params_strings,
       const std::string& nameWithoutTemplate);
 };
+
+}  // namespace oi::detail

--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -47,11 +47,12 @@ extern "C" {
 #include <llvm-c/Disassembler.h>
 }
 
+namespace oi::detail {
+
 using namespace std;
 using namespace clang;
 using namespace llvm;
 using namespace llvm::object;
-using namespace ObjectIntrospection;
 
 static const char* symbolLookupCallback(
     [[maybe_unused]] void* disInfo,
@@ -467,7 +468,7 @@ static void debugDisAsm(
 bool OICompiler::compile(const std::string& code,
                          const fs::path& sourcePath,
                          const fs::path& objectPath) {
-  Metrics::Tracing _("compile");
+  metrics::Tracing _("compile");
 
   /*
    * Note to whoever: if you're having problems compiling code, especially
@@ -588,7 +589,7 @@ std::optional<OICompiler::RelocResult> OICompiler::applyRelocs(
     uintptr_t baseRelocAddress,
     const std::set<fs::path>& objectFiles,
     const std::unordered_map<std::string, uintptr_t>& syntheticSymbols) {
-  Metrics::Tracing relocationTracing("relocation");
+  metrics::Tracing relocationTracing("relocation");
 
   memMgr = std::make_unique<OIMemoryManager>(symbols, syntheticSymbols);
   RuntimeDyld dyld(*memMgr, *memMgr);
@@ -666,3 +667,5 @@ std::optional<OICompiler::RelocResult> OICompiler::applyRelocs(
 
   return res;
 }
+
+}  // namespace oi::detail

--- a/oi/OICompiler.h
+++ b/oi/OICompiler.h
@@ -29,6 +29,8 @@
 #include "oi/SymbolService.h"
 #include "oi/X86InstDefs.h"
 
+namespace oi::detail {
+
 namespace fs = std::filesystem;
 
 class OIMemoryManager;
@@ -42,7 +44,7 @@ class OICompiler {
  public:
   /* Configuration option for `OICompiler` */
   struct Config {
-    ObjectIntrospection::FeatureSet features;
+    FeatureSet features;
 
     std::vector<fs::path> userHeaderPaths{};
     std::vector<fs::path> sysHeaderPaths{};
@@ -221,3 +223,5 @@ std::optional<std::vector<uintptr_t>> OICompiler::locateOpcodes(
 
   return locs;
 }
+
+}  // namespace oi::detail

--- a/oi/OID.cpp
+++ b/oi/OID.cpp
@@ -38,11 +38,10 @@ extern "C" {
 #include "oi/TimeUtils.h"
 #include "oi/TreeBuilder.h"
 
+namespace oi::detail {
+
 /* Global for signal handling */
 std::weak_ptr<OIDebugger> weak_oid;
-
-namespace fs = std::filesystem;
-using namespace ObjectIntrospection;
 
 // Using an enum inside a namespace here instead of an `enum class` because
 // enums defined via `enum class` aren't implicitly convertible to `int`, and
@@ -432,7 +431,7 @@ static ExitStatus::ExitStatus runScript(
 
     {  // Resume stopped thread before cleanup
       VLOG(1) << "Resuming stopped threads...";
-      Metrics::Tracing __("resume_threads");
+      metrics::Tracing __("resume_threads");
       while (oid->processTrap(oidConfig.pid, false) == OIDebugger::OID_CONT) {
       }
     }
@@ -457,7 +456,11 @@ static ExitStatus::ExitStatus runScript(
   return ExitStatus::Success;
 }
 
+}  // namespace oi::detail
+
 int main(int argc, char* argv[]) {
+  using namespace oi::detail;
+
   int debugLevel = 1;
   Oid::Config oidConfig = {};
   std::string scriptFile;
@@ -474,7 +477,7 @@ int main(int argc, char* argv[]) {
   bool logAllStructs = true;
   bool dumpDataSegment = false;
 
-  Metrics::Tracing _("main");
+  metrics::Tracing _("main");
 #ifndef OSS_ENABLE
   folly::InitOptions init;
   init.useGFlags(false);
@@ -679,8 +682,8 @@ int main(int argc, char* argv[]) {
       .jsonPath = jsonPath,
   };
 
-  auto featureSet = OIUtils::processConfigFile(oidConfig.configFile, features,
-                                               compilerConfig, codeGenConfig);
+  auto featureSet = utils::processConfigFile(oidConfig.configFile, features,
+                                             compilerConfig, codeGenConfig);
   if (!featureSet) {
     return ExitStatus::UsageError;
   }
@@ -708,11 +711,11 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  if (Metrics::Tracing::isEnabled()) {
-    LOG(INFO) << "Will write metrics (" << Metrics::Tracing::isEnabled()
-              << ") in " << Metrics::Tracing::outputPath();
+  if (metrics::Tracing::isEnabled()) {
+    LOG(INFO) << "Will write metrics (" << metrics::Tracing::isEnabled()
+              << ") in " << metrics::Tracing::outputPath();
   } else {
-    LOG(INFO) << "Will not write any metric: " << Metrics::Tracing::isEnabled();
+    LOG(INFO) << "Will not write any metric: " << metrics::Tracing::isEnabled();
   }
 
   return ExitStatus::Success;

--- a/oi/OIDebugger.h
+++ b/oi/OIDebugger.h
@@ -29,7 +29,7 @@
 #include "oi/TreeBuilder.h"
 #include "oi/X86InstDefs.h"
 
-namespace fs = std::filesystem;
+namespace oi::detail {
 
 class OIDebugger {
   OIDebugger(const OICodeGen::Config&, OICompiler::Config, TreeBuilder::Config);
@@ -39,7 +39,7 @@ class OIDebugger {
              const OICodeGen::Config&,
              OICompiler::Config,
              TreeBuilder::Config);
-  OIDebugger(fs::path,
+  OIDebugger(std::filesystem::path,
              const OICodeGen::Config&,
              OICompiler::Config,
              TreeBuilder::Config);
@@ -77,11 +77,12 @@ class OIDebugger {
     return oidShouldExit;
   };
 
-  void setCacheBasePath(fs::path basePath) {
-    if (fs::exists(basePath.parent_path()) && !fs::exists(basePath)) {
+  void setCacheBasePath(std::filesystem::path basePath) {
+    if (std::filesystem::exists(basePath.parent_path()) &&
+        !std::filesystem::exists(basePath)) {
       // Create cachedir if parent directory exists
       // TODO if returning false here, throw an error
-      fs::create_directory(basePath);
+      std::filesystem::create_directory(basePath);
     }
     cache.basePath = std::move(basePath);
   }
@@ -140,7 +141,7 @@ class OIDebugger {
     return std::get<2>(typeInfos.at(pdata.getReq().getReqForArg()));
   }
 
-  void setCustomCodeFile(fs::path newCCT) {
+  void setCustomCodeFile(std::filesystem::path newCCT) {
     customCodeFile = std::move(newCCT);
   }
 
@@ -243,8 +244,8 @@ class OIDebugger {
   std::optional<std::string> generateCode(const irequest&);
 
   std::fstream segmentConfigFile;
-  fs::path segConfigFilePath;
-  fs::path customCodeFile;
+  std::filesystem::path segConfigFilePath;
+  std::filesystem::path customCodeFile;
 
   struct c {
     uintptr_t textSegBase{};
@@ -293,3 +294,5 @@ class OIDebugger {
   static constexpr size_t prologueLength = 64;
   static constexpr size_t constLength = 64;
 };
+
+}  // namespace oi::detail

--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -28,7 +28,7 @@
 #include "oi/Headers.h"
 #include "oi/OIUtils.h"
 
-namespace ObjectIntrospection {
+namespace oi::detail {
 
 std::unordered_map<std::string, std::string>
 OIGenerator::oilStrongToWeakSymbolsMap(drgnplusplus::program& prog) {
@@ -191,8 +191,8 @@ int OIGenerator::generate(fs::path& primaryObject, SymbolService& symbols) {
   OICodeGen::Config generatorConfig{};
   OICompiler::Config compilerConfig{};
 
-  auto features = OIUtils::processConfigFile(configFilePath, featuresMap,
-                                             compilerConfig, generatorConfig);
+  auto features = utils::processConfigFile(configFilePath, featuresMap,
+                                           compilerConfig, generatorConfig);
   if (!features) {
     LOG(ERROR) << "failed to process config file";
     return -1;
@@ -223,4 +223,4 @@ int OIGenerator::generate(fs::path& primaryObject, SymbolService& symbols) {
   return 0;
 }
 
-}  // namespace ObjectIntrospection
+}  // namespace oi::detail

--- a/oi/OIGenerator.h
+++ b/oi/OIGenerator.h
@@ -22,7 +22,7 @@
 #include "oi/OICodeGen.h"
 #include "oi/OICompiler.h"
 
-namespace ObjectIntrospection {
+namespace oi::detail {
 
 class OIGenerator {
  public:
@@ -61,4 +61,4 @@ class OIGenerator {
       SymbolService& symbols);
 };
 
-}  // namespace ObjectIntrospection
+}  // namespace oi::detail

--- a/oi/OILexer.h
+++ b/oi/OILexer.h
@@ -27,7 +27,7 @@
 #include "OIParser.tab.hh"
 #include "location.hh"
 
-namespace ObjectIntrospection {
+namespace oi::detail {
 
 class OIScanner : public yyFlexLexer {
  public:
@@ -48,4 +48,4 @@ class OIScanner : public yyFlexLexer {
   OIParser::semantic_type* yylval = nullptr;
 };
 
-}  // namespace ObjectIntrospection
+}  // namespace oi::detail

--- a/oi/OILexer.l
+++ b/oi/OILexer.l
@@ -21,11 +21,11 @@
 #include "oi/OILexer.h"
 #undef  YY_DECL
 #define YY_DECL \
-  int ObjectIntrospection::OIScanner::yylex(ObjectIntrospection::OIParser::semantic_type * const lval, \
-                           ObjectIntrospection::OIParser::location_type *loc )
+  int oi::detail::OIScanner::yylex(oi::detail::OIParser::semantic_type * const lval, \
+                           oi::detail::OIParser::location_type *loc )
 
 /* typedef to make the returns for the tokens shorter */
-using token = ObjectIntrospection::OIParser::token;
+using token = oi::detail::OIParser::token;
 
 /* update location on matching */
 #define YY_USER_ACTION loc->step(); loc->columns(yyleng);
@@ -33,7 +33,7 @@ using token = ObjectIntrospection::OIParser::token;
 
 %option debug
 %option nodefault
-%option yyclass="ObjectIntrospection::OIScanner"
+%option yyclass="oi::detail::OIScanner"
 %option noyywrap
 %option c++
 
@@ -90,7 +90,7 @@ using token = ObjectIntrospection::OIParser::token;
 
 <<EOF>>   {
             if (YYSTATE == COMMENT) {
-              throw ObjectIntrospection::OIParser::syntax_error(
+              throw oi::detail::OIParser::syntax_error(
                 *loc, "unterminated /* comment");
             } else {
               return( token::OI_EOF );

--- a/oi/OILibraryImpl.cpp
+++ b/oi/OILibraryImpl.cpp
@@ -35,6 +35,8 @@ extern "C" {
 
 namespace ObjectIntrospection {
 
+using namespace oi::detail;
+
 OILibraryImpl::OILibraryImpl(OILibrary* self, void* TemplateFunc)
     : _self(self), _TemplateFunc(TemplateFunc) {
   if (_self->opts.debugLevel != 0) {
@@ -84,7 +86,7 @@ void OILibraryImpl::initCompiler() {
 }
 
 bool OILibraryImpl::processConfigFile() {
-  auto features = OIUtils::processConfigFile(
+  auto features = utils::processConfigFile(
       _self->opts.configFilePath,
       {
           {Feature::ChaseRawPointers, _self->opts.chaseRawPointers},

--- a/oi/OILibraryImpl.h
+++ b/oi/OILibraryImpl.h
@@ -39,9 +39,9 @@ class OILibraryImpl {
 
   void* _TemplateFunc;
 
-  OICompiler::Config compilerConfig{};
-  OICodeGen::Config generatorConfig{};
-  std::shared_ptr<SymbolService> symbols{};
+  oi::detail::OICompiler::Config compilerConfig{};
+  oi::detail::OICodeGen::Config generatorConfig{};
+  std::shared_ptr<oi::detail::SymbolService> symbols{};
 
   struct c {
     void* textSegBase = nullptr;

--- a/oi/OIParser.yy
+++ b/oi/OIParser.yy
@@ -15,16 +15,16 @@
  */
 
 /*
- * This is the bison grammar responsible for generating the ObjectIntrospection::OIParser class.
- * This class gives us a number of things worth calling out here if only to
- * remind me later :-):
+ * This is the bison grammar responsible for generating the oi::detail::OIParser
+ * class. This class gives us a number of things worth calling out here if only
+ * to remind me later :-):
  *
  * - A variant interface that replaces the C union interface for the
  * parsers semantic values. Enabled by setting 'api.value.type variant' below.
  */
 %skeleton "lalr1.cc"
 %defines
-%define api.namespace {ObjectIntrospection}
+%define api.namespace {oi::detail}
 %define api.parser.class {OIParser}
 %define parse.trace
 %define parse.error verbose
@@ -32,14 +32,14 @@
 
 %code requires{
   #include <list>
-  namespace ObjectIntrospection {
+  namespace oi::detail {
     class OIScanner;
   }
   class ParseData;
 }
 
 /*
- * ObjectIntrospection::OI_Parser constructor parameters. The scanner object is produced
+ * oi::detail::OIParser constructor parameters. The scanner object is produced
  * by flex and is derived from the yyFlexLexer class. The parser calls
  * its yylex() implementation to generate input tokens. The ParseData
  * object is spopulated by the lexer/parser introspection specifications
@@ -100,7 +100,7 @@ oi_block: OI_PROBETYPE OI_COLON OI_FUNC OI_COLON oi_args
 
 
 void
-ObjectIntrospection::OIParser::error(const location_type &l, const std::string &err_message)
+oi::detail::OIParser::error(const location_type &l, const std::string &err_message)
 {
   LOG(ERROR) << "OI Parse Error: " << err_message << " at " << l;
 }

--- a/oi/OIUtils.cpp
+++ b/oi/OIUtils.cpp
@@ -27,12 +27,11 @@
 
 namespace fs = std::filesystem;
 
-namespace OIUtils {
+namespace oi::detail::utils {
 
-using namespace ObjectIntrospection;
 using namespace std::literals;
 
-std::optional<ObjectIntrospection::FeatureSet> processConfigFile(
+std::optional<FeatureSet> processConfigFile(
     const std::string& configFilePath,
     std::map<Feature, bool> featureMap,
     OICompiler::Config& compilerConfig,
@@ -173,7 +172,7 @@ std::optional<ObjectIntrospection::FeatureSet> processConfigFile(
     }
   }
 
-  ObjectIntrospection::FeatureSet featuresSet;
+  FeatureSet featuresSet;
   for (auto [k, v] : featureMap) {
     if (v) {
       featuresSet[k] = true;
@@ -208,4 +207,4 @@ std::optional<ObjectIntrospection::FeatureSet> processConfigFile(
   return featuresSet;
 }
 
-}  // namespace OIUtils
+}  // namespace oi::detail::utils

--- a/oi/OIUtils.h
+++ b/oi/OIUtils.h
@@ -22,12 +22,11 @@
 #include "oi/OICodeGen.h"
 #include "oi/OICompiler.h"
 
-namespace OIUtils {
+namespace oi::detail::utils {
 
-std::optional<ObjectIntrospection::FeatureSet> processConfigFile(
-    const std::string& configFilePath,
-    std::map<Feature, bool> featureMap,
-    OICompiler::Config& compilerConfig,
-    OICodeGen::Config& generatorConfig);
+std::optional<FeatureSet> processConfigFile(const std::string& configFilePath,
+                                            std::map<Feature, bool> featureMap,
+                                            OICompiler::Config& compilerConfig,
+                                            OICodeGen::Config& generatorConfig);
 
-}  // namespace OIUtils
+}  // namespace oi::detail::utils

--- a/oi/SymbolService.cpp
+++ b/oi/SymbolService.cpp
@@ -34,6 +34,10 @@ extern "C" {
 #include "dwarf.h"
 }
 
+namespace fs = std::filesystem;
+
+namespace oi::detail {
+
 template <typename... Ts>
 struct visitor : Ts... {
   using Ts::operator()...;
@@ -885,3 +889,5 @@ std::optional<RootInfo> SymbolService::getRootType(const irequest& req) {
 
   return RootInfo{paramName, paramType};
 }
+
+}  // namespace oi::detail

--- a/oi/SymbolService.h
+++ b/oi/SymbolService.h
@@ -26,11 +26,11 @@
 #include "oi/Descs.h"
 #include "oi/TypeHierarchy.h"
 
-namespace fs = std::filesystem;
-
 struct Dwfl;
 struct drgn_program;
 struct irequest;
+
+namespace oi::detail {
 
 struct SymbolInfo {
   uint64_t addr;
@@ -40,7 +40,7 @@ struct SymbolInfo {
 class SymbolService {
  public:
   SymbolService(pid_t);
-  SymbolService(fs::path);
+  SymbolService(std::filesystem::path);
   SymbolService(const SymbolService&) = delete;
   SymbolService& operator=(const SymbolService&) = delete;
   ~SymbolService();
@@ -64,13 +64,13 @@ class SymbolService {
   }
 
  private:
-  std::variant<pid_t, fs::path> target;
+  std::variant<pid_t, std::filesystem::path> target;
   struct Dwfl* dwfl{nullptr};
   struct drgn_program* prog{nullptr};
 
   bool loadModules();
   bool loadModulesFromPid(pid_t);
-  bool loadModulesFromPath(const fs::path&);
+  bool loadModulesFromPath(const std::filesystem::path&);
 
   std::vector<std::pair<uint64_t, uint64_t>> executableAddrs{};
   bool hardDisableDrgn = false;
@@ -78,3 +78,5 @@ class SymbolService {
  protected:
   SymbolService() = default;  // For unit tests
 };
+
+}  // namespace oi::detail

--- a/oi/TrapInfo.h
+++ b/oi/TrapInfo.h
@@ -25,6 +25,8 @@ extern "C" {
 #include <sys/user.h>
 }
 
+namespace oi::detail {
+
 /*
  * Breakpoint traps (INT3) instructions are the primary mechanism used to
  * transfer control from the traced process to the debugger. There are several
@@ -114,7 +116,7 @@ class trapInfo {
    */
   uintptr_t replayInstAddr{};
 
-  ObjectIntrospection::Metrics::Tracing lifetime{"trap"};
+  metrics::Tracing lifetime{"trap"};
 
   trapInfo() = default;
   trapInfo(trapType t, uint64_t ta, uint64_t po = 0, bool fv = false)
@@ -132,3 +134,5 @@ inline std::ostream& operator<<(std::ostream& out, const trapInfo& t) {
   return out << "Trap " << trapTypeDescs[t.trapKind] << " @"
              << (void*)t.trapAddr;
 }
+
+}  // namespace oi::detail

--- a/oi/TreeBuilder.cpp
+++ b/oi/TreeBuilder.cpp
@@ -39,6 +39,8 @@ extern "C" {
 #include <sys/types.h>
 }
 
+namespace oi::detail {
+
 /* Tag indicating if the pointer has  been followed or skipped */
 enum class TrackPointerTag : uint64_t {
   /* The content has been skipped.
@@ -229,7 +231,7 @@ void TreeBuilder::build(const std::vector<uint64_t>& data,
 
   oidDataIndex = 4;  // HACK: OID's first 4 outputs are dummy 0s
 
-  ObjectIntrospection::Metrics::Tracing _("build_tree");
+  metrics::Tracing _("build_tree");
   VLOG(1) << "Building tree...";
 
   {
@@ -971,3 +973,5 @@ void TreeBuilder::JSON(NodeID id, std::ofstream& output) {
   }
   output << "}";
 }
+
+}  // namespace oi::detail

--- a/oi/TreeBuilder.h
+++ b/oi/TreeBuilder.h
@@ -36,12 +36,14 @@ class DB;
 // Forward declared, comes from PaddingInfo.h
 struct PaddingInfo;
 
+namespace oi::detail {
+
 class TreeBuilder {
  public:
   struct Config {
     // Don't set default values for the config so the user gets
     // an "unitialized field" warning if he missed any.
-    ObjectIntrospection::FeatureSet features;
+    FeatureSet features;
     bool logAllStructs;
     bool dumpDataSegment;
     std::optional<std::string> jsonPath;
@@ -118,3 +120,5 @@ class TreeBuilder {
                       uint64_t dynamicSize,
                       uint64_t memberSizes);
 };
+
+}  // namespace oi::detail

--- a/oi/exporters/TypeCheckingWalker.cpp
+++ b/oi/exporters/TypeCheckingWalker.cpp
@@ -20,8 +20,7 @@
 template <class>
 inline constexpr bool always_false_v = false;
 
-namespace ObjectIntrospection {
-namespace exporters {
+namespace oi::detail::exporters {
 
 std::optional<TypeCheckingWalker::Element> TypeCheckingWalker::advance() {
   if (stack.empty()) {
@@ -76,5 +75,4 @@ std::optional<TypeCheckingWalker::Element> TypeCheckingWalker::advance() {
       el);
 }
 
-}  // namespace exporters
-}  // namespace ObjectIntrospection
+}  // namespace oi::detail::exporters

--- a/oi/exporters/TypeCheckingWalker.h
+++ b/oi/exporters/TypeCheckingWalker.h
@@ -36,8 +36,7 @@
 
 #include "oi/types/dy.h"
 
-namespace ObjectIntrospection {
-namespace exporters {
+namespace oi::detail::exporters {
 
 class TypeCheckingWalker {
  public:
@@ -74,5 +73,4 @@ class TypeCheckingWalker {
   }
 };
 
-}  // namespace exporters
-}  // namespace ObjectIntrospection
+}  // namespace oi::detail::exporters

--- a/oi/exporters/test/TypeCheckingWalkerTest.cpp
+++ b/oi/exporters/test/TypeCheckingWalkerTest.cpp
@@ -2,8 +2,8 @@
 
 #include "oi/exporters/TypeCheckingWalker.h"
 
-using namespace ObjectIntrospection;
-using exporters::TypeCheckingWalker;
+using namespace oi;
+using oi::detail::exporters::TypeCheckingWalker;
 
 TEST(TypeCheckingWalker, TestUnit) {
   // ASSIGN

--- a/oi/type_graph/AddChildren.cpp
+++ b/oi/type_graph/AddChildren.cpp
@@ -29,7 +29,7 @@ extern "C" {
 template <typename T>
 using ref = std::reference_wrapper<T>;
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass AddChildren::createPass(DrgnParser& drgnParser, SymbolService& symbols) {
   auto fn = [&drgnParser, &symbols](TypeGraph& typeGraph) {
@@ -202,4 +202,4 @@ void AddChildren::enumerateChildClasses(SymbolService& symbols) {
   drgn_type_iterator_destroy(typesIterator);
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/AddChildren.h
+++ b/oi/type_graph/AddChildren.h
@@ -23,10 +23,12 @@
 #include "Types.h"
 #include "Visitor.h"
 
-class SymbolService;
 struct drgn_type;
+namespace oi::detail {
+class SymbolService;
+}
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 class DrgnParser;
 class TypeGraph;
@@ -74,4 +76,4 @@ class AddChildren final : public RecursiveVisitor {
   std::unordered_map<std::string, std::vector<drgn_type*>> childClasses_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/AddPadding.cpp
+++ b/oi/type_graph/AddPadding.cpp
@@ -22,7 +22,7 @@
 template <typename T>
 using ref = std::reference_wrapper<T>;
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass AddPadding::createPass() {
   auto fn = [](TypeGraph& typeGraph) {
@@ -135,4 +135,4 @@ void AddPadding::addPadding(uint64_t paddingStartBits,
   }
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/AddPadding.h
+++ b/oi/type_graph/AddPadding.h
@@ -22,7 +22,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 class TypeGraph;
 
@@ -59,4 +59,4 @@ class AddPadding final : public RecursiveVisitor {
                   std::vector<Member>& paddedMembers);
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/AlignmentCalc.cpp
+++ b/oi/type_graph/AlignmentCalc.cpp
@@ -22,7 +22,7 @@
 template <typename T>
 using ref = std::reference_wrapper<T>;
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass AlignmentCalc::createPass() {
   auto fn = [](TypeGraph& typeGraph) {
@@ -76,4 +76,4 @@ void AlignmentCalc::visit(Class& c) {
   }
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/AlignmentCalc.h
+++ b/oi/type_graph/AlignmentCalc.h
@@ -23,7 +23,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * AlignmentCalc
@@ -46,4 +46,4 @@ class AlignmentCalc final : public RecursiveVisitor {
   std::unordered_set<Type*> visited_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -27,7 +27,7 @@ extern "C" {
 
 #include <regex>
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 namespace {
 
 uint64_t get_drgn_type_size(struct drgn_type* type) {
@@ -499,4 +499,4 @@ DrgnParserError::~DrgnParserError() {
   drgn_error_destroy(err_);
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -27,7 +27,7 @@ struct drgn_error;
 
 struct ContainerInfo;
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * DrgnParser
@@ -110,4 +110,4 @@ class DrgnParserError : public std::runtime_error {
   struct drgn_error* err_ = nullptr;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/EnforceCompatibility.cpp
+++ b/oi/type_graph/EnforceCompatibility.cpp
@@ -24,7 +24,7 @@
 #include "TypeIdentifier.h"
 #include "oi/OICodeGen.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass EnforceCompatibility::createPass() {
   auto fn = [](TypeGraph& typeGraph) {
@@ -78,4 +78,4 @@ void EnforceCompatibility::visit(Class& c) {
   });
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/EnforceCompatibility.h
+++ b/oi/type_graph/EnforceCompatibility.h
@@ -22,7 +22,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * EnforceCompatibility
@@ -46,4 +46,4 @@ class EnforceCompatibility : public RecursiveVisitor {
   NodeTracker& tracker_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/Flattener.cpp
+++ b/oi/type_graph/Flattener.cpp
@@ -18,7 +18,7 @@
 #include "TypeGraph.h"
 #include "TypeIdentifier.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass Flattener::createPass() {
   auto fn = [](TypeGraph& typeGraph) {
@@ -212,4 +212,4 @@ void Flattener::visit(Container& c) {
   }
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/Flattener.h
+++ b/oi/type_graph/Flattener.h
@@ -23,7 +23,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * Flattener
@@ -52,4 +52,4 @@ class Flattener : public RecursiveVisitor {
   std::vector<uint64_t> offset_stack_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -20,7 +20,7 @@
 template <typename T>
 using ref = std::reference_wrapper<T>;
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass NameGen::createPass() {
   auto fn = [](TypeGraph& typeGraph) {
@@ -152,4 +152,4 @@ void NameGen::visit(Typedef& td) {
   accept(td.underlyingType());
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/NameGen.h
+++ b/oi/type_graph/NameGen.h
@@ -24,7 +24,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 // TODO make all final
 /*
@@ -55,4 +55,4 @@ class NameGen final : public RecursiveVisitor {
   int n = 0;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/NodeTracker.h
+++ b/oi/type_graph/NodeTracker.h
@@ -19,7 +19,7 @@
 
 #include "Types.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * NodeTracker
@@ -67,4 +67,4 @@ class NodeTracker {
   std::vector<bool> visited_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/PassManager.cpp
+++ b/oi/type_graph/PassManager.cpp
@@ -26,7 +26,7 @@
 template <typename T>
 using ref = std::reference_wrapper<T>;
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 void Pass::run(TypeGraph& typeGraph) {
   fn_(typeGraph);
@@ -72,4 +72,4 @@ void PassManager::run(TypeGraph& typeGraph) {
   }
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/PassManager.h
+++ b/oi/type_graph/PassManager.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 class TypeGraph;
 class Type;
@@ -59,4 +59,4 @@ class PassManager {
   std::vector<Pass> passes_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/Printer.cpp
+++ b/oi/type_graph/Printer.cpp
@@ -17,7 +17,7 @@
 
 #include <cmath>
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Printer::Printer(std::ostream& out, size_t numTypes) : out_(out) {
   if (numTypes == 0) {
@@ -236,4 +236,4 @@ std::string Printer::align_str(uint64_t align) {
   return ", align: " + std::to_string(align);
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/Printer.h
+++ b/oi/type_graph/Printer.h
@@ -21,7 +21,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * Printer
@@ -60,4 +60,4 @@ class Printer : public ConstVisitor {
   std::unordered_map<const Type*, int> nodeNums_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/Prune.cpp
+++ b/oi/type_graph/Prune.cpp
@@ -18,7 +18,7 @@
 #include "TypeGraph.h"
 #include "TypeIdentifier.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass Prune::createPass() {
   auto fn = [](TypeGraph& typeGraph) {
@@ -62,4 +62,4 @@ void Prune::visit(Class& c) {
   c.functions.shrink_to_fit();
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/Prune.h
+++ b/oi/type_graph/Prune.h
@@ -23,7 +23,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * Prune
@@ -48,4 +48,4 @@ class Prune : public RecursiveVisitor {
   NodeTracker& tracker_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/RemoveMembers.cpp
+++ b/oi/type_graph/RemoveMembers.cpp
@@ -18,7 +18,7 @@
 #include "AddPadding.h"
 #include "TypeGraph.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass RemoveMembers::createPass(
     const std::vector<std::pair<std::string, std::string>>& membersToIgnore) {
@@ -75,4 +75,4 @@ bool RemoveMembers::ignoreMember(const std::string& typeName,
   return false;
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/RemoveMembers.h
+++ b/oi/type_graph/RemoveMembers.h
@@ -21,7 +21,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * RemoveMembers
@@ -54,4 +54,4 @@ class RemoveMembers : public RecursiveVisitor {
   const std::vector<std::pair<std::string, std::string>>& membersToIgnore_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/RemoveTopLevelPointer.cpp
+++ b/oi/type_graph/RemoveTopLevelPointer.cpp
@@ -17,7 +17,7 @@
 
 #include "TypeGraph.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass RemoveTopLevelPointer::createPass() {
   auto fn = [](TypeGraph& typeGraph) {
@@ -42,4 +42,4 @@ void RemoveTopLevelPointer::visit(Pointer& p) {
   topLevelType_ = &p.pointeeType();
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/RemoveTopLevelPointer.h
+++ b/oi/type_graph/RemoveTopLevelPointer.h
@@ -22,7 +22,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * RemoveTopLevelPointer
@@ -41,4 +41,4 @@ class RemoveTopLevelPointer : public LazyVisitor {
   Type* topLevelType_ = nullptr;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/TopoSorter.cpp
+++ b/oi/type_graph/TopoSorter.cpp
@@ -20,7 +20,7 @@
 template <typename T>
 using ref = std::reference_wrapper<T>;
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass TopoSorter::createPass() {
   auto fn = [](TypeGraph& typeGraph) {
@@ -148,4 +148,4 @@ void TopoSorter::acceptAfter(Type* type) {
   }
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/TopoSorter.h
+++ b/oi/type_graph/TopoSorter.h
@@ -23,7 +23,7 @@
 #include "Types.h"
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * TopoSorter
@@ -56,4 +56,4 @@ class TopoSorter : public RecursiveVisitor {
   void acceptAfter(Type* type);
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/TypeGraph.cpp
+++ b/oi/type_graph/TypeGraph.cpp
@@ -15,7 +15,7 @@
  */
 #include "TypeGraph.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 NodeTracker& TypeGraph::resetTracker() noexcept {
   tracker_.reset();
@@ -74,4 +74,4 @@ Primitive& TypeGraph::makeType<Primitive>(Primitive::Kind kind) {
   }
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/TypeGraph.h
+++ b/oi/type_graph/TypeGraph.h
@@ -22,7 +22,7 @@
 #include "NodeTracker.h"
 #include "Types.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * TypeGraph
@@ -91,4 +91,4 @@ class TypeGraph {
   NodeId next_id_ = 0;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/TypeIdentifier.cpp
+++ b/oi/type_graph/TypeIdentifier.cpp
@@ -18,7 +18,7 @@
 #include "TypeGraph.h"
 #include "oi/ContainerInfo.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 Pass TypeIdentifier::createPass(
     const std::vector<ContainerInfo>& passThroughTypes) {
@@ -115,4 +115,4 @@ void TypeIdentifier::visit(Container& c) {
   }
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/TypeIdentifier.h
+++ b/oi/type_graph/TypeIdentifier.h
@@ -23,7 +23,7 @@
 #include "Visitor.h"
 #include "oi/ContainerInfo.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 class TypeGraph;
 
@@ -56,4 +56,4 @@ class TypeIdentifier : public RecursiveVisitor {
   const std::vector<ContainerInfo>& passThroughTypes_;
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/Types.cpp
+++ b/oi/type_graph/Types.cpp
@@ -17,7 +17,7 @@
 
 #include "Visitor.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 #define X(OI_TYPE_NAME)                              \
   void OI_TYPE_NAME::accept(Visitor& v) {            \
@@ -131,4 +131,4 @@ Type& stripTypedefs(Type& type) {
   return *t;
 }
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -50,7 +50,7 @@
 
 struct ContainerInfo;
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 // Must be signed. "-1" represents "leaf node"
 using NodeId = int32_t;
@@ -589,6 +589,6 @@ class DummyAllocator : public Type {
 
 Type& stripTypedefs(Type& type);
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph
 
 #undef DECLARE_ACCEPT

--- a/oi/type_graph/Visitor.h
+++ b/oi/type_graph/Visitor.h
@@ -26,7 +26,7 @@
 
 #include "Types.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 
 /*
  * Visitor
@@ -145,4 +145,4 @@ class LazyConstVisitor : public ConstVisitor {
 #undef X
 };
 
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph

--- a/oi/types/test/StaticTest.cpp
+++ b/oi/types/test/StaticTest.cpp
@@ -4,7 +4,7 @@
 #include "oi/types/dy.h"
 #include "oi/types/st.h"
 
-using namespace ObjectIntrospection;
+using namespace oi;
 
 class DummyDataBuffer {};
 

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -4,8 +4,7 @@ target_include_directories(resources PRIVATE ../)
 
 function(embed_headers output)
   file(WRITE ${output} "#include \"oi/Headers.h\"\n\n")
-  file(APPEND ${output} "namespace ObjectIntrospection {\n")
-  file(APPEND ${output} "namespace headers {\n\n")
+  file(APPEND ${output} "namespace oi::detail::headers {\n")
 
   set(HEADERS
     ../include/oi/types/dy.h
@@ -33,8 +32,7 @@ function(embed_headers output)
     file(APPEND ${output} "const std::string_view ${varname} = R\"CONTENTS(${contents})CONTENTS\";\n\n")
   endforeach()
 
-  file(APPEND ${output} "} // namespace headers\n")
-  file(APPEND ${output} "} // namespace ObjectIntrospection\n")
+  file(APPEND ${output} "} // namespace oi::detail::headers\n")
 endfunction()
 
 embed_headers(${CMAKE_BINARY_DIR}/resources/headers.cpp)

--- a/test/TypeGraphParser.h
+++ b/test/TypeGraphParser.h
@@ -5,11 +5,11 @@
 
 #include "oi/type_graph/Types.h"
 
-using namespace type_graph;
-
-namespace type_graph {
+namespace oi::detail::type_graph {
 class TypeGraph;
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph
+
+using namespace oi::detail::type_graph;
 
 /*
  * TypeGraphParser

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -3,8 +3,12 @@
 #include "gmock/gmock.h"
 #include "oi/SymbolService.h"
 
+namespace oi::detail {
+
 class MockSymbolService : public SymbolService {
  public:
   MockSymbolService() {
   }
 };
+
+}  // namespace oi::detail

--- a/test/test_compiler.cpp
+++ b/test/test_compiler.cpp
@@ -9,6 +9,8 @@
 
 #include "oi/OICompiler.h"
 
+using namespace oi::detail;
+
 namespace fs = std::filesystem;
 
 /* Add the suffix operator _b to easily create array of uint8_t. */

--- a/test/test_drgn_parser.h
+++ b/test/test_drgn_parser.h
@@ -4,11 +4,15 @@
 
 #include "oi/type_graph/DrgnParser.h"
 
-namespace type_graph {
+namespace oi::detail {
+class SymbolService;
+}
+namespace oi::detail::type_graph {
 class TypeGraph;
 }
-class SymbolService;
 struct drgn_type;
+
+using namespace oi::detail;
 
 class DrgnParserTest : public ::testing::Test {
  protected:

--- a/test/test_node_tracker.cpp
+++ b/test/test_node_tracker.cpp
@@ -2,7 +2,7 @@
 
 #include "oi/type_graph/NodeTracker.h"
 
-using namespace type_graph;
+using namespace oi::detail::type_graph;
 
 TEST(NodeTrackerTest, LeafNodes) {
   Primitive myint32{Primitive::Kind::Int32};

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -9,7 +9,7 @@
 
 using ::testing::HasSubstr;
 
-using namespace ObjectIntrospection;
+using namespace oi::detail;
 
 // Utilities
 static ParseData parseString(const std::string& script) {

--- a/test/type_graph_utils.h
+++ b/test/type_graph_utils.h
@@ -6,9 +6,11 @@
 
 #include "oi/type_graph/Types.h"
 
-namespace type_graph {
+namespace oi::detail::type_graph {
 class Pass;
-}  // namespace type_graph
+}  // namespace oi::detail::type_graph
+
+using namespace oi::detail;
 
 void check(const std::vector<std::reference_wrapper<type_graph::Type>>& types,
            std::string_view expected,

--- a/tools/OILGen.cpp
+++ b/tools/OILGen.cpp
@@ -25,7 +25,7 @@
 #include "oi/OIOpts.h"
 
 namespace fs = std::filesystem;
-using namespace ObjectIntrospection;
+using namespace oi::detail;
 
 constexpr static OIOpts opts{
     OIOpt{'h', "help", no_argument, nullptr, "Print this message and exit."},

--- a/tools/OITB.cpp
+++ b/tools/OITB.cpp
@@ -32,7 +32,7 @@
 
 namespace fs = std::filesystem;
 
-using namespace ObjectIntrospection;
+using namespace oi::detail;
 
 constexpr static OIOpts opts{
     OIOpt{'h', "help", no_argument, nullptr, "Print this message and exit"},


### PR DESCRIPTION
## Summary

We currently put stuff all over the place in the root namespace. This is rubbish from a library perspective. Place everything under the `oi::detail` namespace if not user facing, and under the `oi` namespace if it is.

## Test plan

- `make test`
- CI

Should be fine as long as it builds.
