### PR TITLE
std::set implementation for Container V2

### DIFF
--- a/test/integration/std_set_custom_comparator.toml
+++ b/test/integration/std_set_custom_comparator.toml
@@ -31,7 +31,6 @@ includes = ["set", "functional"]
 
 [cases]
   [cases.a]
-    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/306
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;
@@ -62,4 +61,13 @@ includes = ["set", "functional"]
         {"name":"m2", "staticSize":48, "dynamicSize":60, "length":5, "capacity":5, "elementStaticSize":12},
         {"name":"m3", "staticSize":48, "dynamicSize":84, "length":7, "capacity":7, "elementStaticSize":12},
         {"name":"m4", "staticSize":8040, "dynamicSize":108, "length":9, "capacity":9, "elementStaticSize":12}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":8184,
+      "exclusiveSize": 0,
+      "members":[
+        {"name":"m1", "staticSize":48, "exclusiveSize": 156, "length": 3, "capacity": 3},
+        {"name":"m2", "staticSize":48, "exclusiveSize": 228, "length": 5, "capacity": 5},
+        {"name":"m3", "staticSize":48, "exclusiveSize": 300, "length": 7, "capacity": 7},
+        {"name":"m4", "staticSize":8040, "exclusiveSize": 8364, "length": 9, "capacity": 9}
       ]}]'''

--- a/types/set_type.toml
+++ b/types/set_type.toml
@@ -63,3 +63,93 @@ struct TypeHandler<DB, %1% <T0, T1, T2>> {
   }
 };
 """
+
+traversal_func = """
+auto tail = returnArg.write((uintptr_t)&container)
+                .write(container.size());
+
+// The double ampersand is needed otherwise this loop doesn't work with
+// vector<bool>
+for (auto&& it : container) {
+  tail = tail.delegate([&it](auto ret) {
+    return OIInternal::getSizeType<DB>(it, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+func = """
+static constexpr std::array<std::string_view, 1> names{"TODO"};
+static constexpr auto childField = inst::Field{
+  sizeof(T0),
+  "[]",
+  names,
+  TypeHandler<DB, T0>::fields,
+  TypeHandler<DB, T0>::processors,
+};
+
+size_t element_size = 0; // Defined bellow, depending on the implementation
+
+#ifdef __GLIBCXX__
+/* We don't have access to the _Rb_tree_node struct, so we manually re-create it
+ * to get the effective size of a set entry. Is there a better way to do this?
+ *
+ * https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00716_source.html#l00216
+ * From the source of <bits/stl_tree.h>, an _Rb_tree_node has the following members:
+ */
+struct OI_Rb_tree_node {
+  using _Rb_tree_color = int;       // enum
+  using _Base_ptr = std::nullptr_t; // pointer
+
+  _Rb_tree_color      _M_color;  // from parent _Rb_tree_node_base
+  _Base_ptr           _M_parent; // from parent _Rb_tree_node_base
+  _Base_ptr           _M_left;   // from parent _Rb_tree_node_base
+  _Base_ptr           _M_right;  // from parent _Rb_tree_node_base
+  T0                  _M_value;
+};
+
+element_size = sizeof(OI_Rb_tree_node);
+#elif _LIBCPP_VERSION
+static_assert(false && "libc++ is currently not supported");
+
+/* We don't have access to the __tree_node struct, so we manually re-create it
+ * to get the effective size of a set entry. Is there a better way to do this?
+ *
+ * https://github.com/llvm/llvm-project/blob/1b10920164695a487669405223f8bbe93799430c/libcxx/include/__tree#L729-L781
+ * From the source of <__tree>, a __tree_node has the following members:
+ */
+struct OI__tree_node {
+  using pointer = std::nullptr_t;          // pointer
+  using __parent_pointer = std::nullptr_t; // pointer
+
+  pointer           __left_;     // from parent __tree_end_node
+  pointer           __right_;    // from parent __tree_node_base
+  __parent_pointer  __parent_;   // from parent __tree_node_base
+  bool              __is_black_; // from parent __tree_node_base
+  T0                __value_;
+};
+
+element_size = sizeof(OI__tree_node);
+#else
+static_assert(false && "No known element_size for sets. See types/set_type.toml");
+#endif
+
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats {
+  .length = list.length,
+  .capacity = list.length,
+});
+el.exclusive_size += el.container_stats->length * (element_size - sizeof(T0));
+
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(childField);
+"""


### PR DESCRIPTION
## Summary
Container V2 implementation for std::set. This closes #306.

## Test plan
```
$ build/test/integration/integration_test_runner --gtest_filter='OilIntegration.std_set_custom_comparator_a' --verbose --preserve
```
