### PR TITLE
type_graph: provide inputName for all types

### DIFF
--- a/oi/type_graph/AddPadding.cpp
+++ b/oi/type_graph/AddPadding.cpp
@@ -132,8 +132,10 @@ void AddPadding::addPadding(uint64_t paddingStartBits,
     // Pad with an array of bytes
     uint64_t paddingStartByte = (paddingStartBits + 7) / 8;
     auto& paddingArray = typeGraph_.makeType<Array>(primitive, paddingBytes);
-    paddedMembers.emplace_back(paddingArray, MemberPrefix,
-                               paddingStartByte * 8);
+    // Set inputName to an empty string as it has no name in the input
+    auto& m =
+        paddedMembers.emplace_back(paddingArray, "", paddingStartByte * 8);
+    m.name = MemberPrefix;
   }
 }
 

--- a/oi/type_graph/TypeIdentifier.cpp
+++ b/oi/type_graph/TypeIdentifier.cpp
@@ -100,11 +100,12 @@ void TypeIdentifier::visit(Container& c) {
         auto* allocator = dynamic_cast<Class*>(
             &param.type());  // TODO please don't do this...
         Type& typeToAllocate = allocator->templateParams.at(0).type();
-        auto& dummy = typeGraph_.makeType<DummyAllocator>(typeToAllocate, size,
-                                                          param.type().align());
+        auto& dummy = typeGraph_.makeType<DummyAllocator>(
+            typeToAllocate, size, param.type().align(), allocator->name());
         c.templateParams[i] = dummy;
       } else {
-        auto& dummy = typeGraph_.makeType<Dummy>(size, param.type().align());
+        auto& dummy = typeGraph_.makeType<Dummy>(size, param.type().align(),
+                                                 param.type().name());
         c.templateParams[i] = dummy;
       }
     }

--- a/test/test_codegen.cpp
+++ b/test/test_codegen.cpp
@@ -63,7 +63,7 @@ TEST(CodeGenTest, TransformContainerAllocator) {
       Param
         Primitive: int32_t
       Param
-        DummyAllocator (size: 8)
+        DummyAllocator [MyAlloc] (size: 8)
           Primitive: int32_t
 )");
 }
@@ -98,7 +98,7 @@ TEST(CodeGenTest, TransformContainerAllocatorParamInParent) {
       Param
         Primitive: int32_t
       Param
-        DummyAllocator (size: 0)
+        DummyAllocator [MyAlloc<std::pair<const int, int>>] (size: 0)
 [3]       Container: std::pair<int32_t const, int32_t> (size: 8)
             Param
               Primitive: int32_t
@@ -121,16 +121,16 @@ TEST(CodeGenTest, RemovedMemberAlignment) {
         Primitive: int8_t
 )",
                 R"(
-[0] Class: MyClass_0 (size: 24, align: 8)
-      Member: a_0 (offset: 0, align: 1)
+[0] Class: MyClass_0 [MyClass] (size: 24, align: 8)
+      Member: a_0 [a] (offset: 0, align: 1)
         Primitive: int8_t
       Member: __oi_padding_1 (offset: 1)
-[1]     Array: (length: 15)
+[1]     Array: [int8_t[15]] (length: 15)
           Primitive: int8_t
-      Member: c_2 (offset: 16, align: 1)
+      Member: c_2 [c] (offset: 16, align: 1)
         Primitive: int8_t
       Member: __oi_padding_3 (offset: 17)
-[2]     Array: (length: 7)
+[2]     Array: [int8_t[7]] (length: 7)
           Primitive: int8_t
 )");
 }
@@ -144,9 +144,9 @@ TEST(CodeGenTest, UnionMembersAlignment) {
         Primitive: int64_t
 )",
                 R"(
-[0] Union: MyUnion_0 (size: 8, align: 8)
+[0] Union: MyUnion_0 [MyUnion] (size: 8, align: 8)
       Member: __oi_padding_0 (offset: 0)
