### PR TITLE
Implement Container V2 for `unordered` containers

### DIFF
--- a/dev.oid.toml
+++ b/dev.oid.toml
@@ -12,6 +12,7 @@ containers = [
     "PWD/types/set_type.toml",
     "PWD/types/multi_set_type.toml",
     "PWD/types/unordered_set_type.toml",
+    "PWD/types/unordered_multiset_type.toml",
     "PWD/types/seq_type.toml",
     "PWD/types/list_type.toml",
     "PWD/types/cxx11_list_type.toml",

--- a/dev.oid.toml
+++ b/dev.oid.toml
@@ -20,6 +20,7 @@ containers = [
     "PWD/types/uniq_ptr_type.toml",
     "PWD/types/std_map_type.toml",
     "PWD/types/std_unordered_map_type.toml",
+    "PWD/types/std_unordered_multimap_type.toml",
     "PWD/types/pair_type.toml",
     "PWD/types/stack_container_adapter_type.toml",
     "PWD/types/queue_container_adapter_type.toml",

--- a/oi/ContainerTypeEnum.h
+++ b/oi/ContainerTypeEnum.h
@@ -22,6 +22,7 @@
   X(SET_TYPE)                    \
   X(MULTI_SET_TYPE)              \
   X(UNORDERED_SET_TYPE)          \
+  X(UNORDERED_MULTISET_TYPE)     \
   X(SEQ_TYPE)                    \
   X(LIST_TYPE)                   \
   X(STD_MAP_TYPE)                \

--- a/oi/ContainerTypeEnum.h
+++ b/oi/ContainerTypeEnum.h
@@ -26,6 +26,7 @@
   X(LIST_TYPE)                   \
   X(STD_MAP_TYPE)                \
   X(STD_UNORDERED_MAP_TYPE)      \
+  X(STD_UNORDERED_MULTIMAP_TYPE) \
   X(MAP_SEQ_TYPE)                \
   X(BY_MULTI_QRT_TYPE)           \
   X(F14_MAP)                     \

--- a/oi/TreeBuilder.cpp
+++ b/oi/TreeBuilder.cpp
@@ -822,6 +822,7 @@ void TreeBuilder::processContainer(const Variable& variable, Node& node) {
       containerStats.length = containerStats.capacity = next();
       break;
     case UNORDERED_SET_TYPE:
+    case UNORDERED_MULTISET_TYPE:
     case STD_UNORDERED_MULTIMAP_TYPE:
     case STD_UNORDERED_MAP_TYPE: {
       // Account for node overhead

--- a/oi/TreeBuilder.cpp
+++ b/oi/TreeBuilder.cpp
@@ -822,6 +822,7 @@ void TreeBuilder::processContainer(const Variable& variable, Node& node) {
       containerStats.length = containerStats.capacity = next();
       break;
     case UNORDERED_SET_TYPE:
+    case STD_UNORDERED_MULTIMAP_TYPE:
     case STD_UNORDERED_MAP_TYPE: {
       // Account for node overhead
       containerStats.elementStaticSize += next();

--- a/test/ci.oid.toml
+++ b/test/ci.oid.toml
@@ -16,6 +16,7 @@ containers = [
     "../types/uniq_ptr_type.toml",
     "../types/std_map_type.toml",
     "../types/std_unordered_map_type.toml",
+    "../types/std_unordered_multimap_type.toml",
     "../types/pair_type.toml",
     "../types/stack_container_adapter_type.toml",
     "../types/queue_container_adapter_type.toml",

--- a/test/ci.oid.toml
+++ b/test/ci.oid.toml
@@ -8,6 +8,7 @@ containers = [
     "../types/set_type.toml",
     "../types/multi_set_type.toml",
     "../types/unordered_set_type.toml",
+    "../types/unordered_multiset_type.toml",
     "../types/seq_type.toml",
     "../types/list_type.toml",
     "../types/cxx11_list_type.toml",

--- a/test/integration/std_unordered_map_custom_operator.toml
+++ b/test/integration/std_unordered_map_custom_operator.toml
@@ -33,7 +33,6 @@ includes = ["unordered_map"]
 
 [cases]
   [cases.a]
-    oil_skip = "std::unordered_map is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/303
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;
@@ -64,4 +63,12 @@ includes = ["unordered_map"]
         {"name":"m2", "staticSize":120, "dynamicSize":264, "length":5, "capacity":5, "elementStaticSize":32},
         {"name":"m3", "staticSize":120, "dynamicSize":328, "length":7, "capacity":7, "elementStaticSize":32},
         {"name":"m4", "staticSize":184, "dynamicSize":392, "length":9, "capacity":9, "elementStaticSize":32}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":480,
+      "members":[
+        {"name":"m1", "staticSize":56, "exclusiveSize":220, "length":3, "capacity":3},
+        {"name":"m2", "staticSize":120, "exclusiveSize":324, "length":5, "capacity":5},
+        {"name":"m3", "staticSize":120, "exclusiveSize":364, "length":7, "capacity":7},
+        {"name":"m4", "staticSize":184, "exclusiveSize":468, "length":9, "capacity":9}
       ]}]'''

--- a/test/integration/std_unordered_multimap_custom_operator.toml
+++ b/test/integration/std_unordered_multimap_custom_operator.toml
@@ -1,0 +1,74 @@
+definitions = '''
+
+	template <unsigned int N>
+	class CustomIntHasher
+	{
+		double d[N];
+		public:
+		size_t operator() (int const& key) const
+		{
+			return std::hash<int>{}(key);
+		}
+	};
+
+	template <unsigned int N>
+	class CustomEqualFnInt
+	{
+		double d[N];
+		public:
+		bool operator() (int const& t1, int const& t2) const
+		{
+			return t1 == t2;
+		}
+	};
+
+  struct Foo {
+    std::unordered_multimap<int, int> m1;
+    std::unordered_multimap<int, int, CustomIntHasher<8>> m2;
+    std::unordered_multimap<int, int, std::hash<int>, CustomEqualFnInt<8>> m3;
+    std::unordered_multimap<int, int, CustomIntHasher<8>, CustomEqualFnInt<8>> m4;
+  };
+'''
+includes = ["unordered_map"]
+
+[cases]
+  [cases.a]
+    param_types = ["const Foo&"]
+    setup = '''
+      Foo foo;
+
+      for (int i = 0; i < 3; i++) {
+        foo.m1.emplace(i, i * 10);
+      }
+
+      for (int i = 0; i < 5; i++) {
+        foo.m2.emplace(i, i * 10);
+      }
+
+      for (int i = 0; i < 7; i++) {
+        foo.m3.emplace(i, i * 10);
+      }
+
+      for (int i = 0; i < 9; i++) {
+        foo.m4.emplace(i, i * 10);
+      }
+
+      return {foo};
+    '''
+    expect_json = '''[{
+      "staticSize":480,
+      "dynamicSize":1184,
+      "members":[
+        {"name":"m1", "staticSize":56, "dynamicSize":200, "length":3, "capacity":3, "elementStaticSize":32},
+        {"name":"m2", "staticSize":120, "dynamicSize":264, "length":5, "capacity":5, "elementStaticSize":32},
+        {"name":"m3", "staticSize":120, "dynamicSize":328, "length":7, "capacity":7, "elementStaticSize":32},
+        {"name":"m4", "staticSize":184, "dynamicSize":392, "length":9, "capacity":9, "elementStaticSize":32}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":480,
+      "members":[
+        {"name":"m1", "staticSize":56, "exclusiveSize":220, "length":3, "capacity":3},
+        {"name":"m2", "staticSize":120, "exclusiveSize":324, "length":5, "capacity":5},
+        {"name":"m3", "staticSize":120, "exclusiveSize":364, "length":7, "capacity":7},
+        {"name":"m4", "staticSize":184, "exclusiveSize":468, "length":9, "capacity":9}
+      ]}]'''

--- a/test/integration/std_unordered_multiset_custom_operator.toml
+++ b/test/integration/std_unordered_multiset_custom_operator.toml
@@ -1,0 +1,74 @@
+definitions = '''
+
+	template <unsigned int N>
+	class CustomIntHasher
+	{
+		double d[N];
+		public:
+		size_t operator() (int const& key) const
+		{
+			return std::hash<int>{}(key);
+		}
+	};
+
+	template <unsigned int N>
+	class CustomEqualFnInt
+	{
+		double d[N];
+		public:
+		bool operator() (int const& t1, int const& t2) const
+		{
+			return t1 == t2;
+		}
+	};
+
+  struct Foo {
+    std::unordered_multiset<int> m1;
+    std::unordered_multiset<int, CustomIntHasher<8>> m2;
+    std::unordered_multiset<int, std::hash<int>, CustomEqualFnInt<8>> m3;
+    std::unordered_multiset<int, CustomIntHasher<8>, CustomEqualFnInt<8>> m4;
+  };
+'''
+includes = ["unordered_set"]
+
+[cases]
+  [cases.a]
+    param_types = ["const Foo&"]
+    setup = '''
+      Foo foo;
+
+      for (int i = 0; i < 3; i++) {
+        foo.m1.insert(i);
+      }
+
+      for (int i = 0; i < 5; i++) {
+        foo.m2.insert(i);
+      }
+
+      for (int i = 0; i < 7; i++) {
+        foo.m3.insert(i);
+      }
+
+      for (int i = 0; i < 9; i++) {
+        foo.m4.insert(i);
+      }
+
+      return {foo};
+    '''
+    expect_json = '''[{
+      "staticSize":480,
+      "dynamicSize":704,
+      "members":[
+        {"name":"m1", "staticSize":56, "dynamicSize":140, "length":3, "capacity":3, "elementStaticSize":12},
+        {"name":"m2", "staticSize":120, "dynamicSize":164, "length":5, "capacity":5, "elementStaticSize":12},
+        {"name":"m3", "staticSize":120, "dynamicSize":188, "length":7, "capacity":7, "elementStaticSize":12},
+        {"name":"m4", "staticSize":184, "dynamicSize":212, "length":9, "capacity":9, "elementStaticSize":12}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":480,
+      "members":[
+        {"name":"m1", "staticSize":56, "exclusiveSize":220, "length":3, "capacity":3},
+        {"name":"m2", "staticSize":120, "exclusiveSize":324, "length":5, "capacity":5},
+        {"name":"m3", "staticSize":120, "exclusiveSize":364, "length":7, "capacity":7},
+        {"name":"m4", "staticSize":184, "exclusiveSize":468, "length":9, "capacity":9}
+      ]}]'''

--- a/test/integration/std_unordered_set_custom_operator.toml
+++ b/test/integration/std_unordered_set_custom_operator.toml
@@ -33,7 +33,6 @@ includes = ["unordered_set"]
 
 [cases]
   [cases.a]
-    oil_skip = "std::unordered_set is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/302
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;
@@ -64,4 +63,12 @@ includes = ["unordered_set"]
         {"name":"m2", "staticSize":120, "dynamicSize":164, "length":5, "capacity":5, "elementStaticSize":12},
         {"name":"m3", "staticSize":120, "dynamicSize":188, "length":7, "capacity":7, "elementStaticSize":12},
         {"name":"m4", "staticSize":184, "dynamicSize":212, "length":9, "capacity":9, "elementStaticSize":12}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":480,
+      "members":[
+        {"name":"m1", "staticSize":56, "exclusiveSize":220, "length":3, "capacity":3},
+        {"name":"m2", "staticSize":120, "exclusiveSize":324, "length":5, "capacity":5},
+        {"name":"m3", "staticSize":120, "exclusiveSize":364, "length":7, "capacity":7},
+        {"name":"m4", "staticSize":184, "exclusiveSize":468, "length":9, "capacity":9}
       ]}]'''

--- a/types/std_unordered_map_type.toml
+++ b/types/std_unordered_map_type.toml
@@ -74,3 +74,91 @@ struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
   }
 };
 """
+
+traversal_func = """
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.bucket_count())
+  .write(container.size());
+
+for (const auto &it : container) {
+  tail = tail.delegate([&it](auto ret) {
+    return OIInternal::getSizeType<DB>(it, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+// Using the container's capacity to temporarily store the number of buckets
+// TODO: Is there another way to pass a value across processors?
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = std::get<ParsedData::VarInt>(d.val).value,
+});
+"""
+
+[[codegen.processor]]
+type = """
+types::st::List<DB, types::st::Pair<DB,
+  typename TypeHandler<DB, T0>::type,
+  typename TypeHandler<DB, T1>::type>>
+"""
+func = """
+#ifdef __GLIBCXX__
+/* Use libstdc++ implementation __details to compute the size of Nodes and Buckets.
+ *
+ * See the source of <bits/hashtable_policy.h>:
+ * https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00536_source.html
+ */
+using OI_value_type = std::pair<const T0, T1>;
+using OI_Hash_node =
+  std::__detail::_Hash_node<
+    OI_value_type,
+    std::__cache_default<OI_value_type, T2>::value>;
+
+using OI_bucket = std::__detail::_Hash_node_base;
+
+static constexpr size_t element_size = sizeof(OI_Hash_node);
+static constexpr size_t bucket_size = sizeof(OI_bucket);
+#else
+static_assert(false && "No known element_size for sets. See types/set_type.toml");
+#endif
+
+auto list = std::get<ParsedData::List>(d.val);
+// Reading the bucket count that was stored in `capacity` by the processor above.
+size_t bucket_count = el.container_stats->capacity;
+el.exclusive_size += bucket_count * bucket_size;
+el.exclusive_size += list.length * (element_size - sizeof(T0));
+
+// Overwrite the bucket count stored in `capacity` with the actual container's values.
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr std::array<inst::Field, 2> element_fields{
+  make_field<DB, T0>("key"),
+  make_field<DB, T1>("value"),
+};
+
+static constexpr auto element = inst::Field{
+  element_size,
+  element_size - sizeof(T0) - sizeof(T1),
+  "[]",
+  std::array<std::string_view, 0>{},
+  element_fields,
+  std::array<inst::ProcessorInst, 0>{},
+};
+
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(element);
+"""

--- a/types/std_unordered_multimap_type.toml
+++ b/types/std_unordered_multimap_type.toml
@@ -1,0 +1,164 @@
+[info]
+type_name = "std::unordered_multimap"
+stub_template_params = [2,3,4]
+ctype = "STD_UNORDERED_MULTIMAP_TYPE"
+header = "unordered_map"
+
+# Old:
+typeName = "std::unordered_multimap<"
+ns = ["namespace std"]
+numTemplateParams = 2
+replaceTemplateParamIndex = [2, 3]
+allocatorIndex = 4
+
+[codegen]
+decl = """
+template<class K, class T, class H, class KE, class A>
+void getSizeType(const %1%<K, T, H, KE, A> &container, size_t& returnArg);
+"""
+
+func = """
+template<class K, class T, class H, class KE, class A>
+void getSizeType(const %1%<K, T, H, KE, A> &container, size_t& returnArg)
+{
+    constexpr size_t nodeSize = sizeof(typename %1%<K, T, H, KE, A>::node_type);
+    size_t bucketCount = container.bucket_count();
+    size_t numElems = container.size();
+
+    SAVE_SIZE(sizeof(%1%<K, T, H, KE, A>) + (nodeSize * numElems) + (bucketCount * sizeof(uintptr_t)));
+
+    SAVE_DATA((uintptr_t)nodeSize);
+    SAVE_DATA((uintptr_t)bucketCount);
+    SAVE_DATA((uintptr_t)numElems);
+
+    for (auto const& it : container)
+    {
+    getSizeType(it.first, returnArg);
+    getSizeType(it.second, returnArg);
+    }
+}
+"""
+
+handler = """
+template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
+struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
+  using type = types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::Pair<DB,
+        types::st::VarInt<DB>,
+        types::st::List<DB, types::st::Pair<DB,
+          typename TypeHandler<DB, T0>::type,
+          typename TypeHandler<DB, T1>::type
+    >>>>;
+
+  static types::st::Unit<DB> getSizeType(
+      const %1%<T0, T1, T2, T3, T4>& container,
+      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
+    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3, T4>::node_type);
+
+    auto tail = returnArg.write(nodeSize)
+                    .write(container.bucket_count())
+                    .write(container.size());
+
+    // The double ampersand is needed otherwise this loop doesn't work with
+    // vector<bool>
+    for (const auto& it : container) {
+      tail = tail.delegate([&it](auto ret) {
+        return OIInternal::getSizeType<DB>(it.second, ret.delegate([&it](auto ret) {
+            return OIInternal::getSizeType<DB>(it.first, ret);
+        }));
+      });
+    }
+
+    return tail.finish();
+  }
+};
+"""
+
+traversal_func = """
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.bucket_count())
+  .write(container.size());
+
+for (const auto &it : container) {
+  tail = tail.delegate([&it](auto ret) {
+    return OIInternal::getSizeType<DB>(it, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+// Using the container's capacity to temporarily store the number of buckets
+// TODO: Is there another way to pass a value across processors?
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = std::get<ParsedData::VarInt>(d.val).value,
+});
+"""
+
+[[codegen.processor]]
+type = """
+types::st::List<DB, types::st::Pair<DB,
+  typename TypeHandler<DB, T0>::type,
+  typename TypeHandler<DB, T1>::type>>
+"""
+func = """
+#ifdef __GLIBCXX__
+/* Use libstdc++ implementation __details to compute the size of Nodes and Buckets.
+ *
+ * See the source of <bits/hashtable_policy.h>:
+ * https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00536_source.html
+ */
+using OI_value_type = std::pair<const T0, T1>;
+using OI_Hash_node =
+  std::__detail::_Hash_node<
+    OI_value_type,
+    std::__cache_default<OI_value_type, T2>::value>;
+
+using OI_bucket = std::__detail::_Hash_node_base;
+
+static constexpr size_t element_size = sizeof(OI_Hash_node);
+static constexpr size_t bucket_size = sizeof(OI_bucket);
+#else
+static_assert(false && "No known element_size for sets. See types/set_type.toml");
+#endif
+
+auto list = std::get<ParsedData::List>(d.val);
+// Reading the bucket count that was stored in `capacity` by the processor above.
+size_t bucket_count = el.container_stats->capacity;
+el.exclusive_size += bucket_count * bucket_size;
+el.exclusive_size += list.length * (element_size - sizeof(T0));
+
+// Overwrite the bucket count stored in `capacity` with the actual container's values.
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr std::array<inst::Field, 2> element_fields{
+  make_field<DB, T0>("key"),
+  make_field<DB, T1>("value"),
+};
+
+static constexpr auto element = inst::Field{
+  element_size,
+  element_size - sizeof(T0) - sizeof(T1),
+  "[]",
+  std::array<std::string_view, 0>{},
+  element_fields,
+  std::array<inst::ProcessorInst, 0>{},
+};
+
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(element);
+"""

--- a/types/unordered_multiset_type.toml
+++ b/types/unordered_multiset_type.toml
@@ -1,0 +1,137 @@
+[info]
+type_name = "std::unordered_multiset"
+stub_template_params = [1,2,3]
+ctype = "UNORDERED_MULTISET_TYPE"
+header = "unordered_set"
+
+# Old:
+typeName = "std::unordered_multiset<"
+ns = ["namespace std"]
+numTemplateParams = 1
+replaceTemplateParamIndex = [1, 2]
+allocatorIndex = 3
+
+[codegen]
+decl = """
+template <typename Key, typename Hasher, typename KeyEqual, typename Alloc>
+void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& returnArg);
+"""
+
+func = """
+template <typename Key, typename Hasher, typename KeyEqual, typename Alloc>
+void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& returnArg)
+{
+    constexpr size_t nodeSize = sizeof(typename %1%<Key, Hasher, KeyEqual, Alloc>::node_type);
+    size_t bucketCount = container.bucket_count();
+    size_t numElems = container.size();
+    SAVE_SIZE(sizeof(%1%<Key, Hasher, KeyEqual, Alloc>) + (numElems * nodeSize) + (bucketCount * sizeof(uintptr_t)));
+
+    SAVE_DATA((uintptr_t)nodeSize);
+    SAVE_DATA((uintptr_t)bucketCount);
+    SAVE_DATA((uintptr_t)numElems);
+
+    // The double ampersand is needed otherwise this loop doesn't work with vector<bool>
+    for (auto&& it: container) {
+    getSizeType(it, returnArg);
+    }
+}
+"""
+
+handler = """
+template <typename DB, typename T0, typename T1, typename T2, typename T3>
+struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
+  using type = types::st::Pair<
+      DB, types::st::VarInt<DB>,
+      types::st::Pair<
+          DB, types::st::VarInt<DB>,
+          types::st::List<DB, typename TypeHandler<DB, T0>::type>>>;
+
+  static types::st::Unit<DB> getSizeType(
+      const %1%<T0, T1, T2, T3>& container,
+      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
+    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3>::node_type);
+
+    auto tail = returnArg.write(nodeSize)
+                    .write(container.bucket_count())
+                    .write(container.size());
+
+    // The double ampersand is needed otherwise this loop doesn't work with
+    // vector<bool>
+    for (auto&& it : container) {
+      tail = tail.delegate([&it](auto ret) {
+        return OIInternal::getSizeType<DB>(it, ret);
+      });
+    }
+
+    return tail.finish();
+  }
+};
+"""
+
+traversal_func = """
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.bucket_count())
+  .write(container.size());
+
+for (const auto &it : container) {
+  tail = tail.delegate([&it](auto ret) {
+    return OIInternal::getSizeType<DB>(it, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+// Using the container's capacity to temporarily store the number of buckets
+// TODO: Is there another way to pass a value across processors?
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = std::get<ParsedData::VarInt>(d.val).value,
+});
+"""
+
+[[codegen.processor]]
+type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+func = """
+#ifdef __GLIBCXX__
+/* Use libstdc++ implementation __details to compute the size of Nodes and Buckets.
+ *
+ * See the source of <bits/hashtable_policy.h>:
+ * https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00536_source.html
+ */
+using OI_Hash_node =
+  std::__detail::_Hash_node<T0, std::__cache_default<T0, T1>::value>;
+
+using OI_bucket = std::__detail::_Hash_node_base;
+
+static constexpr size_t element_size = sizeof(OI_Hash_node);
+static constexpr size_t bucket_size = sizeof(OI_bucket);
+#else
+static_assert(false && "No known element_size for sets. See types/set_type.toml");
+#endif
+
+auto list = std::get<ParsedData::List>(d.val);
+// Reading the bucket count that was stored in `capacity` by the processor above.
+size_t bucket_count = el.container_stats->capacity;
+el.exclusive_size += bucket_count * bucket_size;
+el.exclusive_size += list.length * (element_size - sizeof(T0));
+
+// Overwrite the bucket count stored in `capacity` with the actual container's values.
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr auto childField = make_field<DB, T0>("[]");
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(childField);
+"""

--- a/types/unordered_set_type.toml
+++ b/types/unordered_set_type.toml
@@ -67,3 +67,71 @@ struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
   }
 };
 """
+
+traversal_func = """
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.bucket_count())
+  .write(container.size());
+
+for (const auto &it : container) {
+  tail = tail.delegate([&it](auto ret) {
+    return OIInternal::getSizeType<DB>(it, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+// Using the container's capacity to temporarily store the number of buckets
+// TODO: Is there another way to pass a value across processors?
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = std::get<ParsedData::VarInt>(d.val).value,
+});
+"""
+
+[[codegen.processor]]
+type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+func = """
+#ifdef __GLIBCXX__
+/* Use libstdc++ implementation __details to compute the size of Nodes and Buckets.
+ *
+ * See the source of <bits/hashtable_policy.h>:
+ * https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00536_source.html
+ */
+using OI_Hash_node =
+  std::__detail::_Hash_node<T0, std::__cache_default<T0, T1>::value>;
+
+using OI_bucket = std::__detail::_Hash_node_base;
+
+static constexpr size_t element_size = sizeof(OI_Hash_node);
+static constexpr size_t bucket_size = sizeof(OI_bucket);
+#else
+static_assert(false && "No known element_size for sets. See types/set_type.toml");
+#endif
+
+auto list = std::get<ParsedData::List>(d.val);
+// Reading the bucket count that was stored in `capacity` by the processor above.
+size_t bucket_count = el.container_stats->capacity;
+el.exclusive_size += bucket_count * bucket_size;
+el.exclusive_size += list.length * (element_size - sizeof(T0));
+
+// Overwrite the bucket count stored in `capacity` with the actual container's values.
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr auto childField = make_field<DB, T0>("[]");
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(childField);
+"""


### PR DESCRIPTION
## Summary
Implement Container V2 for each `unordered` containers.
The size overhead was measured using: https://godbolt.org/z/b4qrr3YdM
Closes #302 and #303.

## Test plan
```
$ build/test/integration/integration_test_runner --gtest_filter='OilIntegration.std_unordered_set_custom_operator_a' --verbose
```
