### PR TITLE
remove dependency on <type_traits>

### DIFF
--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -150,7 +150,8 @@ template <typename T>
 struct DummyAllocator<T, 0> : DummyAllocatorBase<DummyAllocator, T, 0, 0> {};
 
 template <typename Type, size_t ExpectedSize, size_t ActualSize = 0>
-struct validate_size : std::true_type {
+struct validate_size {
+  static constexpr bool value = true;
   static_assert(ExpectedSize == ActualSize);
 };
 
@@ -159,6 +160,7 @@ struct validate_size<Type, ExpectedSize>
     : validate_size<Type, ExpectedSize, sizeof(Type)> {};
 
 template <size_t ExpectedOffset, size_t ActualOffset>
-struct validate_offset : std::true_type {
+struct validate_offset {
+  static constexpr bool value = true;
   static_assert(ExpectedOffset == ActualOffset);
 };


### PR DESCRIPTION
## Summary

Previously `OITraceCode.cpp` was using `std::true_type` without including `<type_traits>`. Rather than including it, implement the same effect ourselves without needing an include.

## Test plan

- CI
