### PR TITLE
oil: fix verbosity level in jit oil

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -1172,8 +1172,8 @@ void CodeGen::generate(
 
   if (VLOG_IS_ON(3)) {
     VLOG(3) << "Generated trace code:\n";
-    // VLOG truncates output, so use std::cout
-    std::cout << code;
+    // VLOG truncates output, so use std::cerr
+    std::cerr << code;
   }
 }
 

--- a/oi/OILibraryImpl.cpp
+++ b/oi/OILibraryImpl.cpp
@@ -104,6 +104,8 @@ void OILibraryImpl::processConfigFile() {
 }
 
 std::pair<void*, const exporters::inst::Inst&> OILibraryImpl::compileCode() {
+  google::SetVLOGLevel("*", opts_.debugLevel);
+
   auto symbols = std::make_shared<SymbolService>(getpid());
 
   auto* prog = symbols->getDrgnProgram();


### PR DESCRIPTION
## Summary

OIL JIT doesn't output verbose information from CodeGen V2. Add the same `SetVLOGLevel` line to `OILibraryImpl.cpp` as in `OID.cpp` to correctly set the output level.

## Test plan
- CI