### PR TITLE
Implement Container V2 for std::map

### DIFF
--- a/test/integration/std_map_custom_comparator.toml
+++ b/test/integration/std_map_custom_comparator.toml
@@ -22,7 +22,7 @@ definitions = '''
   };
 
   struct Foo {
-    std::map<int, int> m1;
+    std::map<int, double> m1;
     std::map<int, int, CustomComparator> m2;
     std::map<int, int, SmallSizedCustomComparator> m3;
     std::map<int, int, BigSizedCustomComparator> m4;
@@ -36,7 +36,6 @@ includes = ["map", "functional"]
 
 [cases]
   [cases.a]
-    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/314
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;
@@ -61,10 +60,28 @@ includes = ["map", "functional"]
     '''
     expect_json = '''[{
       "staticSize":8184,
-      "dynamicSize":768,
+      "dynamicSize":780,
       "members":[
-        {"name":"m1", "staticSize":48, "dynamicSize":96, "length":3, "capacity":3, "elementStaticSize":32},
+        {"name":"m1", "staticSize":48, "dynamicSize":108, "length":3, "capacity":3, "elementStaticSize":36},
         {"name":"m2", "staticSize":48, "dynamicSize":160, "length":5, "capacity":5, "elementStaticSize":32},
         {"name":"m3", "staticSize":48, "dynamicSize":224, "length":7, "capacity":7, "elementStaticSize":32},
         {"name":"m4", "staticSize":8040, "dynamicSize":288, "length":9, "capacity":9, "elementStaticSize":32}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":8184,
+      "exclusiveSize":0,
+      "members":[
+        {"name":"m1",
+         "staticSize":48,
+         "exclusiveSize":48,
+         "length":3,
+         "capacity":3,
+         "members": [
+          {"name":"[]", "staticSize":48, "exclusiveSize":36},
+          {},
+          {}
+         ]},
+        {"name":"m2", "staticSize":48, "exclusiveSize":48, "length":5, "capacity":5},
+        {"name":"m3", "staticSize":48, "exclusiveSize":48, "length":7, "capacity":7},
+        {"name":"m4", "staticSize":8040, "exclusiveSize":8040, "length":9, "capacity":9}
       ]}]'''

--- a/types/set_type.toml
+++ b/types/set_type.toml
@@ -88,17 +88,6 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 [[codegen.processor]]
 type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
 func = """
-static constexpr std::array<std::string_view, 1> names{"TODO"};
-static constexpr auto childField = inst::Field{
-  sizeof(T0),
-  "[]",
-  names,
-  TypeHandler<DB, T0>::fields,
-  TypeHandler<DB, T0>::processors,
-};
-
-size_t element_size = 0; // Defined bellow, depending on the implementation
-
 #ifdef __GLIBCXX__
 /* We don't have access to the _Rb_tree_node struct, so we manually re-create it
  * to get the effective size of a set entry. Is there a better way to do this?
@@ -117,7 +106,7 @@ struct OI_Rb_tree_node {
   T0                  _M_value;
 };
 
-element_size = sizeof(OI_Rb_tree_node);
+static constexpr size_t element_size = sizeof(OI_Rb_tree_node);
 #elif _LIBCPP_VERSION
 static_assert(false && "libc++ is currently not supported");
 
@@ -138,15 +127,24 @@ struct OI__tree_node {
   T0                __value_;
 };
 
-element_size = sizeof(OI__tree_node);
+static constexpr size_t element_size = sizeof(OI__tree_node);
 #else
 static_assert(false && "No known element_size for sets. See types/set_type.toml");
 #endif
 
+static constexpr std::array<std::string_view, 1> names{"TODO"};
+static constexpr auto childField = inst::Field{
+  sizeof(T0),
+  "[]",
+  names,
+  TypeHandler<DB, T0>::fields,
+  TypeHandler<DB, T0>::processors,
+};
+
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats.emplace(result::Element::ContainerStats {
-  .length = list.length,
   .capacity = list.length,
+  .length = list.length,
 });
 el.exclusive_size += el.container_stats->length * (element_size - sizeof(T0));
 

--- a/types/std_map_type.toml
+++ b/types/std_map_type.toml
@@ -68,3 +68,114 @@ struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
   }
 };
 """
