### PR TITLE
Workaround for #289 missing symbol

### DIFF
--- a/types/try_type.toml
+++ b/types/try_type.toml
@@ -27,4 +27,7 @@ void getSizeType(const %1%<T> &container, size_t& returnArg)
         SAVE_DATA(0);
     }
 }
+
+/* Workaround for issue https://github.com/facebookexperimental/object-introspection/issues/289 */
+extern "C" void _ZNSt11logic_errorC2EOS_(void) {}
 """


### PR DESCRIPTION
## Summary
This is a dirty workaround for the issue raised in #289.

## Test plan
I was able to build and run the probe that was hitting this issue in our internal service.