### PR TITLE
OIL v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,9 +334,18 @@ target_link_libraries(treebuilder
 
 ## OI Outputs
 ### Object Introspection as a Library (OIL)
-add_library(oil oi/OILibrary.cpp oi/OILibraryImpl.cpp)
+add_library(oil
+  oi/IntrospectionResult.cpp
+  oi/exporters/ParsedData.cpp
+)
+target_link_libraries(oil folly_headers)
 target_include_directories(oil PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(oil oicore)
+
+add_library(oil_jit
+  oi/OILibrary.cpp
+  oi/OILibraryImpl.cpp
+)
+target_link_libraries(oil_jit oicore oil)
 
 ### Object Introspection as a Library Generator (OILGen)
 add_executable(oilgen

--- a/include/oi/IntrospectionResult-inl.h
+++ b/include/oi/IntrospectionResult-inl.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if defined(INCLUDED_OI_INTROSPECTIONRESULT_INL_H) || \
+    !defined(INCLUDED_OI_INTROSPECTIONRESULT_H)
+static_assert(false,
+              "IntrospectionResult-inl.h provides inline declarations for "
+              "IntrospectionResult.h and should only "
+              "be included by IntrospectionResult.h");
+#endif
+#define INCLUDED_OI_INTROSPECTIONRESULT_INL_H 1
+
+#include <cassert>
+
+#include "IntrospectionResult.h"
+
+namespace oi {
+
+inline IntrospectionResult::IntrospectionResult(std::vector<uint8_t> buf,
+                                                exporters::inst::Inst inst)
+    : buf_(std::move(buf)), inst_(inst) {
+}
+
+inline IntrospectionResult::const_iterator::const_iterator(
+    std::vector<uint8_t>::const_iterator data, exporters::inst::Inst type)
+    : data_(data), stack_({type}) {
+}
+inline IntrospectionResult::const_iterator::const_iterator(
+    std::vector<uint8_t>::const_iterator data)
+    : data_(data) {
+}
+inline IntrospectionResult::const_iterator IntrospectionResult::cbegin() const {
+  return ++const_iterator{buf_.cbegin(), inst_};
+}
+inline IntrospectionResult::const_iterator IntrospectionResult::cend() const {
+  return {buf_.cend()};
+}
+
+inline IntrospectionResult::const_iterator
+IntrospectionResult::const_iterator::operator++(int) {
+  auto old = *this;
+  operator++();
+  return old;
+}
+inline const result::Element& IntrospectionResult::const_iterator::operator*()
+    const {
+  assert(next_);
+  return *next_;
+}
+inline const result::Element* IntrospectionResult::const_iterator::operator->()
+    const {
+  return &*next_;
+}
+
+inline bool IntrospectionResult::const_iterator::operator==(
+    const IntrospectionResult::const_iterator& that) const {
+  return this->data_ == that.data_ && !this->next_.has_value() &&
+         !that.next_.has_value();  // TODO: is this sufficient? kind of hacky as
+                                   // this only works for comparing to .end()
+}
+inline bool IntrospectionResult::const_iterator::operator!=(
+    const IntrospectionResult::const_iterator& that) const {
+  return !(*this == that);
+}
+
+}  // namespace oi

--- a/include/oi/IntrospectionResult.h
+++ b/include/oi/IntrospectionResult.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_OI_INTROSPECTIONRESULT_H
+#define INCLUDED_OI_INTROSPECTIONRESULT_H 1
+
+#include <oi/exporters/inst.h>
+#include <oi/result/Element.h>
+#include <oi/types/dy.h>
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <stack>
+#include <string_view>
+#include <vector>
+
+namespace oi {
+
+class IntrospectionResult {
+ public:
+  class const_iterator {
+    friend class IntrospectionResult;
+
+   public:
+    bool operator==(const const_iterator& that) const;
+    bool operator!=(const const_iterator& that) const;
+    const result::Element& operator*() const;
+    const result::Element* operator->() const;
+    const_iterator& operator++();
+    const_iterator operator++(int);
+
+   private:
+    const_iterator(std::vector<uint8_t>::const_iterator data,
+                   exporters::inst::Inst type);
+    const_iterator(std::vector<uint8_t>::const_iterator data);
+
+    std::vector<uint8_t>::const_iterator data_;
+    std::stack<exporters::inst::Inst> stack_;
+    std::optional<result::Element> next_;
+
+    std::vector<std::string_view> type_path_;
+  };
+
+  IntrospectionResult(std::vector<uint8_t> buf, exporters::inst::Inst inst);
+
+  const_iterator cbegin() const;
+  const_iterator cend() const;
+
+ private:
+  std::vector<uint8_t> buf_;
+  exporters::inst::Inst inst_;
+};
+
+}  // namespace oi
+
+#include <oi/IntrospectionResult-inl.h>
+#endif

--- a/include/oi/exporters/Json.h
+++ b/include/oi/exporters/Json.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_OI_EXPORTERS_JSON_H
+#define INCLUDED_OI_EXPORTERS_JSON_H 1
+
+#include <oi/IntrospectionResult.h>
+
+#include <ostream>
+
+namespace oi::exporters {
+
+class Json {
+ public:
+  Json(std::ostream& out);
+
+  void print(const IntrospectionResult&);
+  void print(IntrospectionResult::const_iterator& it,
+             IntrospectionResult::const_iterator end);
+
+  void setPretty(bool pretty) {
+    pretty_ = pretty;
+  }
+
+ private:
+  bool pretty_ = false;
+  std::ostream& out_;
+};
+
+}  // namespace oi::exporters
+
+#endif

--- a/include/oi/exporters/ParsedData.h
+++ b/include/oi/exporters/ParsedData.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_OI_EXPORTERS_PARSED_DATA_H
+#define INCLUDED_OI_EXPORTERS_PARSED_DATA_H 1
+
+#include <oi/types/dy.h>
+
+#include <cassert>
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+namespace oi::exporters {
+
+struct ParsedData {
+  class Lazy {
+   public:
+    Lazy(std::vector<uint8_t>::const_iterator& it, types::dy::Dynamic ty)
+        : it_(it), ty_(ty) {
+    }
+
+    ParsedData operator()() {
+      return ParsedData::parse(it_, ty_);
+    }
+
+   private:
+    std::vector<uint8_t>::const_iterator& it_;
+    types::dy::Dynamic ty_;
+  };
+
+  struct Unit {};
+  struct VarInt {
+    uint64_t value;
+  };
+  struct Pair {
+    Lazy first;
+    Lazy second;
+  };
+  struct List {
+    uint64_t length;
+    Lazy values;
+  };
+  struct Sum {
+    uint64_t index;
+    Lazy value;
+  };
+
+  static ParsedData parse(std::vector<uint8_t>::const_iterator& it,
+                          types::dy::Dynamic ty);
+
+  ParsedData(Unit&& val_) : val(val_) {
+  }
+  ParsedData(VarInt&& val_) : val(val_) {
+  }
+  ParsedData(Pair&& val_) : val(val_) {
+  }
+  ParsedData(List&& val_) : val(val_) {
+  }
+  ParsedData(Sum&& val_) : val(val_) {
+  }
+
+  std::variant<Unit, VarInt, Pair, List, Sum> val;
+};
+
+}  // namespace oi::exporters
+
+#endif

--- a/include/oi/exporters/inst.h
+++ b/include/oi/exporters/inst.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef INCLUDED_OI_EXPORTERS_INST_H
+#define INCLUDED_OI_EXPORTERS_INST_H 1
+
+#include <oi/exporters/ParsedData.h>
+#include <oi/result/Element.h>
+#include <oi/types/dy.h>
+
+#include <array>
+#include <cstdint>
+#include <initializer_list>
+#include <stack>
+#include <utility>
+#include <variant>
+
+namespace oi::exporters::inst {
+
+struct PopTypePath;
+struct Field;
+
+using Inst = std::variant<PopTypePath, std::reference_wrapper<const Field>>;
+using Processor = void (*)(result::Element&, std::stack<Inst>&, ParsedData);
+using ProcessorInst = std::pair<types::dy::Dynamic, Processor>;
+
+struct PopTypePath {};
+
+struct Field {
+  template <size_t N0, size_t N1, size_t N2>
+  constexpr Field(size_t static_size_,
+                  size_t exclusive_size_,
+                  std::string_view name_,
+                  const std::array<std::string_view, N0>& type_names_,
+                  const std::array<Field, N1>& fields_,
+                  const std::array<ProcessorInst, N2>& processors_);
+  template <size_t N0, size_t N1, size_t N2>
+  constexpr Field(size_t static_size_,
+                  std::string_view name_,
+                  const std::array<std::string_view, N0>& type_names_,
+                  const std::array<Field, N1>& fields_,
+                  const std::array<ProcessorInst, N2>& processors_)
+      : Field(static_size_,
+              static_size_,
+              name_,
+              type_names_,
+              fields_,
+              processors_) {
+  }
+  constexpr Field(const Field&) = default;  // no idea why this is needed
+
+  size_t static_size;
+  size_t exclusive_size;
+  std::string_view name;
+  std::span<const std::string_view> type_names;
+  std::span<const Field> fields;
+  std::span<const ProcessorInst> processors;
+};
+
+template <size_t N0, size_t N1, size_t N2>
+constexpr Field::Field(size_t static_size_,
+                       size_t exclusive_size_,
+                       std::string_view name_,
+                       const std::array<std::string_view, N0>& type_names_,
+                       const std::array<Field, N1>& fields_,
+                       const std::array<ProcessorInst, N2>& processors_)
+    : static_size(static_size_),
+      exclusive_size(exclusive_size_),
+      name(name_),
+      type_names(type_names_),
+      fields(fields_),
+      processors(processors_) {
+}
+
+}  // namespace oi::exporters::inst
+
+#endif

--- a/include/oi/oi-jit-inl.h
+++ b/include/oi/oi-jit-inl.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if defined(INCLUDED_OI_OI_JIT_INL_H) || !defined(INCLUDED_OI_OI_JIT_H)
+static_assert(
+    false,
+    "oi-jit-inl.h provides inline declarations for oi-jit.h and should only "
+    "be included by oi-jit.h");
+#endif
+#define INCLUDED_OI_OI_JIT_INL_H 1
+
+#include <stdexcept>
+
+#include "oi-jit.h"
+
+namespace oi {
+
+template <typename T, Feature... Fs>
+inline std::optional<IntrospectionResult> setupAndIntrospect(
+    const T& objectAddr, const GeneratorOptions& opts) {
+  if (!CodegenHandler<T, Fs...>::init(opts))
+    return std::nullopt;
+
+  return CodegenHandler<T, Fs...>::introspect(objectAddr);
+}
+
+template <typename T, Feature... Fs>
+inline std::atomic<bool>& CodegenHandler<T, Fs...>::getIsCritical() {
+  static std::atomic<bool> isCritical = false;
+  return isCritical;
+}
+
+template <typename T, Feature... Fs>
+inline std::atomic<void (*)(const T&, std::vector<uint8_t>&)>&
+CodegenHandler<T, Fs...>::getIntrospectionFunc() {
+  static std::atomic<void (*)(const T&, std::vector<uint8_t>&)> func = nullptr;
+  return func;
+}
+
+template <typename T, Feature... Fs>
+inline std::atomic<const exporters::inst::Inst*>&
+CodegenHandler<T, Fs...>::getTreeBuilderInstructions() {
+  static std::atomic<const exporters::inst::Inst*> ty = nullptr;
+  return ty;
+}
+
+template <typename T, Feature... Fs>
+inline bool CodegenHandler<T, Fs...>::init(const GeneratorOptions& opts) {
+  if (getIntrospectionFunc().load() != nullptr &&
+      getTreeBuilderInstructions().load() != nullptr)
+    return true;  // already initialised
+  if (getIsCritical().exchange(true))
+    return false;  // other thread is initialising/has failed
+
+  auto lib =
+      OILibrary(reinterpret_cast<void*>(&getIntrospectionFunc), {Fs...}, opts);
+  auto [vfp, ty] = lib.init();
+
+  getIntrospectionFunc().store(reinterpret_cast<func_type>(vfp));
+  getTreeBuilderInstructions().store(&ty);
+  return true;
+}
+
+template <typename T, Feature... Fs>
+inline IntrospectionResult CodegenHandler<T, Fs...>::introspect(
+    const T& objectAddr) {
+  func_type func = getIntrospectionFunc().load();
+  const exporters::inst::Inst* ty = getTreeBuilderInstructions().load();
+
+  if (func == nullptr || ty == nullptr)
+    throw std::logic_error("introspect(const T&) called when uninitialised");
+
+  std::vector<uint8_t> buf;
+  static_assert(sizeof(std::vector<uint8_t>) == 24);
+  func(objectAddr, buf);
+  return IntrospectionResult{std::move(buf), *ty};
+}
+
+}  // namespace oi

--- a/include/oi/oi-jit.h
+++ b/include/oi/oi-jit.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_OI_OI_JIT_H
+#define INCLUDED_OI_OI_JIT_H 1
+
+#include <atomic>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "exporters/inst.h"
+#include "oi.h"
+
+namespace oi::detail {
+class OILibraryImpl;
+}
+
+namespace oi {
+
+struct GeneratorOptions {
+  std::filesystem::path configFilePath;
+  std::filesystem::path sourceFileDumpPath;
+  int debugLevel = 0;
+};
+
+class OILibrary {
+ public:
+  OILibrary(void* atomicHome,
+            std::unordered_set<Feature>,
+            GeneratorOptions opts);
+  ~OILibrary();
+  std::pair<void*, const exporters::inst::Inst&> init();
+
+ private:
+  std::unique_ptr<detail::OILibraryImpl> pimpl_;
+};
+
+/*
+ * setupAndIntrospect
+ *
+ * Execute JIT compilation then introspect the given object. Throws on error.
+ * Returns std::nullopt rather than duplicating initialisation if its ongoing.
+ */
+template <typename T, Feature... Fs>
+std::optional<IntrospectionResult> setupAndIntrospect(
+    const T& objectAddr, const GeneratorOptions& opts);
+
+template <typename T, Feature... Fs>
+class CodegenHandler {
+ public:
+  static bool init(const GeneratorOptions& opts);
+  static IntrospectionResult introspect(const T& objectAddr);
+
+ private:
+  using func_type = void (*)(const T&, std::vector<uint8_t>&);
+
+  static std::atomic<bool>& getIsCritical();
+  static std::atomic<func_type>& getIntrospectionFunc();
+  static std::atomic<const exporters::inst::Inst*>&
+  getTreeBuilderInstructions();
+};
+
+}  // namespace oi
+
+#include "oi-jit-inl.h"
+#endif

--- a/include/oi/oi.h
+++ b/include/oi/oi.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_OI_OI_H
+#define INCLUDED_OI_OI_H 1
+
+#include <oi/IntrospectionResult.h>
+#include <oi/types/dy.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace oi {
+
+enum class Feature {
+  ChaseRawPointers,
+  CaptureThriftIsset,
+  GenJitDebug,
+};
+
+template <typename T, Feature... Fs>
+IntrospectionResult __attribute__((noinline)) introspect(const T& objectAddr);
+
+}  // namespace oi
+
+#ifndef OIL_AOT_COMPILATION
+#include "oi-jit.h"
+#else
+
+template <typename T, Feature... Fs>
+IntrospectionResult __attribute__((noinline)) introspect(const T& objectAddr);
+{ static_assert(false, "OIL v2 does not yet support AoT compilation."); }
+
+#endif
+#endif

--- a/include/oi/result/Element.h
+++ b/include/oi/result/Element.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_OI_RESULT_ELEMENT_H
+#define INCLUDED_OI_RESULT_ELEMENT_H 1
+
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace oi::result {
+
+struct Element {
+  struct ContainerStats {
+    size_t capacity;
+    size_t length;
+  };
+  struct IsSetStats {
+    bool is_set;
+  };
+
+  std::string_view name;
+  std::vector<std::string_view>
+      type_path;  // TODO: should be span<const std::string_view>
+  std::span<const std::string_view> type_names;
+  size_t static_size;
+  size_t exclusive_size;
+
+  std::optional<uintptr_t> pointer;
+  std::optional<ContainerStats> container_stats;
+  std::optional<IsSetStats> is_set_stats;
+};
+
+}  // namespace oi::result
+
+#endif

--- a/include/oi/types/dy.h
+++ b/include/oi/types/dy.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef OI_TYPES_DY_H
-#define OI_TYPES_DY_H 1
+#ifndef INCLUDED_OI_TYPES_DY_H
+#define INCLUDED_OI_TYPES_DY_H 1
 
 /*
  * Dynamic Types
@@ -45,11 +45,11 @@
 
 namespace oi::types::dy {
 
-class Unit;
-class VarInt;
-class Pair;
-class Sum;
-class List;
+struct Unit;
+struct VarInt;
+struct Pair;
+struct Sum;
+struct List;
 
 /*
  * Dynamic
@@ -63,11 +63,10 @@ using Dynamic = std::variant<std::reference_wrapper<const Unit>,
                              std::reference_wrapper<const Sum>,
                              std::reference_wrapper<const List> >;
 
-class Unit {};
-class VarInt {};
+struct Unit {};
+struct VarInt {};
 
-class Pair {
- public:
+struct Pair {
   constexpr Pair(Dynamic first_, Dynamic second_)
       : first(first_), second(second_) {
   }
@@ -76,8 +75,7 @@ class Pair {
   Dynamic second;
 };
 
-class Sum {
- public:
+struct Sum {
   template <size_t N>
   constexpr Sum(const std::array<Dynamic, N>& variants_) : variants(variants_) {
   }
@@ -85,8 +83,7 @@ class Sum {
   std::span<const Dynamic> variants;
 };
 
-class List {
- public:
+struct List {
   constexpr List(Dynamic element_) : element(element_) {
   }
 

--- a/include/oi/types/st.h
+++ b/include/oi/types/st.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef OI_TYPES_ST_H
-#define OI_TYPES_ST_H 1
+#ifndef INCLUDED_OI_TYPES_ST_H
+#define INCLUDED_OI_TYPES_ST_H 1
 
 /*
  * Static Types
@@ -123,7 +123,7 @@ class VarInt {
   }
 
   Unit<DataBuffer> write(uint64_t val) {
-    while (val >= 128) {
+    while (val >= 0x80) {
       _buf.write_byte(0x80 | (val & 0x7f));
       val >>= 7;
     }

--- a/oi/CMakeLists.txt
+++ b/oi/CMakeLists.txt
@@ -52,4 +52,10 @@ target_link_libraries(codegen
   glog::glog
 )
 
+add_library(exporters_json
+  exporters/Json.cpp
+)
+target_include_directories(exporters_json PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(exporters_json oil)
+
 add_subdirectory(type_graph)

--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -80,6 +80,8 @@ class CodeGen {
   void genClassTypeHandler(const type_graph::Class& c, std::string& code);
   void genClassStaticType(const type_graph::Class& c, std::string& code);
   void genClassTraversalFunction(const type_graph::Class& c, std::string& code);
+  void genClassTreeBuilderInstructions(const type_graph::Class& c,
+                                       std::string& code);
 };
 
 }  // namespace oi::detail

--- a/oi/ContainerInfo.h
+++ b/oi/ContainerInfo.h
@@ -27,10 +27,17 @@ ContainerTypeEnum containerTypeEnumFromStr(std::string& str);
 const char* containerTypeEnumToStr(ContainerTypeEnum ty);
 
 struct ContainerInfo {
+  struct Processor {
+    std::string type;
+    std::string func;
+  };
+
   struct Codegen {
     std::string decl;
     std::string func;
     std::string handler = "";
+    std::string traversalFunc = "";
+    std::vector<Processor> processors{};
   };
 
   explicit ContainerInfo(const std::filesystem::path& path);  // Throws

--- a/oi/Features.cpp
+++ b/oi/Features.cpp
@@ -17,16 +17,16 @@
 
 #include <glog/logging.h>
 
-#include <cassert>
 #include <map>
 #include <numeric>
+#include <optional>
 #include <span>
 #include <stdexcept>
 
 namespace oi::detail {
 namespace {
 
-std::string_view featureHelp(Feature f) {
+std::optional<std::string_view> featureHelp(Feature f) {
   switch (f) {
     case Feature::ChaseRawPointers:
       return "Chase raw pointers in the probed object.";
@@ -114,10 +114,11 @@ void featuresHelp(std::ostream& out) {
       });
 
   for (Feature f : allFeatures) {
-    std::string_view name(featureToStr(f));
-
-    out << "  " << name << std::string(longestName - name.size() + 2, ' ')
-        << featureHelp(f) << std::endl;
+    if (const auto h = featureHelp(f)) {
+      std::string_view name(featureToStr(f));
+      out << "  " << name << std::string(longestName - name.size() + 2, ' ')
+          << *h << std::endl;
+    }
   }
 }
 

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -31,6 +31,7 @@
   X(PruneTypeGraph, "prune-type-graph")                    \
   X(TypedDataSegment, "typed-data-segment")                \
   X(TreeBuilderTypeChecking, "tree-builder-type-checking") \
+  X(Library, "library")                                    \
   X(TreeBuilderV2, "tree-builder-v2")                      \
   X(GenJitDebug, "gen-jit-debug")                          \
   X(JitLogging, "jit-logging")                             \

--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <map>
 #include <set>
+#include <span>
 #include <string>
 
 #include "oi/ContainerInfo.h"
@@ -28,6 +29,8 @@ namespace oi::detail {
 
 class FuncGen {
  public:
+  static void DeclareExterns(std::string& code);
+
   static void DeclareStoreData(std::string& testCode);
   static void DefineStoreData(std::string& testCode);
 
@@ -56,6 +59,8 @@ class FuncGen {
   static void DefineTopLevelGetObjectSize(std::string& testCode,
                                           const std::string& type,
                                           const std::string& linkageName);
+  static void DefineTopLevelIntrospect(std::string& code,
+                                       const std::string& type);
 
   static void DefineTopLevelGetSizeRef(std::string& testCode,
                                        const std::string& rawType,
@@ -65,6 +70,11 @@ class FuncGen {
                                             FeatureSet features);
   static void DefineOutputType(std::string& testCode,
                                const std::string& rawType);
+  static void DefineTreeBuilderInstructions(
+      std::string& testCode,
+      const std::string& rawType,
+      size_t exclusiveSize,
+      std::span<const std::string_view> typeNames);
 
   static void DefineTopLevelGetSizeRefRet(std::string& testCode,
                                           const std::string& type);
@@ -77,7 +87,10 @@ class FuncGen {
                                           const std::string& ctype);
 
   static void DefineDataSegmentDataBuffer(std::string& testCode);
-  static void DefineBasicTypeHandlers(std::string& testCode);
+  static void DefineBackInserterDataBuffer(std::string& code);
+  static void DefineBasicTypeHandlers(std::string& code, FeatureSet features);
+
+  static ContainerInfo GetOiArrayContainerInfo();
 };
 
 }  // namespace oi::detail

--- a/oi/Headers.h
+++ b/oi/Headers.h
@@ -19,7 +19,10 @@ namespace oi::detail::headers {
 
 // These externs are provided by our build system. See resources/CMakeLists.txt
 extern const std::string_view oi_OITraceCode_cpp;
-extern const std::string_view oi_types_st_h;
+extern const std::string_view oi_exporters_ParsedData_h;
+extern const std::string_view oi_exporters_inst_h;
+extern const std::string_view oi_result_Element_h;
 extern const std::string_view oi_types_dy_h;
+extern const std::string_view oi_types_st_h;
 
 }  // namespace oi::detail::headers

--- a/oi/IntrospectionResult.cpp
+++ b/oi/IntrospectionResult.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <oi/IntrospectionResult.h>
+#include <oi/exporters/ParsedData.h>
+#include <oi/types/dy.h>
+
+#include <cassert>
+#include <iterator>
+#include <stdexcept>
+
+template <typename T>
+inline constexpr bool always_false_v = false;
+
+namespace oi {
+
+IntrospectionResult::const_iterator&
+IntrospectionResult::const_iterator::operator++() {
+  if (stack_.empty()) {
+    next_ = std::nullopt;
+    return *this;
+  }
+
+  auto el = stack_.top();
+  stack_.pop();
+
+  return std::visit(
+      [this](auto&& r) -> IntrospectionResult::const_iterator& {
+        using U = std::decay_t<decltype(r)>;
+        if constexpr (std::is_same_v<U, exporters::inst::PopTypePath>) {
+          type_path_.pop_back();
+          return operator++();
+        } else {
+          // reference wrapper
+          auto ty = r.get();
+          using T = std::decay_t<decltype(ty)>;
+
+          if constexpr (std::is_same_v<T, exporters::inst::Field>) {
+            type_path_.emplace_back(ty.name);
+            stack_.emplace(exporters::inst::PopTypePath{});
+            next_ = result::Element{
+                .name = ty.name,
+                .type_path = type_path_,
+                .type_names = ty.type_names,
+                .static_size = ty.static_size,
+                .exclusive_size = ty.exclusive_size,
+                .container_stats = std::nullopt,
+                .is_set_stats = std::nullopt,
+            };
+
+            for (const auto& [dy, handler] : ty.processors) {
+              auto parsed = exporters::ParsedData::parse(data_, dy);
+              handler(*next_, stack_, parsed);
+            }
+            for (auto it = ty.fields.rbegin(); it != ty.fields.rend(); ++it) {
+              stack_.emplace(*it);
+            }
+
+            return *this;
+          } else {
+            static_assert(always_false_v<T>, "non-exhaustive visitor!");
+          }
+        }
+      },
+      el);
+}
+
+}  // namespace oi

--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -2983,6 +2983,7 @@ void OICodeGen::declareThriftStruct(std::string& code, std::string_view name) {
 }
 
 bool OICodeGen::generateJitCode(std::string& code) {
+  FuncGen::DeclareExterns(code);
   // Include relevant headers
   code.append("// relevant header includes -----\n");
 

--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -34,12 +34,6 @@
 
 #define C10_USING_CUSTOM_GENERATED_MACROS
 
-// These globals are set by oid, see end of OIDebugger::compileCode()
-extern uint8_t* dataBase;
-extern size_t dataSize;
-extern uintptr_t cookieValue;
-extern int logFile;
-
 constexpr int oidMagicId = 0x01DE8;
 
 #include <array>
@@ -88,21 +82,6 @@ class {
     }
   }
 } static pointers;
-
-void __jlogptr(uintptr_t ptr) {
-  static constexpr char hexdigits[] = "0123456789abcdef";
-  static constexpr size_t ptrlen = 2 * sizeof(ptr);
-
-  static char hexstr[ptrlen + 1] = {};
-
-  size_t i = ptrlen;
-  while (i--) {
-    hexstr[i] = hexdigits[ptr & 0xf];
-    ptr = ptr >> 4;
-  }
-  hexstr[ptrlen] = '\n';
-  write(logFile, hexstr, sizeof(hexstr));
-}
 
 }  // namespace
 

--- a/oi/SymbolService.h
+++ b/oi/SymbolService.h
@@ -56,6 +56,11 @@ class SymbolService {
   static std::string getTypeName(struct drgn_type*);
   std::optional<RootInfo> getRootType(const irequest&);
 
+  static std::optional<drgn_qualified_type> findTypeOfSymbol(
+      drgn_program*, const std::string& symbolName);
+  static std::optional<drgn_qualified_type> findTypeOfAddr(drgn_program*,
+                                                           uintptr_t addr);
+
   std::unordered_map<std::string, std::shared_ptr<FuncDesc>> funcDescs;
   std::unordered_map<std::string, std::shared_ptr<GlobalDesc>> globalDescs;
 

--- a/oi/exporters/Json.cpp
+++ b/oi/exporters/Json.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <oi/exporters/Json.h>
+
+#include <stdexcept>
+
+template <class>
+inline constexpr bool always_false_v = false;
+
+namespace oi::exporters {
+namespace {
+
+template <typename It>
+void printStringList(std::ostream& out, It it, It end, bool pretty) {
+  out << '[';
+  for (; it != end; ++it) {
+    out << '"' << (*it) << '"';
+    if (it != end - 1)
+      out << (pretty ? ", " : ",");
+  }
+  out << ']';
+}
+
+std::string makeIndent(std::vector<std::string_view>& tp) {
+  return std::string((tp.size() - 1) * 4, ' ');
+}
+
+}  // namespace
+
+Json::Json(std::ostream& out) : out_(out) {
+}
+
+void Json::print(const IntrospectionResult& r) {
+  auto begin = r.cbegin();
+  return print(begin, r.cend());
+}
+
+void Json::print(IntrospectionResult::const_iterator& it,
+                 IntrospectionResult::const_iterator end) {
+  std::vector<std::string_view> firstTypePath = it->type_path;
+
+  const auto indent = pretty_ ? makeIndent(firstTypePath) : "";
+  const auto* tab = pretty_ ? "  " : "";
+  const auto* space = pretty_ ? " " : "";
+  const auto* endl = pretty_ ? "\n" : "";
+
+  out_ << '[';
+  out_ << endl << indent;
+
+  bool first = true;
+  while (it != end) {
+    if (it->type_path.size() < firstTypePath.size()) {
+      // no longer a sibling, must be a sibling of the type we're printing
+      break;
+    }
+
+    if (!first)
+      out_ << ',' << endl << indent;
+    first = false;
+
+    out_ << '{' << endl << indent;
+
+    out_ << tab << "\"name\"" << space << ':' << space << "\"" << it->name
+         << "\"," << endl
+         << indent;
+
+    out_ << tab << "\"typePath\"" << space << ':' << space << "";
+    printStringList(out_, it->type_path.begin(), it->type_path.end(), pretty_);
+    out_ << (pretty_ ? ",\n" : ",") << indent;
+
+    out_ << tab << "\"typeNames\"" << space << ':' << space;
+    printStringList(out_, it->type_names.begin(), it->type_names.end(),
+                    pretty_);
+    out_ << ',' << endl << indent;
+
+    out_ << tab << "\"staticSize\":" << space << it->static_size << ',' << endl
+         << indent;
+    out_ << tab << "\"exclusiveSize\":" << space << it->exclusive_size << ','
+         << endl
+         << indent;
+
+    if (it->pointer.has_value()) {
+      out_ << tab << "\"pointer\":" << space << *(it->pointer) << ',' << endl
+           << indent;
+    }
+    if (it->container_stats.has_value()) {
+      out_ << tab << "\"length\":" << space << it->container_stats->length
+           << ',' << endl
+           << indent;
+      out_ << tab << "\"capacity\":" << space << it->container_stats->capacity
+           << ',' << endl
+           << indent;
+    }
+    if (it->is_set_stats.has_value()) {
+      out_ << tab << "\"is_set\":" << space << it->is_set_stats->is_set << ','
+           << endl
+           << indent;
+    }
+
+    out_ << tab << "\"members\":" << space;
+    if ((++it)->type_path.size() > firstTypePath.size()) {
+      print(it, end);
+    } else {
+      out_ << "[]" << endl << indent;
+    }
+
+    out_ << "}";
+  }
+  out_ << endl << indent << ']' << endl;
+}
+
+}  // namespace oi::exporters

--- a/oi/exporters/ParsedData.cpp
+++ b/oi/exporters/ParsedData.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <oi/exporters/ParsedData.h>
+
+#include <cassert>
+#include <stdexcept>
+#include <type_traits>
+
+template <typename T>
+constexpr bool always_false_v = false;
+
+namespace oi::exporters {
+namespace {
+uint64_t parseVarint(std::vector<uint8_t>::const_iterator& it);
+}
+
+ParsedData ParsedData::parse(std::vector<uint8_t>::const_iterator& it,
+                             types::dy::Dynamic dy) {
+  return std::visit(
+      [&it](const auto el) -> ParsedData {
+        auto ty = el.get();
+        using T = std::decay_t<decltype(ty)>;
+        if constexpr (std::is_same_v<T, types::dy::Unit>) {
+          return ParsedData::Unit{};
+        } else if constexpr (std::is_same_v<T, types::dy::VarInt>) {
+          return ParsedData::VarInt{.value = parseVarint(it)};
+        } else if constexpr (std::is_same_v<T, types::dy::Pair>) {
+          return ParsedData::Pair{
+              .first = Lazy{it, ty.first},
+              .second = Lazy{it, ty.second},
+          };
+        } else if constexpr (std::is_same_v<T, types::dy::List>) {
+          return ParsedData::List{
+              .length = parseVarint(it),
+              .values = {it, ty.element},
+          };
+        } else if constexpr (std::is_same_v<T, types::dy::Sum>) {
+          auto index = parseVarint(it);
+          assert(index < ty.variants.size());
+          return ParsedData::Sum{
+              .index = parseVarint(it),
+              .value = {it, ty.variants[index]},
+          };
+        } else {
+          static_assert(always_false_v<T>, "non-exhaustive visitor!");
+        }
+      },
+      dy);
+}
+
+namespace {
+uint64_t parseVarint(std::vector<uint8_t>::const_iterator& it) {
+  uint64_t v = 0;
+  int shift = 0;
+  while (*it >= 0x80) {
+    v |= static_cast<uint64_t>(*it++ & 0x7f) << shift;
+    shift += 7;
+  }
+  v |= static_cast<uint64_t>(*it++ & 0x7f) << shift;
+  return v;
+}
+}  // namespace
+}  // namespace oi::exporters

--- a/oi/type_graph/NameGen.cpp
+++ b/oi/type_graph/NameGen.cpp
@@ -71,6 +71,8 @@ void NameGen::visit(Class& c) {
   std::string name = c.name();
   removeTemplateParams(name);
   deduplicate(name);
+  if (c.name().empty())
+    c.setInputName(name);
   c.setName(name);
 
   // Deduplicate member names. Duplicates may be present after flattening.
@@ -151,6 +153,8 @@ void NameGen::visit(Container& c) {
 void NameGen::visit(Enum& e) {
   std::string name = e.name();
   deduplicate(name);
+  if (e.name().empty())
+    e.setInputName(name);
   e.setName(name);
 }
 

--- a/oi/type_graph/PassManager.cpp
+++ b/oi/type_graph/PassManager.cpp
@@ -40,7 +40,6 @@ namespace {
 void print(const TypeGraph& typeGraph) {
   if (!VLOG_IS_ON(1))
     return;
-
   std::stringstream out;
   Printer printer{out, typeGraph.resetTracker(), typeGraph.size()};
   for (const auto& type : typeGraph.rootTypes()) {

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -231,6 +231,10 @@ class Class : public Type {
     name_ = std::move(name);
   }
 
+  void setInputName(std::string name) {
+    inputName_ = std::move(name);
+  }
+
   virtual size_t size() const override {
     return size_;
   }
@@ -374,6 +378,10 @@ class Enum : public Type {
 
   virtual std::string_view inputName() const override {
     return inputName_;
+  }
+
+  void setInputName(std::string name) {
+    inputName_ = std::move(name);
   }
 
   void setName(std::string name) {

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -7,6 +7,9 @@ function(embed_headers output)
   file(APPEND ${output} "namespace oi::detail::headers {\n")
 
   set(HEADERS
+    ../include/oi/exporters/ParsedData.h
+    ../include/oi/exporters/inst.h
+    ../include/oi/result/Element.h
     ../include/oi/types/dy.h
     ../include/oi/types/st.h
     ../oi/OITraceCode.cpp

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -50,7 +50,7 @@ add_executable(integration_test_target
   ${INTEGRATION_TEST_TARGET_SRC}
   folly_shims.cpp)
 target_compile_options(integration_test_target PRIVATE -O1)
-target_link_libraries(integration_test_target PRIVATE oil Boost::headers ${Boost_LIBRARIES})
+target_link_libraries(integration_test_target PRIVATE oil_jit exporters_json Boost::headers ${Boost_LIBRARIES})
 
 add_executable(integration_test_runner ${INTEGRATION_TEST_RUNNER_SRC} runner_common.cpp)
 target_include_directories(integration_test_runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/integration/alignment.toml
+++ b/test/integration/alignment.toml
@@ -56,6 +56,12 @@ definitions = '''
         {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
           {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''
+    expect_json_v2 = '''[
+      {"staticSize": 32, "exclusiveSize": 15, "members": [
+        {"typeNames": ["int8_t", "__int8_t", "int8_t"], "staticSize": 1, "exclusiveSize": 1},
+        {"typeNames": ["Align16"], "staticSize": 16, "exclusiveSize": 15, "members": [
+          {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1}
+    ]}]}]'''
   [cases.container_struct]
     skip = "container alignment is broken (#143)"
     param_types = ["const std::optional<Align16>&"]
@@ -77,6 +83,16 @@ definitions = '''
           {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
           {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
             {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}]}
+    ]}]}]'''
+    expect_json_v2 = '''[
+      {"staticSize": 64, "exclusiveSize": 15, "members": [
+        {"typeNames": ["int8_t", "__int8_t", "int8_t"], "staticSize": 1, "exclusiveSize": 1},
+        {"typeNames": ["TwoStruct"], "staticSize": 48, "exclusiveSize": 15, "members": [
+          {"typeNames": ["Align16"], "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1}]},
+          {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1},
+          {"typeNames": ["Align16"], "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1}]}
     ]}]}]'''
   [cases.container_two_members]
     skip = "container alignment is broken (#143)"
@@ -101,6 +117,13 @@ definitions = '''
           {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
           {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''
+    expect_json_v2 = '''[
+      {"staticSize": 96, "exclusiveSize": 31, "members": [
+        {"typeNames": ["int8_t", "__int8_t", "int8_t"], "staticSize": 1, "exclusiveSize": 1},
+        {"typeNames": ["MemberAlignment"], "staticSize": 64, "exclusiveSize": 62, "members": [
+          {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1},
+          {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1}
+    ]}]}]'''
   [cases.container_member_alignment]
     skip = "container alignment is broken (#143)"
     param_types = ["const std::optional<MemberAlignment>&"]
@@ -118,6 +141,11 @@ definitions = '''
       {"staticSize": 64, "exclusiveSize": 31, "members": [
         {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
         {"typeName": "UnionMember", "staticSize": 32, "exclusiveSize": 32, "NOT":"members"}
+    ]}]'''
+    expect_json_v2 = '''[
+      {"staticSize": 64, "exclusiveSize": 31, "members": [
+        {"typeNames": ["int8_t", "__int8_t", "int8_t"], "staticSize": 1, "exclusiveSize": 1},
+        {"typeNames": ["UnionMember"], "staticSize": 32, "exclusiveSize": 32, "members":[]}
     ]}]'''
   [cases.container_union_member]
     skip = "container alignment is broken (#143)"
@@ -137,6 +165,14 @@ definitions = '''
           {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
           {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
             {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+    ]}]}]}]'''
+    expect_json_v2 = '''[
+      {"staticSize": 96, "exclusiveSize": 31, "members": [
+        {"typeNames": ["int8_t", "__int8_t", "int8_t"], "staticSize": 1, "exclusiveSize": 1},
+        {"typeNames": ["MemberAlignmentOverriden"], "staticSize": 64, "exclusiveSize": 47, "members": [
+          {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1},
+          {"typeNames": ["Align16"], "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1}
     ]}]}]}]'''
   [cases.container_member_override]
     skip = "container alignment is broken (#143)"
@@ -158,6 +194,13 @@ definitions = '''
         {"typeName": "AlignedStructMemberAlignLower", "staticSize": 128, "exclusiveSize": 126, "members": [
           {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
           {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+    ]}]}]'''
+    expect_json_v2 = '''[
+      {"staticSize": 256, "exclusiveSize": 127, "members": [
+        {"typeNames": ["int8_t", "__int8_t", "int8_t"], "staticSize": 1, "exclusiveSize": 1},
+        {"typeNames": ["AlignedStructMemberAlignLower"], "staticSize": 128, "exclusiveSize": 126, "members": [
+          {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1},
+          {"typeNames": ["int8_t"], "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''
   [cases.container_member_lower]
     skip = "container alignment is broken (#143)"

--- a/test/integration/anonymous.toml
+++ b/test/integration/anonymous.toml
@@ -192,6 +192,7 @@ definitions = '''
     }]'''
 
   [cases.anon_union]
+    oil_skip = "anonymous unions are fully stubbed in the generated code" # https://github.com/facebookexperimental/object-introspection/issues/292
     param_types = ["const AnonUnionContainer&"]
     setup = 'return AnonUnionContainer{ .a = 3 };'
     cli_options = ["-fchase-raw-pointers"]
@@ -202,6 +203,15 @@ definitions = '''
         {"name":"__anon_member_0", "staticSize":2, "dynamicSize":0},
         {"name":"__anon_member_1", "staticSize":8, "dynamicSize":0},
         {"name":"e", "staticSize":4, "dynamicSize":0, "typeName":"int"}
+      ]
+    }]'''
+    expect_json_v2 = '''[{
+      "staticSize": 24,
+      "exclusiveSize": 10,
+      "members": [
+        {"name":"__anon_member_0", "staticSize":2, "exclusiveSize":2},
+        {"name":"__anon_member_1", "staticSize":8, "exclusiveSize":8},
+        {"name":"e", "staticSize":4, "exclusiveSize":4, "typeNames":["int32_t"]}
       ]
     }]'''
 

--- a/test/integration/arrays.toml
+++ b/test/integration/arrays.toml
@@ -30,7 +30,17 @@ definitions = '''
         "capacity":10,
         "elementStaticSize":4
       }]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":40,
+      "exclusiveSize":0,
+      "members":[{
+        "staticSize":40,
+        "exclusiveSize":0,
+        "length":10,
+        "capacity":10
+      }]}]'''
   [cases.member_int0]
+    oil_skip = 'zero length arrays fail codegen v2' # https://github.com/facebookexperimental/object-introspection/issues/295
     # WARNING: zero-length arrays are handled differently to non-empty arrays.
     # They end up not being treated as containers. This should probably change
     # in the future.
@@ -43,8 +53,16 @@ definitions = '''
         "staticSize":0,
         "dynamicSize":0
       }]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":1,
+      "exclusiveSize":1,
+      "members":[{
+        "staticSize":0,
+        "exclusiveSize":0
+      }]}]'''
   [cases.multidim_legacy] # Test for legacy behaviour. Remove with OICodeGen
-    cli_options = ["-Ftype-graph", "-Ftyped-data-segment", "-Ftree-builder-type-checking"]
+    oil_disable = 'oil only runs on codegen v2'
+    cli_options = ["-Ftype-graph", "-Ftyped-data-segment", "-Ftree-builder-type-checking", "-Ftree-builder-v2"]
     param_types = ["const MultiDim&"]
     setup = "return {};"
     expect_json = '''[{
@@ -66,6 +84,12 @@ definitions = '''
         {"staticSize":24, "dynamicSize":0, "exclusiveSize":0, "length":2, "capacity":2, "elementStaticSize":12, "members":[
           {"staticSize":12, "dynamicSize":0, "exclusiveSize":12, "length":3, "capacity":3, "elementStaticSize":4},
           {"staticSize":12, "dynamicSize":0, "exclusiveSize":12, "length":3, "capacity":3, "elementStaticSize":4}]
+      }]}]'''
+    expect_json_v2 = '''[
+      {"staticSize":24, "exclusiveSize":0, "members":[
+        {"staticSize":24, "exclusiveSize":0, "length":2, "capacity":2, "members":[
+          {"staticSize":12, "exclusiveSize":0, "length":3, "capacity":3},
+          {"staticSize":12, "exclusiveSize":0, "length":3, "capacity":3}]
       }]}]'''
   [cases.direct_int10]
     skip = "Direct array arguments don't work"

--- a/test/integration/cycles.toml
+++ b/test/integration/cycles.toml
@@ -154,6 +154,7 @@ definitions = '''
     '''
 
   [cases.unique_ptr]
+    oil_skip = "cycles are broken" # https://github.com/facebookexperimental/object-introspection/issues/293
     param_types = ["std::reference_wrapper<UniqueNode>&"]
     setup = '''
       auto first = std::make_unique<UniqueNode>();
@@ -231,6 +232,7 @@ definitions = '''
     '''
 
   [cases.shared_ptr]
+    oil_skip = "cycles are broken" # https://github.com/facebookexperimental/object-introspection/issues/293
     param_types = ["std::reference_wrapper<SharedNode>&"]
     setup = '''
       auto first = std::make_shared<SharedNode>();

--- a/test/integration/enums_params.toml
+++ b/test/integration/enums_params.toml
@@ -38,7 +38,8 @@ definitions = '''
   [cases.scoped_enum_val_cast]
     param_types = ["const std::array<int, static_cast<size_t>(MyNS::ScopedEnum::Two)>&"]
     setup = "return {};"
-    expect_json = '[{"staticSize":8, "dynamicSize":0, "length":2, "capacity":2, "elementStaticSize":4}]'
+    expect_json = '[{"staticSize":8, "length":2, "capacity":2, "elementStaticSize":4}]'
+    expect_json_v2 = '[{"staticSize":8, "dynamicSize":0, "length":2, "capacity":2}]'
 
   [cases.scoped_enum_val]
     param_types = ["const MyClass<MyNS::ScopedEnum::One>&"]
@@ -59,4 +60,5 @@ definitions = '''
   [cases.unscoped_enum_val_cast]
     param_types = ["const std::array<int, MyNS::ONE>&"]
     setup = "return {};"
-    expect_json = '[{"staticSize":4, "dynamicSize":0, "length":1, "capacity":1, "elementStaticSize":4}]'
+    expect_json = '[{"staticSize":4, "length":1, "capacity":1, "elementStaticSize":4}]'
+    expect_json_v2 = '[{"staticSize":4, "length":1, "capacity":1}]'

--- a/test/integration/fbstring.toml
+++ b/test/integration/fbstring.toml
@@ -1,6 +1,7 @@
 includes = ["folly/FBString.h"]
 [cases]
   [cases.empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/322
     param_types = ["folly::fbstring&"]
     setup = "return {};"
     expect_json = '''
@@ -26,6 +27,7 @@ includes = ["folly/FBString.h"]
     '''
 
   [cases.inline]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/322
     param_types = ["folly::fbstring&"]
     setup = 'return {"012345"};'
     expect_json = '''
@@ -51,6 +53,7 @@ includes = ["folly/FBString.h"]
     '''
 
   [cases.heap_allocated]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/322
     param_types = ["folly::fbstring&"]
     setup = 'return {"abcdefghijklmnopqrstuvwxzy"};'
     expect_json = '''
@@ -76,6 +79,7 @@ includes = ["folly/FBString.h"]
     '''
 
   [cases.string_pooled]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/322
     param_types = ["folly::fbstring&"]
     setup = "return folly::fbstring(1024, 'c');"
     expect_json = '''

--- a/test/integration/folly_small_vector.toml
+++ b/test/integration/folly_small_vector.toml
@@ -1,23 +1,28 @@
 includes = ["folly/small_vector.h", "vector"]
 [cases]
   [cases.int_default_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/321
     param_types = ["const folly::small_vector<int>&"]
     setup = "return {};"
     expect_json = '[{"staticSize":16, "dynamicSize":0, "exclusiveSize":16, "length":0, "capacity":2, "elementStaticSize":4}]'
   [cases.int_default_inlined]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/321
     param_types = ["const folly::small_vector<int>&"]
     setup = "return {{1,2}};"
     expect_json = '[{"staticSize":16, "dynamicSize":0, "exclusiveSize":16, "length":2, "capacity":2, "elementStaticSize":4}]'
   [cases.int_default_overflow]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/321
     param_types = ["const folly::small_vector<int>&"]
     setup = "return {{1,2,3,4}};"
     expect_json = '[{"staticSize":16, "dynamicSize":24, "exclusiveSize":40, "length":4, "capacity":6, "elementStaticSize":4}]'
 
   [cases.vector_3_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/321
     param_types = ["const folly::small_vector<std::vector<int>, 3>&"]
     setup = "return {};"
     expect_json = '[{"staticSize":80, "dynamicSize":0, "exclusiveSize":80, "length":0, "capacity":3, "elementStaticSize":24}]'
   [cases.vector_3_inlined]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/321
     param_types = ["const folly::small_vector<std::vector<int>, 3>&"]
     setup = "return {{ {1,2,3}, {4}, {5,6} }};"
     expect_json = '''[
@@ -27,6 +32,7 @@ includes = ["folly/small_vector.h", "vector"]
         {"staticSize":24, "dynamicSize":8, "exclusiveSize":32, "length":2, "capacity":2, "elementStaticSize":4}
     ]}]'''
   [cases.vector_3_overflow]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/321
     param_types = ["const folly::small_vector<std::vector<int>, 3>&"]
     setup = "return {{ {1,2,3}, {4}, {5,6}, {7} }};"
     expect_json = '''[
@@ -38,6 +44,7 @@ includes = ["folly/small_vector.h", "vector"]
     ]}]'''
 
   [cases.int_always_heap]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/321
     param_types = ["const folly::small_vector<int, 0>&"]
     setup = "return {{1}};"
     expect_json = '[{"staticSize":16, "dynamicSize":4, "exclusiveSize":20, "length":1, "capacity":1, "elementStaticSize":4}]'

--- a/test/integration/folly_sorted_vector_map.toml
+++ b/test/integration/folly_sorted_vector_map.toml
@@ -4,10 +4,39 @@ includes = ["folly/sorted_vector_types.h", "vector"]
     param_types = ["const folly::sorted_vector_map<int, int>&"]
     setup = "return {};"
     expect_json = '[{"staticSize":24, "dynamicSize":0, "exclusiveSize":24, "length":0, "capacity":0, "elementStaticSize":8}]'
+    expect_json_v2 = '[{"staticSize":24, "exclusiveSize":24, "length":0, "capacity":0, "members":[]}]'
   [cases.int_int_some]
     param_types = ["const folly::sorted_vector_map<int, int>&"]
     setup = "return {{ {1,2}, {3,4} }};"
     expect_json = '[{"staticSize":24, "dynamicSize":16, "exclusiveSize":40, "length":2, "capacity":2, "elementStaticSize":8}]'
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "length":2, "capacity":2, "members":[
+      {"staticSize":8, "exclusiveSize":0, "members": [
+        {"name":"key", "staticSize":4, "exclusiveSize":4},
+        {"name":"value", "staticSize":4, "exclusiveSize":4}
+      ]},
+      {"staticSize":8, "exclusiveSize":0, "members": [
+        {"name":"key", "staticSize":4, "exclusiveSize":4},
+        {"name":"value", "staticSize":4, "exclusiveSize":4}
+      ]}
+    ]}]'''
+  [cases.int_int_reserve]
+    param_types = ["const folly::sorted_vector_map<int, int>&"]
+    setup = '''
+      folly::sorted_vector_map<int, int> m{{ {1,2}, {3,4} }};
+      m.reserve(10);
+      return m;
+    '''
+    expect_json = '[{"staticSize":24, "dynamicSize":80, "exclusiveSize":104, "length":2, "capacity":10, "elementStaticSize":8}]'
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":88, "length":2, "capacity":10, "members":[
+      {"staticSize":8, "exclusiveSize":0, "members": [
+        {"name":"key", "staticSize":4, "exclusiveSize":4},
+        {"name":"value", "staticSize":4, "exclusiveSize":4}
+      ]},
+      {"staticSize":8, "exclusiveSize":0, "members": [
+        {"name":"key", "staticSize":4, "exclusiveSize":4},
+        {"name":"value", "staticSize":4, "exclusiveSize":4}
+      ]}
+    ]}]'''
 
   [cases.int_vector_empty]
     skip = "Wrong results" # https://github.com/facebookexperimental/object-introspection/issues/258

--- a/test/integration/ignored.toml
+++ b/test/integration/ignored.toml
@@ -10,6 +10,7 @@ definitions = '''
 
 [cases]
   [cases.a]
+    oil_skip = 'v2 hides the member entirely when it should show it with static size' # todo: github issue
     param_types = ["const Bar&"]
     setup = """
       return Bar{

--- a/test/integration/inheritance_access.toml
+++ b/test/integration/inheritance_access.toml
@@ -1,18 +1,18 @@
 definitions = '''
   class Base {
-    int base_int;
+    int32_t base_int;
   };
 
   class Public : public Base {
-    int public_int;
+    int32_t public_int;
   };
 
   class Protected : protected Base {
-    int protected_int;
+    int32_t protected_int;
   };
 
   class Private : private Base {
-    int private_int;
+    int32_t private_int;
   };
 '''
 [cases]
@@ -21,30 +21,27 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[{
       "staticSize":8,
-      "dynamicSize":0,
       "members":[
-        {"name":"base_int", "staticSize":4, "dynamicSize":0, "typeName": "int"},
-        {"name":"public_int", "staticSize":4, "dynamicSize":0, "typeName": "int"}
+        {"name":"base_int", "staticSize":4, "typeName": "int32_t"},
+        {"name":"public_int", "staticSize":4, "typeName": "int32_t"}
       ]}]'''
   [cases.protected]
     param_types = ["const Protected&"]
     setup = "return {};"
     expect_json = '''[{
       "staticSize":8,
-      "dynamicSize":0,
       "members":[
-        {"name":"base_int", "staticSize":4, "dynamicSize":0, "typeName": "int"},
-        {"name":"protected_int", "staticSize":4, "dynamicSize":0, "typeName": "int"}
+        {"name":"base_int", "staticSize":4, "typeName": "int32_t"},
+        {"name":"protected_int", "staticSize":4, "typeName": "int32_t"}
       ]}]'''
   [cases.private]
     param_types = ["const Private&"]
     setup = "return {};"
     expect_json = '''[{
       "staticSize":8,
-      "dynamicSize":0,
       "members":[
-        {"name":"base_int", "staticSize":4, "dynamicSize":0, "typeName": "int"},
-        {"name":"private_int", "staticSize":4, "dynamicSize":0, "typeName": "int"}
+        {"name":"base_int", "staticSize":4, "typeName": "int32_t"},
+        {"name":"private_int", "staticSize":4, "typeName": "int32_t"}
       ]}]'''
   [cases.public_as_base]
     param_types = ["const Base&"]
@@ -52,7 +49,6 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[{
       "staticSize":4,
-      "dynamicSize":0,
       "members":[
-        {"name":"base_int", "staticSize":4, "dynamicSize":0, "typeName": "int"}
+        {"name":"base_int", "staticSize":4, "typeName": "int32_t"}
       ]}]'''

--- a/test/integration/inheritance_multiple.toml
+++ b/test/integration/inheritance_multiple.toml
@@ -34,3 +34,14 @@ definitions = '''
         {"name":"e", "staticSize":4, "dynamicSize":0, "typeName": "int"},
         {"name":"f", "staticSize":4, "dynamicSize":0, "typeName": "int"}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":24,
+      "exclusiveSize":0,
+      "members":[
+        {"name":"a", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
+        {"name":"b", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
+        {"name":"c", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
+        {"name":"d", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
+        {"name":"e", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
+        {"name":"f", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]}
+      ]}]'''

--- a/test/integration/inheritance_polymorphic_non_dynamic_base.toml
+++ b/test/integration/inheritance_polymorphic_non_dynamic_base.toml
@@ -82,6 +82,7 @@ definitions = '''
         {"name":"vec_b", "staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4}
       ]}]'''
   [cases.b_no_polymorphic]
+    oil_skip = "vptr included in output when it should probably be hidden" # https://github.com/facebookexperimental/object-introspection/issues/291
     param_types = ["const B&"]
     arg_types = ["B"]
     setup = '''
@@ -157,6 +158,7 @@ definitions = '''
         {"name":"int_c", "staticSize":4, "dynamicSize":0}
       ]}]'''
   [cases.c_no_polymorphic]
+    oil_skip = 'vptrs are included int he json output' # https://github.com/facebookexperimental/object-introspection/issues/291
     param_types = ["const C&"]
     arg_types = ["C"]
     setup = '''
@@ -174,3 +176,14 @@ definitions = '''
         {"name":"vec_b", "staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4},
         {"name":"int_c", "staticSize":4, "dynamicSize":0}
       ]}]'''
+    expect_json_v2 = '''[{
+      "typeNames": ["C"],
+      "staticSize": 48,
+      "exclusiveSize": 8,
+      "members": [
+        {"name":"int_a", "staticSize":4, "exclusiveSize":4},
+        {"staticSize":8, "exclusiveSize":8},
+        {"name":"vec_b", "staticSize":24, "exclusiveSize":24, "length":3, "capacity":3},
+        {"name":"int_c", "staticSize":4, "exclusiveSize":4}
+      ]
+    }]'''

--- a/test/integration/multi_arg.toml
+++ b/test/integration/multi_arg.toml
@@ -12,6 +12,7 @@ definitions = '''
 
 [cases]
   [cases.a]
+    oil_disable = 'multi-argument probing has no meaning for oil'
     param_types = ["int", "double"]
     args = "arg0,arg1"
     setup = "return {1,2.0};"

--- a/test/integration/namespaces.toml
+++ b/test/integration/namespaces.toml
@@ -16,6 +16,7 @@ definitions = '''
 '''
 [cases]
   [cases.queue]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/308
     param_types = ["const std::queue<std::pair<nsA::Foo, nsB::Foo>>&"]
     setup = "return std::queue<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>>({{ns_namespaces::nsA::Foo(), ns_namespaces::nsB::Foo()}});"
     expect_json = '''[{
@@ -23,6 +24,7 @@ definitions = '''
       "staticSize": 80, "dynamicSize": 12, "length": 1, "capacity": 1, "elementStaticSize": 12
     }]'''
   [cases.stack]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/305
     param_types = ["const std::stack<std::pair<nsA::Foo, nsB::Foo>>&"]
     setup = "return std::stack<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>>({{ns_namespaces::nsA::Foo(), ns_namespaces::nsB::Foo()}});"
     expect_json = '''[{

--- a/test/integration/padding.toml
+++ b/test/integration/padding.toml
@@ -93,10 +93,15 @@ definitions = '''
       ]}]'''
 
   [cases.parent_padding]
+    oid_skip = 'calculating incorrectly'
     param_types = ["const PaddedChild&"]
     setup = "return PaddedChild{};"
     expect_json = '''[{
       "staticSize": 104,
       "dynamicSize": 0,
       "paddingSavingsSize": 19
+    }]'''
+    expect_json_v2 = '''[{
+      "staticSize": 104,
+      "exclusiveSize": 32
     }]'''

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -14,8 +14,7 @@ definitions = '''
 
 [cases]
   [cases.int]
-    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
-    oil_disable = "oil can't chase raw pointers safely"
+    skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["int*"]
     setup = "return new int(1);"
     cli_options = ["-fchase-raw-pointers"]
@@ -33,7 +32,7 @@ definitions = '''
       ]
     }]'''
   [cases.int_no_follow]
-    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
+    skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["int*"]
     setup = "return new int(1);"
     expect_json = '''[{
@@ -44,7 +43,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.int_null]
-    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
+    skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["int*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -57,8 +56,7 @@ definitions = '''
 
 
   [cases.void]
-    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
-    oil_disable = "oil can't chase raw pointers safely"
+    skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["void*"]
     setup = "return new int(1);"
     cli_options = ["-fchase-raw-pointers"]
@@ -70,7 +68,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.void_no_follow]
-    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
+    skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["void*"]
     setup = "return new int(1);"
     expect_json = '''[{
@@ -81,7 +79,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.void_null]
-    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
+    skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["void*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -94,8 +92,7 @@ definitions = '''
 
 
   [cases.vector]
-    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
-    oil_disable = "oil can't chase raw pointers safely"
+    skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
     cli_options = ["-fchase-raw-pointers"]
@@ -113,7 +110,7 @@ definitions = '''
       ]
     }]'''
   [cases.vector_no_follow]
-    oid_skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
+    skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
     expect_json = '''[{
@@ -124,7 +121,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.vector_null]
-    oid_skip = "BAD DATA SEGMENT!!! top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
+    skip = "BAD DATA SEGMENT!!! top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["std::vector<int>*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -224,7 +221,7 @@ definitions = '''
         {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}}
       ]}]'''
   [cases.vector_of_pointers_no_follow]
-    oid_skip = "pointer field is missing from results" # https://github.com/facebookexperimental/object-introspection/issues/21
+    skip = "pointer field is missing from results" # https://github.com/facebookexperimental/object-introspection/issues/21
     param_types = ["const std::vector<int*>&"]
     setup = "return {{new int(1), nullptr, new int(3)}};"
     expect_json = '''[{

--- a/test/integration/pointers_function.toml
+++ b/test/integration/pointers_function.toml
@@ -14,7 +14,7 @@ definitions = '''
 
 [cases]
   [cases.raw]
-    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
+    skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{myFunction}};"
     expect_json = '''[{
@@ -46,7 +46,7 @@ definitions = '''
       }]
     }]'''
   [cases.raw_null]
-    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
+    skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{nullptr}};"
     expect_json = '''[{
@@ -62,7 +62,7 @@ definitions = '''
     }]'''
 
   [cases.std_function]
-    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
+    skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["std::function<void(int)> &"]
     setup = "return myFunction;"
     expect_json = '''[{
@@ -86,7 +86,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.std_function_null]
-    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
+    skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["std::function<void(int)> &"]
     setup = "return nullptr;"
     expect_json = '''[{

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -32,7 +32,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.raw_no_follow]
-    oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
     expect_json = '''[{
@@ -43,7 +43,7 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.raw_null]
-    oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
     param_types = ["IncompleteType*"]
     setup = "return nullptr;"
     expect_json = '''[{
@@ -55,6 +55,7 @@ definitions = '''
     }]'''
 
   [cases.unique_ptr]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/299
     param_types = ["const std::unique_ptr<IncompleteType, decltype(&incomplete_type_deleter)>&"]
     setup = '''
       auto raw_ptr = static_cast<IncompleteType*>(::operator new(5));
@@ -63,6 +64,7 @@ definitions = '''
     '''
     expect_json = '[{"staticSize":16, "dynamicSize":0, "NOT":"members"}]'
   [cases.unique_ptr_null]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/299
     param_types = ["const std::unique_ptr<IncompleteType, decltype(&incomplete_type_deleter)>&"]
     setup = '''
       return std::unique_ptr<IncompleteType, decltype(&incomplete_type_deleter)>(
@@ -71,6 +73,7 @@ definitions = '''
     expect_json = '[{"staticSize":16, "dynamicSize":0, "NOT":"members"}]'
 
   [cases.shared_ptr]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/300
     param_types = ["const std::shared_ptr<IncompleteType>&"]
     setup = '''
       auto raw_ptr = static_cast<IncompleteType*>(::operator new(5));
@@ -78,6 +81,7 @@ definitions = '''
     '''
     expect_json = '[{"staticSize":16, "dynamicSize":0, "NOT":"members"}]'
   [cases.shared_ptr_null]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/300
     param_types = ["const std::shared_ptr<IncompleteType>"]
     setup = "return nullptr;"
     expect_json = '[{"staticSize":16, "dynamicSize":0, "NOT":"members"}]'

--- a/test/integration/runner_common.h
+++ b/test/integration/runner_common.h
@@ -49,16 +49,6 @@ class IntegrationBase : public ::testing::Test {
 
   std::string stdout_;
   std::string stderr_;
-};
-
-class OidIntegration : public IntegrationBase {
- protected:
-  std::string TmpDirStr() override;
-
-  OidProc runOidOnProcess(OidOpts opts,
-                          std::vector<std::string> extra_args,
-                          std::string configPrefix,
-                          std::string configSuffix);
 
   /*
    * compare_json
@@ -70,6 +60,16 @@ class OidIntegration : public IntegrationBase {
                     const boost::property_tree::ptree& actual_json,
                     const std::string& full_key = "root",
                     bool expect_eq = true);
+};
+
+class OidIntegration : public IntegrationBase {
+ protected:
+  std::string TmpDirStr() override;
+
+  OidProc runOidOnProcess(OidOpts opts,
+                          std::vector<std::string> extra_args,
+                          std::string configPrefix,
+                          std::string configSuffix);
 };
 
 class OilIntegration : public IntegrationBase {

--- a/test/integration/simple.toml
+++ b/test/integration/simple.toml
@@ -44,6 +44,5 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[{
       "staticSize":8,
-      "dynamicSize":0,
-      "NOT":"members"
+      "dynamicSize":0
     }]'''

--- a/test/integration/sorted_vector_set.toml
+++ b/test/integration/sorted_vector_set.toml
@@ -5,6 +5,7 @@ definitions = '''
 
 [cases]
   [cases.no_ints]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/320
     param_types = ["const sorted_vector_set<int>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -22,6 +23,7 @@ definitions = '''
     }]}]'''
 
   [cases.some_ints]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/320
     param_types = ["const sorted_vector_set<int>&"]
     setup = '''
       sorted_vector_set<int> is;

--- a/test/integration/std_array.toml
+++ b/test/integration/std_array.toml
@@ -1,6 +1,7 @@
 includes = ["array", "cstdint", "vector"]
 [cases]
   [cases.uint64_length_0]
+    oil_skip = 'needs updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/318
     param_types = ["std::array<std::uint64_t, 0>&"]
     setup = "return {{}};"
     expect_json = '''
@@ -16,6 +17,7 @@ includes = ["array", "cstdint", "vector"]
     ]
     '''
   [cases.uint64_length_1]
+    oil_skip = 'needs updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/318
     param_types = ["std::array<std::uint64_t, 1>&"]
     setup = "return {{1}};"
     expect_json = '''
@@ -31,6 +33,7 @@ includes = ["array", "cstdint", "vector"]
     ]
     '''
   [cases.uint64_length_8]
+    oil_skip = 'needs updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/318
     param_types = ["std::array<std::uint64_t, 8>&"]
     setup = "return {{0,1,2,3,4,5,6,7}};"
     expect_json = '''
@@ -45,6 +48,7 @@ includes = ["array", "cstdint", "vector"]
     ]
     '''
   [cases.vector_length_1]
+    oil_skip = 'needs updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/318
     param_types = ["std::array<std::vector<std::uint64_t>, 1>&"]
     setup = "return {{std::initializer_list<std::uint64_t>({1,2,3,4,5})}};"
     expect_json = '''
@@ -65,6 +69,7 @@ includes = ["array", "cstdint", "vector"]
     ]
     '''
   [cases.vector_length_2]
+    oil_skip = 'needs updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/318
     param_types = ["std::array<std::vector<std::uint64_t>, 2>&"]
     setup = "return {{std::initializer_list<std::uint64_t>({1,2,3,4,5}), std::initializer_list<std::uint64_t>({6,7,8,9})}};"
     expect_json = '''

--- a/test/integration/std_conditional.toml
+++ b/test/integration/std_conditional.toml
@@ -16,6 +16,7 @@ public:
 '''
 [cases]
   [cases.a]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/317
     param_types = ["const C&"]
     setup = '''
       C foo;

--- a/test/integration/std_deque.toml
+++ b/test/integration/std_deque.toml
@@ -3,18 +3,22 @@
 includes = ["deque"]
 [cases]
   [cases.int_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/316
     param_types = ["const std::deque<int>&"]
     setup = "return {};"
     expect_json = '[{"staticSize":80, "dynamicSize":0, "length":0, "capacity":0, "elementStaticSize":4}]'
   [cases.int_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/316
     param_types = ["const std::deque<int>&"]
     setup = "return {{1,2,3}};"
     expect_json = '[{"staticSize":80, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4}]'
   [cases.deque_int_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/316
     param_types = ["const std::deque<std::deque<int>>&"]
     setup = "return {};"
     expect_json = '[{"staticSize":80, "dynamicSize":0, "length":0, "capacity":0, "elementStaticSize":80}]'
   [cases.deque_int_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/316
     param_types = ["const std::deque<std::deque<int>>&"]
     setup = "return {{{1,2,3},{},{4,5}}};"
     expect_json = '''[{

--- a/test/integration/std_deque_del_allocator.toml
+++ b/test/integration/std_deque_del_allocator.toml
@@ -24,6 +24,7 @@ includes = ["deque"]
 
 [cases]
   [cases.a]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/316
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;

--- a/test/integration/std_list_del_allocator.toml
+++ b/test/integration/std_list_del_allocator.toml
@@ -27,6 +27,7 @@ includes = ["list"]
 
 [cases]
   [cases.a]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/315
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;

--- a/test/integration/std_map_custom_comparator.toml
+++ b/test/integration/std_map_custom_comparator.toml
@@ -36,6 +36,7 @@ includes = ["map", "functional"]
 
 [cases]
   [cases.a]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/314
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;

--- a/test/integration/std_multimap_custom_comparator.toml
+++ b/test/integration/std_multimap_custom_comparator.toml
@@ -14,6 +14,7 @@ includes = ["map"]
 
 [cases]
   [cases.a]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/313
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;

--- a/test/integration/std_optional.toml
+++ b/test/integration/std_optional.toml
@@ -1,6 +1,7 @@
 includes = ["optional", "cstdint", "vector"]
 [cases]
   [cases.uint64_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/312
     param_types = ["std::optional<std::uint64_t>&"]
     setup = "return std::nullopt;"
     expect_json = '''
@@ -16,6 +17,7 @@ includes = ["optional", "cstdint", "vector"]
     ]
     '''
   [cases.uint64_present]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/312
     param_types = ["std::optional<std::uint64_t>&"]
     setup = "return 64;"
     expect_json = '''
@@ -31,6 +33,7 @@ includes = ["optional", "cstdint", "vector"]
     ]
     '''
   [cases.vector_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/312
     param_types = ["std::optional<std::vector<std::uint64_t>>&"]
     setup = "return std::nullopt;"
     expect_json = '''
@@ -46,6 +49,7 @@ includes = ["optional", "cstdint", "vector"]
     ]
     '''
   [cases.vector_present]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/312
     param_types = ["std::optional<std::vector<std::uint64_t>>&"]
     setup = "return {{{1,2,3,4,5}}};"
     expect_json = '''

--- a/test/integration/std_pair.toml
+++ b/test/integration/std_pair.toml
@@ -1,6 +1,7 @@
 includes = ["vector", "utility", "cstdint"]
 [cases]
   [cases.uint64_uint64]
+    oil_skip = 'tests need updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/310
     param_types = ["std::pair<std::uint64_t, std::uint64_t>&"]
     setup = "return {{0, 1}};"
     expect_json = '''
@@ -14,6 +15,7 @@ includes = ["vector", "utility", "cstdint"]
     ]
     '''
   [cases.uint64_uint32]
+    oil_skip = 'tests need updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/310
     param_types = ["std::pair<std::uint64_t, std::uint32_t>&"]
     setup = "return {{0, 1}};"
     # Should still have static size of 16 due to padding
@@ -28,6 +30,7 @@ includes = ["vector", "utility", "cstdint"]
     ]
     '''
   [cases.vector_vector]
+    oil_skip = 'tests need updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/310
     param_types = ["std::pair<std::vector<std::uint64_t>, std::vector<std::uint64_t>>&"]
     setup = "return {{std::initializer_list<std::uint64_t>({0,1,2}), std::initializer_list<std::uint64_t>({3,4,5,6})}};"
     expect_json = '''

--- a/test/integration/std_priority_queue.toml
+++ b/test/integration/std_priority_queue.toml
@@ -1,6 +1,7 @@
 includes = ["queue"]
 [cases]
   [cases.int_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/309
     param_types = ["const std::priority_queue<int>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -13,6 +14,7 @@ includes = ["queue"]
         }
       ]}]'''
   [cases.int_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/309
     param_types = ["const std::priority_queue<int>&"]
     setup = "return std::priority_queue<int>({}, {3,2,1});"
     expect_json = '''[{
@@ -25,6 +27,7 @@ includes = ["queue"]
         }
       ]}]'''
   [cases.adapter_deque_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/309
     param_types = ["const std::priority_queue<int, std::deque<int>>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -37,6 +40,7 @@ includes = ["queue"]
         }
       ]}]'''
   [cases.adapter_deque_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/309
     param_types = ["const std::priority_queue<int, std::deque<int>>&"]
     setup = "return std::priority_queue<int, std::deque<int>>({}, {3,2,1});"
     expect_json = '''[{

--- a/test/integration/std_queue.toml
+++ b/test/integration/std_queue.toml
@@ -1,6 +1,7 @@
 includes = ["queue"]
 [cases]
   [cases.int_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/308
     param_types = ["const std::queue<int>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -13,6 +14,7 @@ includes = ["queue"]
         }
       ]}]'''
   [cases.int_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/308
     param_types = ["const std::queue<int>&"]
     setup = "return std::queue<int>({1,2,3});"
     expect_json = '''[{
@@ -25,6 +27,7 @@ includes = ["queue"]
         }
       ]}]'''
   [cases.queue_int_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/308
     param_types = ["const std::queue<std::queue<int>>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -35,6 +38,7 @@ includes = ["queue"]
         }
       ]}]'''
   [cases.queue_int_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/308
     param_types = ["const std::queue<std::queue<int>>&"]
     setup = '''
       return std::queue<std::queue<int>>({
@@ -83,6 +87,7 @@ includes = ["queue"]
         }
       ]}]'''
   [cases.adapter_vector_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/308
     param_types = ["const std::queue<int, std::vector<int>>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -95,6 +100,7 @@ includes = ["queue"]
         }
       ]}]'''
   [cases.adapter_vector_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/308
     param_types = ["const std::queue<int, std::vector<int>>&"]
     setup = "return std::queue<int, std::vector<int>>({1,2,3});"
     expect_json = '''[{

--- a/test/integration/std_reference_wrapper.toml
+++ b/test/integration/std_reference_wrapper.toml
@@ -1,10 +1,12 @@
 includes = ["functional"]
 [cases]
   [cases.int]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/307
     param_types = ["const std::reference_wrapper<int>&"]
     setup = "return std::ref(*new int(1));"
     expect_json = '[{"staticSize":8, "dynamicSize":4, "length":1, "capacity":1, "elementStaticSize":4}]'
   [cases.vector]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/307
     param_types = ["const std::vector<std::reference_wrapper<int>>&"]
     setup = "return {{std::ref(*new int(1)), std::ref(*new int(2)), std::ref(*new int(3))}};"
     expect_json = '''[{

--- a/test/integration/std_set_custom_comparator.toml
+++ b/test/integration/std_set_custom_comparator.toml
@@ -31,6 +31,7 @@ includes = ["set", "functional"]
 
 [cases]
   [cases.a]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/306
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;

--- a/test/integration/std_smart_ptr.toml
+++ b/test/integration/std_smart_ptr.toml
@@ -7,6 +7,7 @@ definitions = '''
 '''
 [cases]
   [cases.unique_ptr_uint64_empty]
+    oil_skip = "std::unique_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/299
     param_types = ["std::unique_ptr<std::uint64_t>&"]
     setup = "return {nullptr};"
     expect_json = '''
@@ -22,6 +23,7 @@ definitions = '''
     ]
     '''
   [cases.unique_ptr_uint64_present]
+    oil_skip = "std::unique_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/299
     param_types = ["std::unique_ptr<std::uint64_t>&"]
     setup = "return {std::make_unique<std::uint64_t>(64)};"
     expect_json = '''
@@ -36,6 +38,7 @@ definitions = '''
     ]
     '''
   [cases.unique_ptr_vector_empty]
+    oil_skip = "std::unique_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/299
     param_types = ["std::unique_ptr<std::vector<std::uint64_t>>&"]
     setup = "return {nullptr};"
     expect_json = '''
@@ -50,6 +53,7 @@ definitions = '''
     ]
     '''
   [cases.unique_ptr_vector_present]
+    oil_skip = "std::unique_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/299
     param_types = ["std::unique_ptr<std::vector<std::uint64_t>>&"]
     setup = "return {std::make_unique<std::vector<std::uint64_t>>(std::initializer_list<std::uint64_t>({1,2,3,4,5}))};"
     expect_json = '''
@@ -72,6 +76,7 @@ definitions = '''
     ]
     '''
   [cases.unique_ptr_void_empty]
+    oil_skip = "std::unique_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/299
     param_types = ["std::unique_ptr<void, decltype(&void_int_deleter)>&"]
     setup = "return {std::unique_ptr<void, decltype(&void_int_deleter)>(nullptr, &void_int_deleter)};"
     expect_json = '''
@@ -83,6 +88,7 @@ definitions = '''
     ]
     '''
   [cases.unique_ptr_void_present]
+    oil_skip = "std::unique_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/299
     param_types = ["std::unique_ptr<void, decltype(&void_int_deleter)>&"]
     setup = "return {std::unique_ptr<void, decltype(&void_int_deleter)>(new int, &void_int_deleter)};"
     expect_json = '''
@@ -94,6 +100,7 @@ definitions = '''
     ]
     '''
   [cases.shared_ptr_uint64_empty]
+    oil_skip = "std::shared_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/300
     param_types = ["std::shared_ptr<std::uint64_t>&"]
     setup = "return {nullptr};"
     expect_json = '''
@@ -108,6 +115,7 @@ definitions = '''
     ]
     '''
   [cases.shared_ptr_uint64_present]
+    oil_skip = "std::shared_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/300
     param_types = ["std::shared_ptr<std::uint64_t>&"]
     setup = "return std::make_shared<std::uint64_t>(64);"
     expect_json = '''
@@ -122,6 +130,7 @@ definitions = '''
     ]
     '''
   [cases.shared_ptr_vector_empty]
+    oil_skip = "std::shared_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/300
     param_types = ["std::shared_ptr<std::vector<std::uint64_t>>&"]
     setup = "return {nullptr};"
     expect_json = '''
@@ -136,6 +145,7 @@ definitions = '''
     ]
     '''
   [cases.shared_ptr_vector_present]
+    oil_skip = "std::shared_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/300
     param_types = ["std::shared_ptr<std::vector<std::uint64_t>>&"]
     setup = "return std::make_shared<std::vector<std::uint64_t>>(std::initializer_list<std::uint64_t>({1,2,3,4,5}));"
     expect_json = '''
@@ -156,6 +166,7 @@ definitions = '''
     ]
     '''
   [cases.shared_ptr_void_empty]
+    oil_skip = "std::shared_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/300
     param_types = ["std::shared_ptr<void>&"]
     setup = "return {nullptr};"
     expect_json = '''
@@ -168,6 +179,7 @@ definitions = '''
     ]
     '''
   [cases.shared_ptr_void_present]
+    oil_skip = "std::shared_ptr is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/300
     param_types = ["std::shared_ptr<void>&"]
     setup = "return {std::shared_ptr<void>(new int)};"
     expect_json = '''
@@ -192,6 +204,7 @@ definitions = '''
       }
     ]
     '''
+    expect_json_v2 = '''[{ "staticSize": 16, "exclusiveSize": 16, "members":[]}]'''
   [cases.weak_ptr_int64_void_empty]
     param_types = ["std::weak_ptr<void>&"]
     setup = "return std::weak_ptr<void>();"
@@ -205,6 +218,7 @@ definitions = '''
       }
     ]
     '''
+    expect_json_v2 = '''[{ "staticSize": 16, "exclusiveSize": 16, "members":[]}]'''
   [cases.weak_ptr_int64_present]
     param_types = ["std::weak_ptr<std::uint64_t>&"]
     setup = '''
@@ -222,6 +236,7 @@ definitions = '''
       }
     ]
     '''
+    expect_json_v2 = '''[{ "staticSize": 16, "exclusiveSize": 16, "members":[]}]'''
   [cases.weak_ptr_int64_expired]
     param_types = ["std::weak_ptr<std::uint64_t>&"]
     setup = '''
@@ -239,6 +254,7 @@ definitions = '''
       }
     ]
     '''
+    expect_json_v2 = '''[{ "staticSize": 16, "exclusiveSize": 16, "members":[]}]'''
   [cases.weak_ptr_int64_present_chase]
     param_types = ["std::weak_ptr<std::uint64_t>&"]
     cli_options = ["-fchase-raw-pointers"]
@@ -257,6 +273,7 @@ definitions = '''
       }
     ]
     '''
+    expect_json_v2 = '''[{ "staticSize": 16, "exclusiveSize": 16, "members":[]}]'''
   [cases.weak_ptr_int64_expired_chase]
     param_types = ["std::weak_ptr<std::uint64_t>&"]
     cli_options = ["-fchase-raw-pointers"]
@@ -273,3 +290,4 @@ definitions = '''
       }
     ]
     '''
+    expect_json_v2 = '''[{ "staticSize": 16, "exclusiveSize": 16, "members":[]}]'''

--- a/test/integration/std_stack.toml
+++ b/test/integration/std_stack.toml
@@ -1,6 +1,7 @@
 includes = ["stack", "vector"]
 [cases]
   [cases.int_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/305
     param_types = ["const std::stack<int>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -13,6 +14,7 @@ includes = ["stack", "vector"]
         }
       ]}]'''
   [cases.int_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/305
     param_types = ["const std::stack<int>&"]
     setup = "return std::stack<int>({1,2,3});"
     expect_json = '''[{
@@ -25,6 +27,7 @@ includes = ["stack", "vector"]
         }
       ]}]'''
   [cases.stack_int_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/305
     param_types = ["const std::stack<std::stack<int>>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -35,6 +38,7 @@ includes = ["stack", "vector"]
         }
       ]}]'''
   [cases.stack_int_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/305
     param_types = ["const std::stack<std::stack<int>>&"]
     setup = '''
       return std::stack<std::stack<int>>({
@@ -83,6 +87,7 @@ includes = ["stack", "vector"]
         }
       ]}]'''
   [cases.adapter_vector_empty]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/305
     param_types = ["const std::stack<int, std::vector<int>>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -95,6 +100,7 @@ includes = ["stack", "vector"]
         }
       ]}]'''
   [cases.adapter_vector_some]
+    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/305
     param_types = ["const std::stack<int, std::vector<int>>&"]
     setup = "return std::stack<int, std::vector<int>>({1,2,3});"
     expect_json = '''[{

--- a/test/integration/std_string.toml
+++ b/test/integration/std_string.toml
@@ -1,6 +1,7 @@
 includes = ["string"]
 [cases]
   [cases.empty]
+    oil_skip = 'needs updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/311
     param_types = ["std::string&"]
     setup = "return {};"
     expect_json = '''
@@ -25,6 +26,7 @@ includes = ["string"]
     ]
     '''
   [cases.sso]
+    oil_skip = 'needs updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/311
     param_types = ["std::string&"]
     setup = 'return {"012345"};'
     expect_json = '''
@@ -49,6 +51,7 @@ includes = ["string"]
     ]
     '''
   [cases.heap_allocated]
+    oil_skip = 'needs updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/311
     param_types = ["std::string&"]
     setup = 'return {"abcdefghijklmnopqrstuvwxzy"};'
     expect_json = '''

--- a/test/integration/std_tuple.toml
+++ b/test/integration/std_tuple.toml
@@ -9,6 +9,7 @@ struct Bar {
 '''
 [cases]
   [cases.uint64_uint64]
+    oil_skip = "std::tuple is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/304
     param_types = ["Bar&"]
     setup = '''
       Foo f;

--- a/test/integration/std_unordered_map_custom_operator.toml
+++ b/test/integration/std_unordered_map_custom_operator.toml
@@ -33,6 +33,7 @@ includes = ["unordered_map"]
 
 [cases]
   [cases.a]
+    oil_skip = "std::unordered_map is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/303
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;

--- a/test/integration/std_unordered_set_custom_operator.toml
+++ b/test/integration/std_unordered_set_custom_operator.toml
@@ -33,6 +33,7 @@ includes = ["unordered_set"]
 
 [cases]
   [cases.a]
+    oil_skip = "std::unordered_set is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/302
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;

--- a/test/integration/std_variant.toml
+++ b/test/integration/std_variant.toml
@@ -9,6 +9,7 @@ definitions = '''
 
 [cases]
   [cases.char_int64_1]
+    oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
     param_types = ["const std::variant<char, int64_t>&"]
     setup = "return 'a';"
     expect_json = '''[{
@@ -22,6 +23,7 @@ definitions = '''
         {"typeName":"char", "staticSize":1, "exclusiveSize":1, "dynamicSize":0}
       ]}]'''
   [cases.char_int64_2]
+    oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
     param_types = ["const std::variant<char, int64_t>&"]
     setup = "return 1234;"
     expect_json = '''[{
@@ -36,6 +38,7 @@ definitions = '''
       ]}]'''
 
   [cases.vector_int_1]
+    oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
     param_types = ["const std::variant<std::vector<int>, int>&"]
     setup = "return std::vector<int>{1,2,3};"
     expect_json = '''[{
@@ -57,6 +60,7 @@ definitions = '''
         }
       ]}]'''
   [cases.vector_int_2]
+    oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
     param_types = ["const std::variant<std::vector<int>, int>&"]
     setup = "return 123;"
     expect_json = '''[{
@@ -74,6 +78,7 @@ definitions = '''
       ]}]'''
 
   [cases.optional]
+    oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
     # This test case ensures that the alignment of std::variant is set
     # correctly, as otherwise the size of the std::optional would be wrong
     param_types = ["const std::optional<std::variant<char, int64_t>>&"]
@@ -100,6 +105,7 @@ definitions = '''
       ]}]'''
 
   [cases.empty]
+    oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
     # https://en.cppreference.com/w/cpp/utility/variant/valueless_by_exception
     param_types = ["const std::variant<int, Thrower>&"]
     setup = '''
@@ -127,6 +133,7 @@ definitions = '''
   # 0xff can be a valid index if there are at least 256 parameters, and that
   # the invalid index value is raised to 0xffff.
   [cases.256_params_256]
+    oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
     param_types = ["const std::variant<Thrower,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,char>&"]
     setup = "return 'a';"
     expect_json = '''[{
@@ -140,6 +147,7 @@ definitions = '''
         {"typeName":"char", "staticSize":1, "exclusiveSize":1, "dynamicSize":0}
       ]}]'''
   [cases.256_params_empty]
+    oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
     param_types = ["const std::variant<Thrower,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,char>&"]
     setup = '''
       std::variant<Thrower,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,char> var{'a'};

--- a/test/integration/std_vector.toml
+++ b/test/integration/std_vector.toml
@@ -4,10 +4,16 @@ includes = ["vector"]
     param_types = ["const std::vector<int>&"]
     setup = "return {};"
     expect_json = '[{"staticSize":24, "dynamicSize":0, "length":0, "capacity":0, "elementStaticSize":4}]'
+    expect_json_v2 = '[{"staticSize":24, "exclusiveSize":24, "length":0, "capacity":0, "members":[]}]'
   [cases.int_some]
     param_types = ["const std::vector<int>&"]
     setup = "return {{1,2,3}};"
     expect_json = '[{"staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4}]'
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "length":3, "capacity":3, "members":[
+      {"staticSize":4, "exclusiveSize":4},
+      {"staticSize":4, "exclusiveSize":4},
+      {"staticSize":4, "exclusiveSize":4}
+    ]}]'''
   [cases.bool_empty]
     skip = true # https://github.com/facebookexperimental/object-introspection/issues/14
     param_types = ["const std::vector<bool>&"]
@@ -22,6 +28,7 @@ includes = ["vector"]
     param_types = ["const std::vector<std::vector<int>>&"]
     setup = "return {};"
     expect_json = '[{"staticSize":24, "dynamicSize":0, "length":0, "capacity":0, "elementStaticSize":24}]'
+    expect_json_v2 = '[{"staticSize":24, "exclusiveSize":24, "length":0, "capacity":0, "members":[]}]'
   [cases.vector_int_some]
     param_types = ["const std::vector<std::vector<int>>&"]
     setup = "return {{{1,2,3},{4},{5,6}}};"
@@ -37,6 +44,11 @@ includes = ["vector"]
         {"staticSize":24, "dynamicSize":4, "exclusiveSize":28, "length":1, "capacity":1, "elementStaticSize":4},
         {"staticSize":24, "dynamicSize":8, "exclusiveSize":32, "length":2, "capacity":2, "elementStaticSize":4}
       ]}]'''
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "length":3, "capacity": 3, "members":[
+      {"staticSize":24, "exclusiveSize":24, "length":3, "capacity": 3, "members":[]},
+      {"staticSize":24, "exclusiveSize":24, "length":1, "capacity": 1, "members":[]},
+      {"staticSize":24, "exclusiveSize":24, "length":2, "capacity": 2, "members":[]}
+    ]}]'''
   [cases.reserve]
     param_types = ["const std::vector<int>&"]
     setup = '''
@@ -45,3 +57,8 @@ includes = ["vector"]
       return ret;
     '''
     expect_json = '[{"staticSize":24, "dynamicSize":40, "exclusiveSize":64, "length":3, "capacity":10, "elementStaticSize":4}]'
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":52, "length":3, "capacity":10, "members":[
+      {"staticSize":4, "exclusiveSize":4},
+      {"staticSize":4, "exclusiveSize":4},
+      {"staticSize":4, "exclusiveSize":4}
+    ]}]'''

--- a/test/integration/std_vector_del_allocator.toml
+++ b/test/integration/std_vector_del_allocator.toml
@@ -27,6 +27,7 @@ includes = ["vector"]
 
 [cases]
   [cases.a]
+    oil_skip = "oil gets the exclusive size of vector subfields wrong" # https://github.com/facebookexperimental/object-introspection/issues/301
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;
@@ -57,3 +58,22 @@ includes = ["vector"]
               ]}
           ]}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":48,
+      "exclusiveSize":0,
+      "members":[
+        {"name":"v1", "staticSize":24, "exclusiveSize":24, "length":1, "capacity":1, "members":[
+          {"name":"[]", "staticSize":4, "exclusiveSize":0, "members":[
+            {"name":"a", "staticSize":4, "exclusiveSize":4, "members":[]}
+          ]}
+        ]},
+        {"name":"v2", "staticSize":24, "exclusiveSize":24, "length":2, "capacity":2, "members":[
+          {"name":"[]", "staticSize":4, "exclusiveSize":0, "members":[
+            {"name":"b", "staticSize":4, "exclusiveSize":4, "members":[]}
+          ]},
+          {"name":"[]", "staticSize":4, "exclusiveSize":0, "members":[
+            {"name":"b", "staticSize":4, "exclusiveSize":4, "members":[]}
+          ]}
+        ]}
+      ]
+      }]'''

--- a/test/integration/templates.toml
+++ b/test/integration/templates.toml
@@ -24,6 +24,7 @@ definitions = '''
 
 [cases]
   [cases.int]
+    oil_skip = "primitives are named differently in treebuilderv2" # https://github.com/facebookexperimental/object-introspection/issues/286
     param_types = ["const TemplatedClass1<int>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -48,7 +49,19 @@ definitions = '''
         "capacity":0,
         "elementStaticSize":4
     }]}]'''
+    expect_json_v2 = '''[{
+      "typeName":"TemplatedClass1<std::vector<int, std::allocator<int> > >",
+      "staticSize":24,
+      "exclusiveSize":0,
+      "members":[{
+        "typeName":"std::vector<int32_t, std::allocator<int32_t>>",
+        "staticSize":24,
+        "exclusiveSize":24,
+        "length":0,
+        "capacity":0
+    }]}]'''
   [cases.two]
+    oil_skip = "OIL returns better primitive names"
     param_types = ["const TemplatedClass2<Foo, int>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -72,4 +85,14 @@ definitions = '''
         "length":3,
         "capacity":3,
         "elementStaticSize":4
+    }]}]'''
+    expect_json_v2 = '''[{
+      "typeName":"TemplatedClassVal<3>",
+      "staticSize":12,
+      "exclusiveSize":0,
+      "members":[{
+        "staticSize":12,
+        "exclusiveSize":0,
+        "length":3,
+        "capacity":3
     }]}]'''

--- a/test/integration/thrift_isset.toml
+++ b/test/integration/thrift_isset.toml
@@ -77,6 +77,7 @@ namespace cpp2 {
 
 [cases]
   [cases.unpacked]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructUnpacked&"]
     setup = '''
       cpp2::MyThriftStructUnpacked ret;
@@ -96,6 +97,7 @@ namespace cpp2 {
       ]}]'''
 
   [cases.packed]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructPacked&"]
     setup = '''
       cpp2::MyThriftStructPacked ret;
@@ -126,6 +128,7 @@ namespace cpp2 {
       ]}]'''
 
   [cases.packed_non_atomic]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructPackedNonAtomic&"]
     setup = '''
       cpp2::MyThriftStructPackedNonAtomic ret;
@@ -146,6 +149,7 @@ namespace cpp2 {
       ]}]'''
 
   [cases.out_of_order]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructOutOfOrder&"]
     setup = '''
       cpp2::MyThriftStructOutOfOrder ret;
@@ -164,6 +168,7 @@ namespace cpp2 {
       ]}]'''
 
   [cases.required]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructRequired&"]
     setup = '''
       cpp2::MyThriftStructRequired ret;
@@ -186,6 +191,7 @@ namespace cpp2 {
       ]}]'''
 
   [cases.box]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructBoxed&"]
     setup = '''
       cpp2::MyThriftStructBoxed ret;
@@ -207,6 +213,7 @@ namespace cpp2 {
       ]}]'''
 
   [cases.no_capture]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructBoxed&"]
     setup = '''
       cpp2::MyThriftStructBoxed ret;

--- a/test/integration/thrift_isset_missing.toml
+++ b/test/integration/thrift_isset_missing.toml
@@ -58,6 +58,7 @@ raw_definitions = '''
 '''
 [cases]
   [cases.present]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const FakeThriftWithData&"]
     setup = '''
       FakeThriftWithData ret;
@@ -78,6 +79,7 @@ raw_definitions = '''
         {"name":"__isset", "staticSize":3}
       ]}]'''
   [cases.missing]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const FakeThriftWithoutData&"]
     setup = '''
       FakeThriftWithoutData ret;
@@ -98,6 +100,7 @@ raw_definitions = '''
         {"name":"__isset", "staticSize":3}
       ]}]'''
   [cases.mixed]
+    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const Mixed&"]
     setup = '''
       Mixed ret;

--- a/test/integration/thrift_namespaces.toml
+++ b/test/integration/thrift_namespaces.toml
@@ -10,6 +10,7 @@ thrift_definitions = '''
 
 [cases]
   [cases.a]
+    oil_skip = 'enum type template arguments do not match' # https://github.com/facebookexperimental/object-introspection/issues/297
     param_types = ["const namespaceA::namespaceB::TTTTT&"]
     setup = '''
       namespaceA::namespaceB::TTTTT ret;

--- a/test/integration/thrift_unions.toml
+++ b/test/integration/thrift_unions.toml
@@ -33,6 +33,13 @@ namespace cpp2 {
         {"typeName":"storage_type", "name":"value_", "staticSize":4},
         {"typeName":"underlying_type_t<cpp2::StaticUnion::Type>", "name":"type_", "staticSize":4}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":8,
+      "exclusiveSize":0,
+      "members":[
+        {"typeNames":["storage_type"], "name":"value_", "staticSize":4, "exclusiveSize":4},
+        {"typeNames":["underlying_type_t<cpp2::StaticUnion::Type>", "type", "int32_t"], "name":"type_", "staticSize":4, "exclusiveSize":4}
+      ]}]'''
   [cases.dynamic_int]
     param_types = ["const cpp2::DynamicUnion&"]
     setup = '''
@@ -47,6 +54,13 @@ namespace cpp2 {
         {"typeName":"storage_type", "name":"value_", "staticSize":24},
         {"typeName":"underlying_type_t<cpp2::DynamicUnion::Type>", "name":"type_", "staticSize":4}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":32,
+      "exclusiveSize":4,
+      "members":[
+        {"typeNames":["storage_type"], "name":"value_", "staticSize":24, "exclusiveSize":24},
+        {"typeNames":["underlying_type_t<cpp2::DynamicUnion::Type>", "type", "int32_t"], "name":"type_", "staticSize":4, "exclusiveSize":4}
+      ]}]'''
   [cases.dynamic_vec]
     param_types = ["const cpp2::DynamicUnion&"]
     setup = '''
@@ -60,4 +74,11 @@ namespace cpp2 {
       "members":[
         {"typeName":"storage_type", "name":"value_", "staticSize":24},
         {"typeName":"underlying_type_t<cpp2::DynamicUnion::Type>", "name":"type_", "staticSize":4}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":32,
+      "exclusiveSize":4,
+      "members":[
+        {"typeNames":["storage_type"], "name":"value_", "staticSize":24, "exclusiveSize":24},
+        {"typeNames":["underlying_type_t<cpp2::DynamicUnion::Type>", "type", "int32_t"], "name":"type_", "staticSize":4, "exclusiveSize":4}
       ]}]'''

--- a/test/integration/typedefed_parent.toml
+++ b/test/integration/typedefed_parent.toml
@@ -27,6 +27,13 @@ definitions = '''
         {"name":"a", "staticSize":24, "dynamicSize":12, "length":3, "capacity":3},
         {"name":"b", "staticSize":24, "dynamicSize":20, "length":5, "capacity":5}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":48,
+      "exclusiveSize":0,
+      "members":[
+        {"name":"a", "staticSize":24, "exclusiveSize":24, "length":3, "capacity":3},
+        {"name":"b", "staticSize":24, "exclusiveSize":24, "length":5, "capacity":5}
+      ]}]'''
   [cases.multilevel_typedef_parent]
     param_types = ["const Bar_2&"]
     setup = '''
@@ -39,4 +46,11 @@ definitions = '''
       "members":[
         {"name":"a", "staticSize":24, "dynamicSize":12, "length":3, "capacity":3},
         {"name":"c", "staticSize":24, "dynamicSize":20, "length":5, "capacity":5}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":48,
+      "exclusiveSize":0,
+      "members":[
+        {"name":"a", "staticSize":24, "exclusiveSize":24, "length":3, "capacity":3},
+        {"name":"c", "staticSize":24, "exclusiveSize":24, "length":5, "capacity":5}
       ]}]'''

--- a/test/integration/typedefs.toml
+++ b/test/integration/typedefs.toml
@@ -4,9 +4,15 @@ definitions = '''
   using UsingUInt64 = uint64_t;
   using IntVector = std::vector<int>;
   using Anonymous = struct { int n; };
+
+  template <typename T>
+  struct Proxy {
+    T t;
+  };
 '''
 [cases]
   [cases.c_style]
+    oil_disable = "oil can't pick up top level typedefs"
     param_types = ["TdUInt64"]
     setup = "return {};"
     expect_json = '''[{
@@ -24,6 +30,7 @@ definitions = '''
         }
       ]}]'''
   [cases.using]
+    oil_disable = "oil can't pick up top level typedefs"
     param_types = ["UsingUInt64"]
     setup = "return {};"
     expect_json = '''[{
@@ -41,6 +48,7 @@ definitions = '''
         }
       ]}]'''
   [cases.container]
+    oil_disable = "oil can't pick up top level typedefs"
     param_types = ["const IntVector&"]
     setup = "return {};"
     expect_json = '''[{
@@ -61,7 +69,7 @@ definitions = '''
         }
       ]}]'''
   [cases.anonymous]
-    oil_skip = "TreeBuilder crashes" # https://github.com/facebookexperimental/object-introspection/issues/232
+    oil_disable = "oil can't pick up top level typedefs"
     param_types = ["const Anonymous&"]
     setup = "return {};"
     expect_json = '''[{
@@ -86,3 +94,4 @@ definitions = '''
             }
         ]}
       ]}]'''
+

--- a/test/integration/unions.toml
+++ b/test/integration/unions.toml
@@ -45,14 +45,17 @@ definitions = '''
     param_types = ["const MyUnion&"]
     setup = "return 123;"
     expect_json = '[{"staticSize":56, "dynamicSize":0, "exclusiveSize":56, "NOT":"members"}]'
+    expect_json_v2 = '[{"staticSize":56, "dynamicSize":0, "exclusiveSize":56, "members":[]}]'
   [cases.vector]
     param_types = ["const MyUnion&"]
     setup = "return std::vector{1,2,3};"
     expect_json = '[{"staticSize":56, "dynamicSize":0, "exclusiveSize":56, "NOT":"members"}]'
+    expect_json_v2 = '[{"staticSize":56, "dynamicSize":0, "exclusiveSize":56, "members":[]}]'
   [cases.unordered_map]
     param_types = ["const MyUnion&"]
     setup = 'return std::unordered_map<std::string, std::string>{{"a", "b"}, {"c","d"}};'
     expect_json = '[{"staticSize":56, "dynamicSize":0, "exclusiveSize":56, "NOT":"members"}]'
+    expect_json_v2 = '[{"staticSize":56, "dynamicSize":0, "exclusiveSize":56, "members":[]}]'
 
   [cases.alignment]
     # Wrap the union in a pair as a way of inferring its alignment
@@ -63,6 +66,11 @@ definitions = '''
         {"staticSize":1, "dynamicSize":0, "exclusiveSize":1},
         {"staticSize":56, "dynamicSize":0, "exclusiveSize":56, "NOT":"members"}
       ]}]'''
+    expect_json_v2 = '''[
+      {"staticSize":64, "dynamicSize":0, "exclusiveSize":7, "members":[
+        {"staticSize":1, "dynamicSize":0, "exclusiveSize":1},
+        {"staticSize":56, "dynamicSize":0, "exclusiveSize":56, "members":[]}
+      ]}]'''
 
   [cases.tagged_int]
     param_types = ["const TaggedUnion&"]
@@ -72,6 +80,11 @@ definitions = '''
         {"name":"storage", "staticSize":56, "dynamicSize":0, "exclusiveSize":56, "NOT":"members"},
         {"name":"tag", "staticSize":1, "dynamicSize":0, "exclusiveSize":1, "NOT":"members"}
       ]}]'''
+    expect_json_v2 = '''[
+      {"staticSize":64, "dynamicSize":0, "exclusiveSize":7, "members":[
+        {"name":"storage", "staticSize":56, "dynamicSize":0, "exclusiveSize":56, "members":[]},
+        {"name":"tag", "staticSize":1, "dynamicSize":0, "exclusiveSize":1, "members":[]}
+      ]}]'''
   [cases.tagged_vector]
     param_types = ["const TaggedUnion&"]
     setup = "return TaggedUnion{MyUnion{std::vector{1,2,3}}, 1};"
@@ -80,6 +93,11 @@ definitions = '''
         {"name":"storage", "staticSize":56, "dynamicSize":0, "exclusiveSize":56, "NOT":"members"},
         {"name":"tag", "staticSize":1, "dynamicSize":0, "exclusiveSize":1, "NOT":"members"}
       ]}]'''
+    expect_json_v2 = '''[
+      {"staticSize":64, "dynamicSize":0, "exclusiveSize":7, "members":[
+        {"name":"storage", "staticSize":56, "dynamicSize":0, "exclusiveSize":56, "members":[]},
+        {"name":"tag", "staticSize":1, "dynamicSize":0, "exclusiveSize":1, "members":[]}
+      ]}]'''
   [cases.tagged_unordered_map]
     param_types = ["const TaggedUnion&"]
     setup = 'return TaggedUnion{MyUnion{std::unordered_map<std::string, std::string>{{"a", "b"}, {"c","d"}}}, 2};'
@@ -87,4 +105,9 @@ definitions = '''
       {"staticSize":64, "dynamicSize":0, "exclusiveSize":7, "members":[
         {"name":"storage", "staticSize":56, "dynamicSize":0, "exclusiveSize":56, "NOT":"members"},
         {"name":"tag", "staticSize":1, "dynamicSize":0, "exclusiveSize":1, "NOT":"members"}
+      ]}]'''
+    expect_json_v2 = '''[
+      {"staticSize":64, "dynamicSize":0, "exclusiveSize":7, "members":[
+        {"name":"storage", "staticSize":56, "dynamicSize":0, "exclusiveSize":56, "members":[]},
+        {"name":"tag", "staticSize":1, "dynamicSize":0, "exclusiveSize":1, "members":[]}
       ]}]'''

--- a/test/test_add_children.cpp
+++ b/test/test_add_children.cpp
@@ -50,14 +50,16 @@ TEST_F(AddChildrenTest, SimpleStruct) {
 TEST_F(AddChildrenTest, InheritanceStatic) {
   // Should do nothing
   test("oid_test_case_inheritance_access_public", R"(
-[2] Pointer
+[4] Pointer
 [0]   Class: Public (size: 8)
         Parent (offset: 0)
 [1]       Class: Base (size: 4)
             Member: base_int (offset: 0)
-              Primitive: int32_t
+[3]           Typedef: int32_t
+[2]             Typedef: __int32_t
+                  Primitive: int32_t
         Member: public_int (offset: 4)
-          Primitive: int32_t
+          [3]
 )");
 }
 

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -144,14 +144,16 @@ TEST_F(DrgnParserTest, SimpleUnion) {
 
 TEST_F(DrgnParserTest, Inheritance) {
   test("oid_test_case_inheritance_access_public", R"(
-[2] Pointer
+[4] Pointer
 [0]   Class: Public (size: 8)
         Parent (offset: 0)
 [1]       Class: Base (size: 4)
             Member: base_int (offset: 0)
-              Primitive: int32_t
+[3]           Typedef: int32_t
+[2]             Typedef: __int32_t
+                  Primitive: int32_t
         Member: public_int (offset: 4)
-          Primitive: int32_t
+          [3]
 )");
 }
 

--- a/test/test_name_gen.cpp
+++ b/test/test_name_gen.cpp
@@ -446,7 +446,7 @@ TEST(NameGenTest, AnonymousTypes) {
   EXPECT_EQ(myenum.name(), "__oi_anon_1");
   EXPECT_EQ(mytypedef.name(), "__oi_anon_2");
 
-  EXPECT_EQ(myclass.inputName(), "");
-  EXPECT_EQ(myenum.inputName(), "");
+  EXPECT_EQ(myclass.inputName(), "__oi_anon_0");
+  EXPECT_EQ(myenum.inputName(), "__oi_anon_1");
   EXPECT_EQ(mytypedef.inputName(), "");
 }

--- a/types/array_type.toml
+++ b/types/array_type.toml
@@ -49,3 +49,34 @@ struct TypeHandler<DB, %1%<T0, N>> {
   }
 };
 """
+
+traversal_func = """
+    auto tail = returnArg.write(container.size());
+
+    for (auto & it: container) {
+        tail = tail.delegate([&it](auto ret) {
+            return TypeHandler<DB, T0>::getSizeType(it, ret);
+        });
+    }
+
+    return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+func = """
+static constexpr std::array<std::string_view, 1> names{"TODO"};
+static constexpr inst::Field childField{
+  sizeof(T0),
+  "[]",
+  names,
+  TypeHandler<DB, T0>::fields,
+  TypeHandler<DB, T0>::processors,
+};
+
+size_t size = std::get<ParsedData::List>(d.val).length;
+el.exclusive_size = N0 == 0 ? 1 : 0;
+el.container_stats.emplace(result::Element::ContainerStats{ .capacity = size, .length = size });
+for (size_t i = 0; i < size; i++)
+  ins.emplace(childField);
+"""

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -53,3 +53,34 @@ struct TypeHandler<DB, %1% <T0>> {
   }
 };
 """
+
+traversal_func = """
+    bool sso = ((uintptr_t)container.data() <
+                (uintptr_t)(&container + sizeof(std::__cxx11::basic_string<T0>))) &&
+               ((uintptr_t)container.data() >= (uintptr_t)&container);
+
+    return returnArg.write(container.capacity())
+        .write(sso)
+        .write(container.size());
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+uint64_t capacity = std::get<ParsedData::VarInt>(d.val).value;
+el.container_stats.emplace(result::Element::ContainerStats { .capacity = capacity });
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+bool sso = std::get<ParsedData::VarInt>(d.val).value;
+if (!sso)
+  el.exclusive_size += el.container_stats->capacity * sizeof(T0);
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.container_stats->length = std::get<ParsedData::VarInt>(d.val).value;
+"""

--- a/types/map_seq_type.toml
+++ b/types/map_seq_type.toml
@@ -66,3 +66,73 @@ struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4, T5>> {
   }
 };
 """
+
+traversal_func = '''
+    auto tail = returnArg.write((uintptr_t)&container)
+                    .write(container.capacity())
+                    .write(container.size());
+
+    for (const auto& kv : container) {
+      tail = tail.delegate([&kv](auto ret) {
+        auto next = ret.delegate([&kv](typename TypeHandler<DB, T0>::type ret) {
+          return OIInternal::getSizeType<DB>(kv.first, ret);
+        });
+        return OIInternal::getSizeType<DB>(kv.second, next);
+      });
+    }
+
+    return tail.finish();
+'''
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = '''
+el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get<ParsedData::VarInt>(d.val).value });
+'''
+
+[[codegen.processor]]
+type = '''types::st::List<DB, types::st::Pair<DB,
+  typename TypeHandler<DB, T0>::type,
+  typename TypeHandler<DB, T1>::type
+>>'''
+func = '''
+using element_type = std::pair<T0, T1>;
+
+static constexpr std::array<std::string_view, 1> names{"TODO"};
+
+static constexpr std::array<inst::Field, 2> entryFields{
+  inst::Field{
+    sizeof(T0),
+    "key",
+    names,
+    TypeHandler<DB, T0>::fields,
+    TypeHandler<DB, T0>::processors,
+  },
+  inst::Field{
+    sizeof(T1),
+    "value",
+    names,
+    TypeHandler<DB, T1>::fields,
+    TypeHandler<DB, T1>::processors,
+  },
+};
+static constexpr auto entryField = inst::Field {
+  sizeof(element_type),
+  sizeof(element_type) - sizeof(T0) - sizeof(T1),
+  "[]",
+  names,
+  entryFields,
+  std::array<inst::ProcessorInst, 0>{},
+};
+
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats->length = list.length;
+el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(element_type);
+
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(entryField);
+'''

--- a/types/pair_type.toml
+++ b/types/pair_type.toml
@@ -45,3 +45,36 @@ struct TypeHandler<DB, %1%<T0, T1>> {
   }
 };
 """
+
+traversal_func = """
+    return OIInternal::getSizeType<DB>(
+        container.second,
+        returnArg.delegate([&container](auto ret) {
+            return OIInternal::getSizeType<DB>(container.first, ret);
+        })
+    );
+"""
+
+[[codegen.processor]]
+type = "types::st::Pair<DB, typename TypeHandler<DB, T0>::type, typename TypeHandler<DB, T1>::type>"
+func = """
+static constexpr std::array<std::string_view, 1> names{"TODO"};
+static constexpr auto firstField = inst::Field{
+  sizeof(T0),
+  "first",
+  names,
+  TypeHandler<DB, T0>::fields,
+  TypeHandler<DB, T0>::processors,
+};
+static constexpr auto secondField = inst::Field{
+  sizeof(T1),
+  "second",
+  names,
+  TypeHandler<DB, T1>::fields,
+  TypeHandler<DB, T1>::processors,
+};
+
+el.exclusive_size = sizeof(std::pair<T0, T1>) - sizeof(T0) - sizeof(T1);
+ins.emplace(secondField);
+ins.emplace(firstField);
+"""

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -1,10 +1,10 @@
 [info]
 type_name = "std::vector"
 stub_template_params = [1]
-ctype = "SEQ_TYPE"
 header = "vector"
 
 # Old:
+ctype = "SEQ_TYPE"
 typeName = "std::vector<"
 ns = ["namespace std"]
 numTemplateParams = 1
@@ -62,4 +62,52 @@ struct TypeHandler<DB, %1%<T0, T1>> {
     return tail.finish();
   }
 };
+"""
+
+traversal_func = """
+auto tail = returnArg.write((uintptr_t)&container)
+                .write(container.capacity())
+                .write(container.size());
+
+// The double ampersand is needed otherwise this loop doesn't work with
+// vector<bool>
+for (auto&& it : container) {
+  tail = tail.delegate([&it](auto ret) {
+    return OIInternal::getSizeType<DB>(it, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get<ParsedData::VarInt>(d.val).value });
+"""
+
+[[codegen.processor]]
+type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+func = """
+static constexpr std::array<std::string_view, 1> names{"TODO"};
+static constexpr auto childField = inst::Field{
+  sizeof(T0),
+  "[]",
+  names,
+  TypeHandler<DB, T0>::fields,
+  TypeHandler<DB, T0>::processors,
+};
+
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats->length = list.length;
+el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(T0);
+
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(childField);
 """

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -1,7 +1,7 @@
 [info]
 type_name = "folly::sorted_vector_set"
-ctype = "SORTED_VEC_SET_TYPE"
 header = "folly/sorted_vector_types.h"
+ctype = "SORTED_VEC_SET_TYPE"
 stub_template_params = [1,2]
 underlying_container_index = 4
 

--- a/types/thrift_isset_type.toml
+++ b/types/thrift_isset_type.toml
@@ -19,3 +19,7 @@ func = """
 handler = """
 // DummyHandler %1%
 """
+
+traversal_func = """
+return returnArg;
+"""

--- a/types/weak_ptr_type.toml
+++ b/types/weak_ptr_type.toml
@@ -36,3 +36,6 @@ struct TypeHandler<DB, %1%<T0>> {
   }
 };
 """
+
+traversal_func = "return returnArg;"
+


### PR DESCRIPTION
## Summary

Updates Object Introspection as a Library (OIL) to produce the full output tree of an introspected type, similar to OID.

## Test plan

- CI
