### PR TITLE
CodeGen Fixes

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -267,10 +267,14 @@ void genDefsClass(const Class& c, std::string& code) {
     code += "__attribute__((__packed__)) ";
   }
 
-  if (c.kind() == Class::Kind::Union) {
-    // Need to specify alignment manually for unions as their members have been
-    // removed. It would be nice to do this for all types, but our alignment
-    // information is not complete, so it would result in some errors.
+  if (c.members.size() == 1 &&
+      c.members[0].name.starts_with(AddPadding::MemberPrefix)) {
+    // Need to specify alignment manually for types which have been stubbed.
+    // It would be nice to do this for all types, but our alignment information
+    // is not complete, so it would result in some errors.
+    //
+    // Once we are able to read alignment info from DWARF, then this should be
+    // able to be applied to everything.
     code += "alignas(" + std::to_string(c.align()) + ") ";
   }
 

--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -113,10 +113,16 @@ void NameGen::visit(Container& c) {
     if (param.value) {
       name += *param.value;
     } else {
-      if (param.qualifiers[Qualifier::Const]) {
-        name += "const ";
-      }
       name += param.type()->name();
+      // The "const" keyword must come after the type name so that pointers are
+      // handled correctly.
+      //
+      // When we're told that we have a const member with type "Foo*", we want
+      // "Foo* const", meaning const pointer to Foo, rather than "const Foo*",
+      // meaning pointer to const Foo.
+      if (param.qualifiers[Qualifier::Const]) {
+        name += " const";
+      }
     }
     name += ", ";
   }

--- a/oi/type_graph/TopoSorter.cpp
+++ b/oi/type_graph/TopoSorter.cpp
@@ -85,6 +85,8 @@ bool containerAllowsIncompleteParams(const Container& c) {
   switch (c.containerInfo_.ctype) {
     case SEQ_TYPE:
     case LIST_TYPE:
+    case UNIQ_PTR_TYPE:
+    case SHRD_PTR_TYPE:
       // Also std::forward_list, if we ever support that
       // Would be good to have this as an option in the TOML files
       return true;

--- a/test/test_codegen.cpp
+++ b/test/test_codegen.cpp
@@ -148,14 +148,14 @@ TEST(CodeGenTest, TransformContainerAllocatorParamInParent) {
           Function: deallocate
 )",
                 R"(
-[0] Container: std::map<int32_t, int32_t, DummyAllocator<std::pair<const int32_t, int32_t>, 0, 0>> (size: 24)
+[0] Container: std::map<int32_t, int32_t, DummyAllocator<std::pair<int32_t const, int32_t>, 0, 0>> (size: 24)
       Param
         Primitive: int32_t
       Param
         Primitive: int32_t
       Param
         DummyAllocator (size: 0)
-[1]       Container: std::pair<const int32_t, int32_t> (size: 8)
+[1]       Container: std::pair<int32_t const, int32_t> (size: 8)
             Param
               Primitive: int32_t
               Qualifiers: const

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -171,18 +171,24 @@ TEST(NameGenTest, ContainerParamsDuplicatesAcrossContainers) {
 TEST(NameGenTest, ContainerParamsConst) {
   auto myparam1 = Class{0, Class::Kind::Struct, "MyConstParam", 13};
   auto myparam2 = Class{1, Class::Kind::Struct, "MyParam", 13};
+  auto ptrParam = Class{2, Class::Kind::Struct, "PtrParam", 13};
+  auto myparam3 = Pointer{3, ptrParam};
 
   auto mycontainer = getVector();
   mycontainer.templateParams.push_back(
       TemplateParam{myparam1, {Qualifier::Const}});
   mycontainer.templateParams.push_back(TemplateParam{myparam2});
+  mycontainer.templateParams.push_back(
+      TemplateParam{myparam3, {Qualifier::Const}});
 
   NameGen nameGen;
   nameGen.generateNames({mycontainer});
 
   EXPECT_EQ(myparam1.name(), "MyConstParam_0");
   EXPECT_EQ(myparam2.name(), "MyParam_1");
-  EXPECT_EQ(mycontainer.name(), "std::vector<const MyConstParam_0, MyParam_1>");
+  EXPECT_EQ(myparam3.name(), "PtrParam_2*");
+  EXPECT_EQ(mycontainer.name(),
+            "std::vector<MyConstParam_0 const, MyParam_1, PtrParam_2* const>");
 }
 
 TEST(NameGenTest, ContainerNoParams) {


### PR DESCRIPTION
These minor fixes bring CodeGen v2 to parity with CodeGen v1 on the AdFilterData type.

i.e. It now just fails with a small number of static asserts

See commit messages and comments for details on the changes.