### PR TITLE
DrgnParser: Don't error out for certain bad DWARF

### DIFF
--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -67,7 +67,8 @@ class DrgnParser {
   Array& enumerateArray(struct drgn_type* type);
   Primitive& enumeratePrimitive(struct drgn_type* type);
 
-  void enumerateTemplateParam(drgn_type_template_parameter* tparams,
+  void enumerateTemplateParam(struct drgn_type* type,
+                              drgn_type_template_parameter* tparams,
                               size_t i,
                               std::vector<TemplateParam>& params);
   void enumerateClassTemplateParams(struct drgn_type* type,


### PR DESCRIPTION
Match the behaviour of CodeGen v1 and just log warnings when certain debug info has issues.

Example warning:
```
W0811 10:20:40.967265 112689 DrgnParser.cpp:522] Error looking up parent (1) for type 'EventBase': 2 DW_TAG_member has invalid DW_AT_data_member_location
```