### PR TITLE
Tweak social media previews for Oid website

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,1 @@
+.docusaurus

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -48,8 +48,8 @@ const config = {
   headTags: [
     // Favicons declarations
     { tagName: 'link', attributes: { rel: 'apple-touch-icon', sizes: '180x180', href: '/img/apple-touch-icon.png' } },
-    { tagName: 'link', attributes: { rel: 'icon', sizes: '32x32', href: '/img/favicon-32x32.png' } },
-    { tagName: 'link', attributes: { rel: 'icon', sizes: '16x16', href: '/img/favicon-16x16.png' } },
+    { tagName: 'link', attributes: { rel: 'icon', sizes: '32x32', href: 'img/favicon-32x32.png' } },
+    { tagName: 'link', attributes: { rel: 'icon', sizes: '16x16', href: 'img/favicon-16x16.png' } },
     { tagName: 'link', attributes: { rel: 'manifest', href: '/site.webmanifest' } },
     { tagName: 'link', attributes: { rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#5bbad5' } },
     { tagName: 'meta', attributes: { name: 'apple-mobile-web-app-title', content: 'Object Introspection' } },

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -65,8 +65,8 @@ export default function Home() {
   const {siteConfig = {}} = context;
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      title={`${siteConfig.title}`}
+      description="Object Introspection provides byte accurate memory occupancy information for arbitrarily complex C++ object hierarchies including all static and  dynamic memory allocations in an object.">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">{siteConfig.title}</h1>


### PR DESCRIPTION
Hello, hope everyone is doing well! :)

## Summary
I noticed that the website has some default text in the social media preview. I went ahead and tweaked it to not be the default anymore.

In addition, it seems like the favicon dosen't seem to work: https://realfavicongenerator.net/favicon_checker?protocol=https&site=facebookexperimental.github.io%2Fobject-introspection%2F

I attempted to fix this by making the link relative.

## Test plan
Serve website via docusaurus instructions and verify title/meta tag is updated. Also verify that favicon shows up. 

To "test" favicon in production, I removed the leading `/` from the favicon on the live site using inspect element, after which I could see the favicon again. I'll try to follow up to make sure things are working properly on the site for this one. 