+
+traversal_func = """
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.size());
+
+for (const auto &entry: container) {
+  tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
+    auto next =  ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
+      return OIInternal::getSizeType<DB>(key, ret);
+    });
+    return OIInternal::getSizeType<DB>(value, next);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
+
+[[codegen.processor]]
+type = """
+types::st::List<DB, types::st::Pair<DB,
+  typename TypeHandler<DB, T0>::type,
+  typename TypeHandler<DB, T1>::type>>
+"""
+func = """
+#ifdef __GLIBCXX__
+/* We don't have access to the _Rb_tree_node struct, so we manually re-create it
+ * to get the effective size of a map entry. Is there a better way to do this?
+ *
+ * https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00716_source.html#l00216
+ * From the source of <bits/stl_tree.h>, an _Rb_tree_node has the following members:
+ */
+struct OI_Rb_tree_node {
+  using _Rb_tree_color = int;       // enum
+  using _Base_ptr = std::nullptr_t; // pointer
+  using _value_type = std::pair<const T0, T1>; // from https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00692_source.html#l00105
+
+  _Rb_tree_color _M_color;  // from parent _Rb_tree_node_base
+  _Base_ptr      _M_parent; // from parent _Rb_tree_node_base
+  _Base_ptr      _M_left;   // from parent _Rb_tree_node_base
+  _Base_ptr      _M_right;  // from parent _Rb_tree_node_base
+  _value_type    _M_value;
+};
+
+static constexpr size_t element_size = sizeof(OI_Rb_tree_node);
+#elif _LIBCPP_VERSION
+static_assert(false && "libc++ is currently not supported");
+
+/* We don't have access to the __tree_node struct, so we manually re-create it
+ * to get the effective size of a map entry. Is there a better way to do this?
+ *
+ * https://github.com/llvm/llvm-project/blob/1b10920164695a487669405223f8bbe93799430c/libcxx/include/__tree#L729-L781
+ * From the source of <__tree>, a __tree_node has the following members:
+ */
+struct OI__tree_node {
+  using pointer = std::nullptr_t;          // pointer
+  using __parent_pointer = std::nullptr_t; // pointer
+  using _value_pair = std::pair<const T0, T1>; // from https://github.com/llvm/llvm-project/blob/main/libcxx/include/map#L1024
+
+  pointer          __left_;     // from parent __tree_end_node
+  pointer          __right_;    // from parent __tree_node_base
+  __parent_pointer __parent_;   // from parent __tree_node_base
+  bool             __is_black_; // from parent __tree_node_base
+  _value_type      __value_;
+};
+
+static constexpr size_t element_size = sizeof(OI__tree_node);
+#else
+static_assert(false && "No known element_size for sets. See types/std_map_type.toml");
+#endif
+
+static constexpr std::array<std::string_view, 1> names{"TODO"};
+
+static constexpr std::array<inst::Field, 2> element_fields{
+  inst::Field {
+    sizeof(T0),
+    "key",
+    names,
+    TypeHandler<DB, T0>::fields,
+    TypeHandler<DB, T0>::processors,
+  },
+  inst::Field {
+    sizeof(T1),
+    "value",
+    names,
+    TypeHandler<DB, T1>::fields,
+    TypeHandler<DB, T1>::processors,
+  },
+};
+static constexpr auto element = inst::Field {
+  element_size,
+  element_size - sizeof(T0) - sizeof(T1),
+  "[]",
+  names,
+  element_fields,
+  std::array<inst::ProcessorInst, 0>{},
+};
+
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(element);
+"""


### PR DESCRIPTION
## Summary
Implement Container V2 for std::map and update std::set container with `static constexpr element_size`.
Closes issue #π (#314).

## Test plan
```
build/test/integration/integration_test_runner --gtest_filter='OilIntegration.std_map_custom_comparator_a' --verbose```