### PR TITLE
tbv2: add make_field helper

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -985,6 +985,22 @@ void addStandardTypeHandlers(TypeGraph& typeGraph,
     }
 )";
 
+  if (features[Feature::TreeBuilderV2]) {
+    code += R"(
+template <typename DB, typename T>
+constexpr inst::Field make_field(std::string_view name) {
+  return inst::Field{
+    sizeof(T),
+    sizeof(T), // TODO: this is incorrect for excl size
+    name,
+    NameProvider<T>::names,
+    TypeHandler<DB, T>::fields,
+    TypeHandler<DB, T>::processors,
+  };
+}
+)";
+  }
+
   // TODO: bit of a hack - making ContainerInfo a node in the type graph and
   // traversing for it would remove the need for this set altogether.
   std::unordered_set<const ContainerInfo*> used{};

--- a/types/array_type.toml
+++ b/types/array_type.toml
@@ -65,13 +65,7 @@ traversal_func = """
 [[codegen.processor]]
 type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
 func = """
-static constexpr inst::Field childField{
-  sizeof(T0),
-  "[]",
-  NameProvider<T0>::names,
-  TypeHandler<DB, T0>::fields,
-  TypeHandler<DB, T0>::processors,
-};
+static constexpr auto childField = make_field<DB, T0>("[]");
 
 size_t size = std::get<ParsedData::List>(d.val).length;
 el.exclusive_size = N0 == 0 ? 1 : 0;

--- a/types/map_seq_type.toml
+++ b/types/map_seq_type.toml
@@ -103,23 +103,10 @@ func = '''
 using element_type = std::pair<T0, T1>;
 
 static constexpr std::array<inst::Field, 2> entryFields{
-  inst::Field{
-    sizeof(T0),
-    "key",
-    NameProvider<T0>::names,
-    TypeHandler<DB, T0>::fields,
-    TypeHandler<DB, T0>::processors,
-  },
-  inst::Field{
-    sizeof(T1),
-    "value",
-    NameProvider<T1>::names,
-    TypeHandler<DB, T1>::fields,
-    TypeHandler<DB, T1>::processors,
-  },
+  make_field<DB, T0>("key"),
+  make_field<DB, T1>("value"),
 };
-
-static constexpr auto entryField = inst::Field {
+static constexpr auto entry = inst::Field {
   sizeof(element_type),
   sizeof(element_type) - sizeof(T0) - sizeof(T1),
   "[]",
@@ -133,5 +120,5 @@ el.container_stats->length = list.length;
 el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(element_type);
 
 for (size_t i = 0; i < list.length; i++)
-  ins.emplace(entryField);
+  ins.emplace(entry);
 '''

--- a/types/multi_map_type.toml
+++ b/types/multi_map_type.toml
@@ -135,28 +135,16 @@ static constexpr size_t element_size = sizeof(OI__tree_node);
 static_assert(false && "No known element_size for sets. See types/multi_map_type.toml");
 #endif
 