-[1]     Array: (length: 8)
+[1]     Array: [int8_t[8]] (length: 8)
           Primitive: int8_t
 )");
 }

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -19,6 +19,8 @@ TEST(NameGenTest, ClassParams) {
   EXPECT_EQ(myclass.name(), "MyClass_0");
   EXPECT_EQ(myparam1.name(), "MyParam_1");
   EXPECT_EQ(myparam2.name(), "MyParam_2");
+
+  EXPECT_EQ(myclass.inputName(), "MyClass<MyParam, MyParam>");
 }
 
 TEST(NameGenTest, ClassContainerParam) {
@@ -34,6 +36,8 @@ TEST(NameGenTest, ClassContainerParam) {
 
   EXPECT_EQ(myclass.name(), "MyClass_0");
   EXPECT_EQ(myparam.name(), "std::vector<int32_t>");
+
+  EXPECT_EQ(myclass.inputName(), "MyClass");
 }
 
 TEST(NameGenTest, ClassParents) {
@@ -49,6 +53,10 @@ TEST(NameGenTest, ClassParents) {
   EXPECT_EQ(myclass.name(), "MyClass_0");
   EXPECT_EQ(myparent1.name(), "MyParent_1");
   EXPECT_EQ(myparent2.name(), "MyParent_2");
+
+  EXPECT_EQ(myclass.inputName(), "MyClass");
+  EXPECT_EQ(myparent1.inputName(), "MyParent");
+  EXPECT_EQ(myparent2.inputName(), "MyParent");
 }
 
 TEST(NameGenTest, ClassMembers) {
@@ -68,6 +76,12 @@ TEST(NameGenTest, ClassMembers) {
   EXPECT_EQ(myclass.members[1].name, "mem_1");
   EXPECT_EQ(mymember1.name(), "MyMember_1");
   EXPECT_EQ(mymember2.name(), "MyMember_2");
+
+  EXPECT_EQ(myclass.inputName(), "MyClass");
+  EXPECT_EQ(myclass.members[0].inputName, "mem");
+  EXPECT_EQ(myclass.members[1].inputName, "mem");
+  EXPECT_EQ(mymember1.inputName(), "MyMember");
+  EXPECT_EQ(mymember2.inputName(), "MyMember");
 }
 
 TEST(NameGenTest, ClassMemberInvalidChar) {
@@ -81,6 +95,9 @@ TEST(NameGenTest, ClassMemberInvalidChar) {
 
   EXPECT_EQ(myclass.name(), "MyClass_0");
   EXPECT_EQ(myclass.members[0].name, "mem$Nope_0");
+
+  EXPECT_EQ(myclass.inputName(), "MyClass");
+  EXPECT_EQ(myclass.members[0].inputName, "mem.Nope");
 }
 
 TEST(NameGenTest, ClassChildren) {
@@ -96,6 +113,10 @@ TEST(NameGenTest, ClassChildren) {
   EXPECT_EQ(myclass.name(), "MyClass_0");
   EXPECT_EQ(mychild1.name(), "MyChild_1");
   EXPECT_EQ(mychild2.name(), "MyChild_2");
+
+  EXPECT_EQ(myclass.inputName(), "MyClass");
+  EXPECT_EQ(mychild1.inputName(), "MyChild");
+  EXPECT_EQ(mychild2.inputName(), "MyChild");
 }
 
 TEST(NameGenTest, ContainerParams) {
@@ -111,6 +132,10 @@ TEST(NameGenTest, ContainerParams) {
   EXPECT_EQ(myparam1.name(), "MyParam_0");
   EXPECT_EQ(myparam2.name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
+
+  EXPECT_EQ(myparam1.inputName(), "MyParam");
+  EXPECT_EQ(myparam2.inputName(), "MyParam");
+  EXPECT_EQ(mycontainer.inputName(), "std::vector<MyParam, MyParam>");
 }
 
 TEST(NameGenTest, ContainerParamsDuplicates) {
@@ -124,6 +149,9 @@ TEST(NameGenTest, ContainerParamsDuplicates) {
 
   EXPECT_EQ(myparam.name(), "MyParam_0");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_0>");
+
+  EXPECT_EQ(myparam.inputName(), "MyParam");
+  EXPECT_EQ(mycontainer.inputName(), "std::vector<MyParam, MyParam>");
 }
 
 TEST(NameGenTest, ContainerParamsDuplicatesDeep) {
@@ -143,6 +171,11 @@ TEST(NameGenTest, ContainerParamsDuplicatesDeep) {
   EXPECT_EQ(mycontainer1.name(), "std::vector<MyParam_0>");
   EXPECT_EQ(mycontainer2.name(),
             "std::vector<MyParam_0, std::vector<MyParam_0>>");
+
+  EXPECT_EQ(myparam.inputName(), "MyParam");
+  EXPECT_EQ(mycontainer1.inputName(), "std::vector<MyParam>");
+  EXPECT_EQ(mycontainer2.inputName(),
+            "std::vector<MyParam, std::vector<MyParam>>");
 }
 
 TEST(NameGenTest, ContainerParamsDuplicatesAcrossContainers) {
@@ -166,6 +199,12 @@ TEST(NameGenTest, ContainerParamsDuplicatesAcrossContainers) {
   EXPECT_EQ(myparam3.name(), "MyParam_2");
   EXPECT_EQ(mycontainer1.name(), "std::vector<MyParam_0, MyParam_1>");
   EXPECT_EQ(mycontainer2.name(), "std::vector<MyParam_1, MyParam_2>");
+
+  EXPECT_EQ(myparam1.inputName(), "MyParam");
+  EXPECT_EQ(myparam2.inputName(), "MyParam");
+  EXPECT_EQ(myparam3.inputName(), "MyParam");
+  EXPECT_EQ(mycontainer1.inputName(), "std::vector<MyParam, MyParam>");
+  EXPECT_EQ(mycontainer2.inputName(), "std::vector<MyParam, MyParam>");
 }
 
 TEST(NameGenTest, ContainerParamsConst) {
@@ -189,6 +228,12 @@ TEST(NameGenTest, ContainerParamsConst) {
   EXPECT_EQ(myparam3.name(), "PtrParam_2*");
   EXPECT_EQ(mycontainer.name(),
             "std::vector<MyConstParam_0 const, MyParam_1, PtrParam_2* const>");
+
+  EXPECT_EQ(myparam1.inputName(), "MyConstParam");
+  EXPECT_EQ(myparam2.inputName(), "MyParam");
+  EXPECT_EQ(myparam3.inputName(), "PtrParam*");
+  EXPECT_EQ(mycontainer.inputName(),
+            "std::vector<MyConstParam const, MyParam, PtrParam* const>");
 }
 
 TEST(NameGenTest, ContainerNoParams) {
@@ -198,6 +243,7 @@ TEST(NameGenTest, ContainerNoParams) {
   nameGen.generateNames({mycontainer});
 
   EXPECT_EQ(mycontainer.name(), "std::vector");
+  EXPECT_EQ(mycontainer.inputName(), "std::vector");
 }
 
 TEST(NameGenTest, ContainerParamsValue) {
@@ -215,6 +261,10 @@ TEST(NameGenTest, ContainerParamsValue) {
   EXPECT_EQ(myint.name(), "int32_t");
   EXPECT_EQ(myenum.name(), "MyEnum_0");
   EXPECT_EQ(mycontainer.name(), "std::vector<123, MyEnum::OptionC>");
+
+  EXPECT_EQ(myint.inputName(), "int32_t");
+  EXPECT_EQ(myenum.inputName(), "MyEnum");
+  EXPECT_EQ(mycontainer.inputName(), "std::vector<123, MyEnum::OptionC>");
 }
 
 TEST(NameGenTest, Enum) {
@@ -226,6 +276,9 @@ TEST(NameGenTest, Enum) {
 
   EXPECT_EQ(myenum0.name(), "MyEnum_0");
   EXPECT_EQ(myenum1.name(), "MyEnum_1");
+
+  EXPECT_EQ(myenum0.inputName(), "MyEnum");
+  EXPECT_EQ(myenum1.inputName(), "MyEnum");
 }
 
 TEST(NameGenTest, Array) {
@@ -245,6 +298,11 @@ TEST(NameGenTest, Array) {
   EXPECT_EQ(myparam2.name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
   EXPECT_EQ(myarray.name(), "OIArray<std::vector<MyParam_0, MyParam_1>, 5>");
+
+  EXPECT_EQ(myparam1.inputName(), "MyParam");
+  EXPECT_EQ(myparam2.inputName(), "MyParam");
+  EXPECT_EQ(mycontainer.inputName(), "std::vector<MyParam, MyParam>");
+  EXPECT_EQ(myarray.inputName(), "std::vector<MyParam, MyParam>[5]");
 }
 
 TEST(NameGenTest, Typedef) {
@@ -264,6 +322,11 @@ TEST(NameGenTest, Typedef) {
   EXPECT_EQ(myparam2.name(), "MyParam_2");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_1, MyParam_2>");
   EXPECT_EQ(mytypedef.name(), "MyTypedef_0");
+
+  EXPECT_EQ(myparam1.inputName(), "MyParam");
+  EXPECT_EQ(myparam2.inputName(), "MyParam");
+  EXPECT_EQ(mycontainer.inputName(), "std::vector<MyParam, MyParam>");
+  EXPECT_EQ(mytypedef.inputName(), "MyTypedef");
 }
 
 TEST(NameGenTest, TypedefAliasTemplate) {
@@ -274,6 +337,7 @@ TEST(NameGenTest, TypedefAliasTemplate) {
   nameGen.generateNames({mytypedef});
 
   EXPECT_EQ(mytypedef.name(), "MyTypedef_0");
+  EXPECT_EQ(mytypedef.inputName(), "MyTypedef<ParamA, ParamB>");
 }
 
 TEST(NameGenTest, Pointer) {
@@ -293,15 +357,21 @@ TEST(NameGenTest, Pointer) {
   EXPECT_EQ(myparam2.name(), "MyParam_1");
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
   EXPECT_EQ(mypointer.name(), "std::vector<MyParam_0, MyParam_1>*");
+
+  EXPECT_EQ(myparam1.inputName(), "MyParam");
+  EXPECT_EQ(myparam2.inputName(), "MyParam");
+  EXPECT_EQ(mycontainer.inputName(), "std::vector<MyParam, MyParam>");
+  EXPECT_EQ(mypointer.inputName(), "std::vector<MyParam, MyParam>*");
 }
 
 TEST(NameGenTest, Dummy) {
-  auto dummy = Dummy{12, 34};
+  auto dummy = Dummy{12, 34, "InputName"};
 
   NameGen nameGen;
   nameGen.generateNames({dummy});
 
   EXPECT_EQ(dummy.name(), "DummySizedOperator<12, 34>");
+  EXPECT_EQ(dummy.inputName(), "InputName");
 }
 
 TEST(NameGenTest, DummyAllocator) {
@@ -312,7 +382,7 @@ TEST(NameGenTest, DummyAllocator) {
   mycontainer.templateParams.push_back(myparam1);
   mycontainer.templateParams.push_back(myparam2);
 
-  auto myalloc = DummyAllocator{mycontainer, 12, 34};
+  auto myalloc = DummyAllocator{mycontainer, 12, 34, "BigAllocator"};
 
   NameGen nameGen;
   nameGen.generateNames({myalloc});
@@ -322,6 +392,11 @@ TEST(NameGenTest, DummyAllocator) {
   EXPECT_EQ(mycontainer.name(), "std::vector<MyParam_0, MyParam_1>");
   EXPECT_EQ(myalloc.name(),
             "DummyAllocator<std::vector<MyParam_0, MyParam_1>, 12, 34>");
+
+  EXPECT_EQ(myparam1.inputName(), "MyParam");
+  EXPECT_EQ(myparam2.inputName(), "MyParam");
+  EXPECT_EQ(mycontainer.inputName(), "std::vector<MyParam, MyParam>");
+  EXPECT_EQ(myalloc.inputName(), "BigAllocator");
 }
 
 TEST(NameGenTest, Cycle) {
@@ -336,6 +411,9 @@ TEST(NameGenTest, Cycle) {
 
   EXPECT_EQ(classA.name(), "ClassA_0");
   EXPECT_EQ(classB.name(), "ClassB_1");
+
+  EXPECT_EQ(classA.inputName(), "ClassA");
+  EXPECT_EQ(classB.inputName(), "ClassB");
 }
 
 TEST(NameGenTest, ContainerCycle) {
@@ -349,6 +427,9 @@ TEST(NameGenTest, ContainerCycle) {
 
   EXPECT_EQ(myclass.name(), "MyClass_0");
   EXPECT_EQ(container.name(), "std::vector<MyClass_0>");
+
+  EXPECT_EQ(myclass.inputName(), "MyClass");
+  EXPECT_EQ(container.inputName(), "std::vector<MyClass>");
 }
 
 TEST(NameGenTest, AnonymousTypes) {
@@ -364,4 +445,8 @@ TEST(NameGenTest, AnonymousTypes) {
   EXPECT_EQ(myclass.name(), "__oi_anon_0");
   EXPECT_EQ(myenum.name(), "__oi_anon_1");
   EXPECT_EQ(mytypedef.name(), "__oi_anon_2");
+
+  EXPECT_EQ(myclass.inputName(), "");
+  EXPECT_EQ(myenum.inputName(), "");
+  EXPECT_EQ(mytypedef.inputName(), "");
 }

--- a/test/test_type_identifier.cpp
+++ b/test/test_type_identifier.cpp
@@ -23,7 +23,7 @@ TEST(TypeIdentifierTest, StubbedParam) {
       Param
         Primitive: int32_t
       Param
-        Dummy (size: 4)
+        Dummy [MyParam] (size: 4)
       Param
         Primitive: int32_t
 )");
@@ -48,7 +48,7 @@ TEST(TypeIdentifierTest, Allocator) {
       Param
         Primitive: int32_t
       Param
-        DummyAllocator (size: 8)
+        DummyAllocator [MyAlloc] (size: 8)
           Primitive: int32_t
       Param
         Primitive: int32_t
@@ -74,7 +74,7 @@ TEST(TypeIdentifierTest, AllocatorSize1) {
       Param
         Primitive: int32_t
       Param
-        DummyAllocator (size: 0)
+        DummyAllocator [MyAlloc] (size: 0)
           Primitive: int32_t
       Param
         Primitive: int32_t
@@ -134,7 +134,7 @@ TEST(TypeIdentifierTest, DummyNotReplaced) {
       Param
         Primitive: int32_t
       Param
-        Dummy (size: 22)
+        Dummy [InputName] (size: 22)
 )");
 }
 
@@ -144,7 +144,7 @@ TEST(TypeIdentifierTest, DummyAllocatorNotReplaced) {
       Param
         Primitive: int32_t
       Param
-        DummyAllocator (size: 22)
+        DummyAllocator [InputName] (size: 22)
           Primitive: int32_t
 )");
 }


### PR DESCRIPTION
## Summary

Type Graph deduplicates and modifies names to better fit the generated code, for example `int32_t[4]` becomes `OIArray<int32_t, 4>` and `struct MyStruct` might become `struct MyStruct_0`.

Add an `inputName` which better represents the original input code which can be used when building the tree.

## Test plan

Updated `test_codegen.cpp` and `test_name_gen.cpp` to respect these changes. This is more to assert any changes are deliberate rather than to claim the current ones are correct...

- CI