-static constexpr std::array<inst::Field, 2> element_fields{
-  inst::Field {
-    sizeof(T0),
-    "key",
-    NameProvider<T0>::names,
-    TypeHandler<DB, T0>::fields,
-    TypeHandler<DB, T0>::processors,
-  },
-  inst::Field {
-    sizeof(T1),
-    "value",
-    NameProvider<T1>::names,
-    TypeHandler<DB, T1>::fields,
-    TypeHandler<DB, T1>::processors,
-  },
+static constexpr std::array<inst::Field, 2> elementFields{
+  make_field<DB, T0>("key"),
+  make_field<DB, T1>("value"),
 };
 static constexpr auto element = inst::Field {
   element_size,
   element_size - sizeof(T0) - sizeof(T1),
   "[]",
   std::array<std::string_view, 0>{},
-  element_fields,
+  elementFields,
   std::array<inst::ProcessorInst, 0>{},
 };
 

--- a/types/multi_set_type.toml
+++ b/types/multi_set_type.toml
@@ -128,13 +128,7 @@ static constexpr size_t element_size = sizeof(OI__tree_node);
 static_assert(false && "No known element_size for multisets. See types/multi_set_type.toml");
 #endif
 
-static constexpr auto childField = inst::Field{
-  sizeof(T0),
-  "[]",
-  NameProvider<T0>::names,
-  TypeHandler<DB, T0>::fields,
-  TypeHandler<DB, T0>::processors,
-};
+static constexpr auto childField = make_field<DB, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats.emplace(result::Element::ContainerStats {

--- a/types/pair_type.toml
+++ b/types/pair_type.toml
@@ -58,20 +58,8 @@ traversal_func = """
 [[codegen.processor]]
 type = "types::st::Pair<DB, typename TypeHandler<DB, T0>::type, typename TypeHandler<DB, T1>::type>"
 func = """
-static constexpr auto firstField = inst::Field{
-  sizeof(T0),
-  "first",
-  NameProvider<T0>::names,
-  TypeHandler<DB, T0>::fields,
-  TypeHandler<DB, T0>::processors,
-};
-static constexpr auto secondField = inst::Field{
-  sizeof(T1),
-  "second",
-  NameProvider<T1>::names,
-  TypeHandler<DB, T1>::fields,
-  TypeHandler<DB, T1>::processors,
-};
+static constexpr auto firstField = make_field<DB, T0>("first");
+static constexpr auto secondField = make_field<DB, T1>("second");
 
 el.exclusive_size = sizeof(std::pair<T0, T1>) - sizeof(T0) - sizeof(T1);
 ins.emplace(secondField);

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -95,13 +95,7 @@ el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get
 [[codegen.processor]]
 type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
 func = """
-static constexpr auto childField = inst::Field{
-  sizeof(T0),
-  "[]",
-  NameProvider<T0>::names,
-  TypeHandler<DB, T0>::fields,
-  TypeHandler<DB, T0>::processors,
-};
+static constexpr auto childField = make_field<DB, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats->length = list.length;

--- a/types/set_type.toml
+++ b/types/set_type.toml
@@ -132,13 +132,7 @@ static constexpr size_t element_size = sizeof(OI__tree_node);
 static_assert(false && "No known element_size for sets. See types/set_type.toml");
 #endif
 
-static constexpr auto childField = inst::Field{
-  sizeof(T0),
-  "[]",
-  NameProvider<T0>::names,
-  TypeHandler<DB, T0>::fields,
-  TypeHandler<DB, T0>::processors,
-};
+static constexpr auto childField = make_field<DB, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats.emplace(result::Element::ContainerStats {

--- a/types/std_map_type.toml
+++ b/types/std_map_type.toml
@@ -144,22 +144,10 @@ static_assert(false && "No known element_size for sets. See types/std_map_type.t
 #endif
 
 static constexpr std::array<inst::Field, 2> element_fields{
-  inst::Field {
-    sizeof(T0),
-    "key",
-    NameProvider<T0>::names,
-    TypeHandler<DB, T0>::fields,
-    TypeHandler<DB, T0>::processors,
-  },
-  inst::Field {
-    sizeof(T1),
-    "value",
-    NameProvider<T1>::names,
-    TypeHandler<DB, T1>::fields,
-    TypeHandler<DB, T1>::processors,
-  },
+  make_field<DB, T0>("key"),
+  make_field<DB, T1>("value"),
 };
-static constexpr auto element = inst::Field {
+static constexpr inst::Field element{
   element_size,
   element_size - sizeof(T0) - sizeof(T1),
   "[]",


### PR DESCRIPTION
## Summary

Creating `inst::Field`s is mostly repetitive. Deduplicate it in containers with a `make_field` helper. Once exclusive size is fully sorted this can be done for struct members too.

## Test plan
- CI
