### PR TITLE
Implement Container V2 for F14Set

### DIFF
--- a/dev.oid.toml
+++ b/dev.oid.toml
@@ -39,6 +39,7 @@ containers = [
     "PWD/types/f14_vector_map.toml",
     "PWD/types/f14_fast_set.toml",
     "PWD/types/f14_node_set.toml",
+    "PWD/types/f14_value_set.toml",
     "PWD/types/f14_vector_set.toml",
     "PWD/types/sorted_vec_set_type.toml",
     "PWD/types/map_seq_type.toml",

--- a/dev.oid.toml
+++ b/dev.oid.toml
@@ -36,6 +36,7 @@ containers = [
     "PWD/types/small_vec_type.toml",
     "PWD/types/f14_fast_map.toml",
     "PWD/types/f14_node_map.toml",
+    "PWD/types/f14_value_map.toml",
     "PWD/types/f14_vector_map.toml",
     "PWD/types/f14_fast_set.toml",
     "PWD/types/f14_node_set.toml",

--- a/test/ci.oid.toml
+++ b/test/ci.oid.toml
@@ -35,6 +35,7 @@ containers = [
     "../types/f14_vector_map.toml",
     "../types/f14_fast_set.toml",
     "../types/f14_node_set.toml",
+    "../types/f14_value_set.toml",
     "../types/f14_vector_set.toml",
     "../types/sorted_vec_set_type.toml",
     "../types/map_seq_type.toml",

--- a/test/ci.oid.toml
+++ b/test/ci.oid.toml
@@ -32,6 +32,7 @@ containers = [
     "../types/small_vec_type.toml",
     "../types/f14_fast_map.toml",
     "../types/f14_node_map.toml",
+    "../types/f14_value_map.toml",
     "../types/f14_vector_map.toml",
     "../types/f14_fast_set.toml",
     "../types/f14_node_set.toml",

--- a/test/integration/folly_f14_fast_set.toml
+++ b/test/integration/folly_f14_fast_set.toml
@@ -1,0 +1,83 @@
+includes = ["folly/container/F14Set.h"]
+definitions = '''
+  struct Bar {
+    float a, b;
+  };
+
+  inline bool operator==(const Bar &lhs, const Bar &rhs) noexcept {
+    return lhs.a == rhs.a && lhs.b == rhs.b;
+  }
+
+  struct BarHasher {
+    inline size_t operator()(const Bar &bar) const {
+      return folly::hash::hash_combine(bar.a, bar.b);
+    }
+  };
+
+  struct Foo {
+    folly::F14FastSet<int> m1;
+    folly::F14FastSet<Bar, BarHasher> m2;
+    folly::F14FastSet<int> m3;
+    folly::F14FastSet<int> m4;
+  };
+'''
+
+[cases]
+  [cases.a]
+    param_types = ["const Foo&"]
+    setup = '''
+      Foo foo;
+
+      foo.m1.reserve(3);
+      for (int i = 0; i < 3; i++) {
+        foo.m1.emplace(i);
+      }
+
+      foo.m2.reserve(5);
+      for (int i = 0; i < 5; i++) {
+        foo.m2.emplace(Bar{(float)i, 0.0f});
+      }
+
+      foo.m3.reserve(7);
+      for (int i = 0; i < 7; i++) {
+        foo.m3.emplace(i);
+      }
+
+      foo.m4.reserve(9);
+      for (int i = 0; i < 9; i++) {
+        foo.m4.emplace(i);
+      }
+
+      return {foo};
+    '''
+    expect_json = '''[{
+      "staticSize":96,
+      "dynamicSize":208,
+      "members":[
+        {"name":"m1", "staticSize":24, "dynamicSize":32, "length":3, "capacity":3, "elementStaticSize":4},
+        {
+          "name":"m2",
+          "staticSize":24,
+          "dynamicSize":64,
+          "length":5,
+          "capacity":5,
+          "elementStaticSize":8,
+          "members":[
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]}
+        ]},
+        {"name":"m3", "staticSize":24, "dynamicSize":48, "length":7, "capacity":7, "elementStaticSize":4},
+        {"name":"m4", "staticSize":24, "dynamicSize":64, "length":9, "capacity":9, "elementStaticSize":4}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":96,
+      "exclusiveSize": 0,
+      "members":[
+        {"name":"m1", "staticSize":24, "exclusiveSize": 24, "length": 3, "capacity": 3},
+        {"name":"m2", "staticSize":24, "exclusiveSize": 24, "length": 5, "capacity": 5},
+        {"name":"m3", "staticSize":24, "exclusiveSize": 24, "length": 7, "capacity": 7},
+        {"name":"m4", "staticSize":24, "exclusiveSize": 24, "length": 9, "capacity": 9}
+      ]}]'''

--- a/test/integration/folly_f14_node_set.toml
+++ b/test/integration/folly_f14_node_set.toml
@@ -1,0 +1,83 @@
+includes = ["folly/container/F14Set.h"]
+definitions = '''
+  struct Bar {
+    float a, b;
+  };
+
+  inline bool operator==(const Bar &lhs, const Bar &rhs) noexcept {
+    return lhs.a == rhs.a && lhs.b == rhs.b;
+  }
+
+  struct BarHasher {
+    inline size_t operator()(const Bar &bar) const {
+      return folly::hash::hash_combine(bar.a, bar.b);
+    }
+  };
+
+  struct Foo {
+    folly::F14NodeSet<int> m1;
+    folly::F14NodeSet<Bar, BarHasher> m2;
+    folly::F14NodeSet<int> m3;
+    folly::F14NodeSet<int> m4;
+  };
+'''
+
+[cases]
+  [cases.a]
+    param_types = ["const Foo&"]
+    setup = '''
+      Foo foo;
+
+      foo.m1.reserve(3);
+      for (int i = 0; i < 3; i++) {
+        foo.m1.emplace(i);
+      }
+
+      foo.m2.reserve(5);
+      for (int i = 0; i < 5; i++) {
+        foo.m2.emplace(Bar{(float)i, 0.0f});
+      }
+
+      foo.m3.reserve(7);
+      for (int i = 0; i < 7; i++) {
+        foo.m3.emplace(i);
+      }
+
+      foo.m4.reserve(9);
+      for (int i = 0; i < 9; i++) {
+        foo.m4.emplace(i);
+      }
+
+      return {foo};
+    '''
+    expect_json = '''[{
+      "staticSize":96,
+      "dynamicSize":404,
+      "members":[
+        {"name":"m1", "staticSize":24, "dynamicSize":60, "length":3, "capacity":3, "elementStaticSize":4},
+        {
+          "name":"m2",
+          "staticSize":24,
+          "dynamicSize":104,
+          "length":5,
+          "capacity":5,
+          "elementStaticSize":8,
+          "members":[
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]}
+        ]},
+        {"name":"m3", "staticSize":24, "dynamicSize":108, "length":7, "capacity":7, "elementStaticSize":4},
+        {"name":"m4", "staticSize":24, "dynamicSize":132, "length":9, "capacity":9, "elementStaticSize":4}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":96,
+      "exclusiveSize": 0,
+      "members":[
+        {"name":"m1", "staticSize":24, "exclusiveSize": 24, "length": 3, "capacity": 3},
+        {"name":"m2", "staticSize":24, "exclusiveSize": 24, "length": 5, "capacity": 5},
+        {"name":"m3", "staticSize":24, "exclusiveSize": 24, "length": 7, "capacity": 7},
+        {"name":"m4", "staticSize":24, "exclusiveSize": 24, "length": 9, "capacity": 9}
+      ]}]'''

--- a/test/integration/folly_f14_value_map.toml
+++ b/test/integration/folly_f14_value_map.toml
@@ -1,0 +1,78 @@
+includes = ["folly/container/F14Map.h"]
+definitions = '''
+  struct Bar {
+    float a, b;
+  };
+
+  struct Foo {
+    folly::F14ValueMap<int, int> m1;
+    folly::F14ValueMap<int, Bar> m2;
+    folly::F14ValueMap<int, int> m3;
+    folly::F14ValueMap<int, int> m4;
+  };
+'''
+
+[cases]
+  [cases.a]
+    param_types = ["const Foo&"]
+    setup = '''
+      Foo foo;
+
+      foo.m1.reserve(3);
+      for (int i = 0; i < 3; i++) {
+        foo.m1.emplace(i, i);
+      }
+
+      foo.m2.reserve(5);
+      for (int i = 0; i < 5; i++) {
+        foo.m2.emplace(i, Bar{0.0f, 0.0f});
+      }
+
+      foo.m3.reserve(7);
+      for (int i = 0; i < 7; i++) {
+        foo.m3.emplace(i, i);
+      }
+
+      foo.m4.reserve(9);
+      for (int i = 0; i < 9; i++) {
+        foo.m4.emplace(i, i);
+      }
+
+      return {foo};
+    '''
+    expect_json = '''[{
+      "staticSize":96,
+      "dynamicSize":304,
+      "members":[
+        {"name":"m1", "staticSize":24, "dynamicSize":48, "length":3, "capacity":3, "elementStaticSize":8},
+        {
+          "name":"m2",
+          "staticSize":24,
+          "dynamicSize":80,
+          "length":5,
+          "capacity":5,
+          "elementStaticSize":12,
+          "members":[
+            {"staticSize": 4},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize": 4},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize": 4},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize": 4},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize": 4},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]}
+        ]},
+        {"name":"m3", "staticSize":24, "dynamicSize":80, "length":7, "capacity":7, "elementStaticSize":8},
+        {"name":"m4", "staticSize":24, "dynamicSize":96, "length":9, "capacity":9, "elementStaticSize":8}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":96,
+      "exclusiveSize": 0,
+      "members":[
+        {"name":"m1", "staticSize":24, "exclusiveSize": 24, "length": 3, "capacity": 3},
+        {"name":"m2", "staticSize":24, "exclusiveSize": 24, "length": 5, "capacity": 5},
+        {"name":"m3", "staticSize":24, "exclusiveSize": 24, "length": 7, "capacity": 7},
+        {"name":"m4", "staticSize":24, "exclusiveSize": 24, "length": 9, "capacity": 9}
+      ]}]'''

--- a/test/integration/folly_f14_value_set.toml
+++ b/test/integration/folly_f14_value_set.toml
@@ -1,0 +1,83 @@
+includes = ["folly/container/F14Set.h"]
+definitions = '''
+  struct Bar {
+    float a, b;
+  };
+
+  inline bool operator==(const Bar &lhs, const Bar &rhs) noexcept {
+    return lhs.a == rhs.a && lhs.b == rhs.b;
+  }
+
+  struct BarHasher {
+    inline size_t operator()(const Bar &bar) const {
+      return folly::hash::hash_combine(bar.a, bar.b);
+    }
+  };
+
+  struct Foo {
+    folly::F14ValueSet<int> m1;
+    folly::F14ValueSet<Bar, BarHasher> m2;
+    folly::F14ValueSet<int> m3;
+    folly::F14ValueSet<int> m4;
+  };
+'''
+
+[cases]
+  [cases.a]
+    param_types = ["const Foo&"]
+    setup = '''
+      Foo foo;
+
+      foo.m1.reserve(3);
+      for (int i = 0; i < 3; i++) {
+        foo.m1.emplace(i);
+      }
+
+      foo.m2.reserve(5);
+      for (int i = 0; i < 5; i++) {
+        foo.m2.emplace(Bar{(float)i, 0.0f});
+      }
+
+      foo.m3.reserve(7);
+      for (int i = 0; i < 7; i++) {
+        foo.m3.emplace(i);
+      }
+
+      foo.m4.reserve(9);
+      for (int i = 0; i < 9; i++) {
+        foo.m4.emplace(i);
+      }
+
+      return {foo};
+    '''
+    expect_json = '''[{
+      "staticSize":96,
+      "dynamicSize":208,
+      "members":[
+        {"name":"m1", "staticSize":24, "dynamicSize":32, "length":3, "capacity":3, "elementStaticSize":4},
+        {
+          "name":"m2",
+          "staticSize":24,
+          "dynamicSize":64,
+          "length":5,
+          "capacity":5,
+          "elementStaticSize":8,
+          "members":[
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]}
+        ]},
+        {"name":"m3", "staticSize":24, "dynamicSize":48, "length":7, "capacity":7, "elementStaticSize":4},
+        {"name":"m4", "staticSize":24, "dynamicSize":64, "length":9, "capacity":9, "elementStaticSize":4}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":96,
+      "exclusiveSize": 0,
+      "members":[
+        {"name":"m1", "staticSize":24, "exclusiveSize": 24, "length": 3, "capacity": 3},
+        {"name":"m2", "staticSize":24, "exclusiveSize": 24, "length": 5, "capacity": 5},
+        {"name":"m3", "staticSize":24, "exclusiveSize": 24, "length": 7, "capacity": 7},
+        {"name":"m4", "staticSize":24, "exclusiveSize": 24, "length": 9, "capacity": 9}
+      ]}]'''

--- a/test/integration/folly_f14_vector_set.toml
+++ b/test/integration/folly_f14_vector_set.toml
@@ -1,0 +1,83 @@
+includes = ["folly/container/F14Set.h"]
+definitions = '''
+  struct Bar {
+    float a, b;
+  };
+
+  inline bool operator==(const Bar &lhs, const Bar &rhs) noexcept {
+    return lhs.a == rhs.a && lhs.b == rhs.b;
+  }
+
+  struct BarHasher {
+    inline size_t operator()(const Bar &bar) const {
+      return folly::hash::hash_combine(bar.a, bar.b);
+    }
+  };
+
+  struct Foo {
+    folly::F14VectorSet<int> m1;
+    folly::F14VectorSet<Bar, BarHasher> m2;
+    folly::F14VectorSet<int> m3;
+    folly::F14VectorSet<int> m4;
+  };
+'''
+
+[cases]
+  [cases.a]
+    param_types = ["const Foo&"]
+    setup = '''
+      Foo foo;
+
+      foo.m1.reserve(3);
+      for (int i = 0; i < 3; i++) {
+        foo.m1.emplace(i);
+      }
+
+      foo.m2.reserve(5);
+      for (int i = 0; i < 5; i++) {
+        foo.m2.emplace(Bar{(float)i, 0.0f});
+      }
+
+      foo.m3.reserve(7);
+      for (int i = 0; i < 7; i++) {
+        foo.m3.emplace(i);
+      }
+
+      foo.m4.reserve(9);
+      for (int i = 0; i < 9; i++) {
+        foo.m4.emplace(i);
+      }
+
+      return {foo};
+    '''
+    expect_json = '''[{
+      "staticSize":96,
+      "dynamicSize":304,
+      "members":[
+        {"name":"m1", "staticSize":24, "dynamicSize":48, "length":3, "capacity":3, "elementStaticSize":4},
+        {
+          "name":"m2",
+          "staticSize":24,
+          "dynamicSize":80,
+          "length":5,
+          "capacity":5,
+          "elementStaticSize":8,
+          "members":[
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]},
+            {"staticSize":8, "members":[{"name":"a"}, {"name": "b"}]}
+        ]},
+        {"name":"m3", "staticSize":24, "dynamicSize":80, "length":7, "capacity":7, "elementStaticSize":4},
+        {"name":"m4", "staticSize":24, "dynamicSize":96, "length":9, "capacity":9, "elementStaticSize":4}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":96,
+      "exclusiveSize": 0,
+      "members":[
+        {"name":"m1", "staticSize":24, "exclusiveSize": 24, "length": 3, "capacity": 3},
+        {"name":"m2", "staticSize":24, "exclusiveSize": 24, "length": 5, "capacity": 5},
+        {"name":"m3", "staticSize":24, "exclusiveSize": 24, "length": 7, "capacity": 7},
+        {"name":"m4", "staticSize":24, "exclusiveSize": 24, "length": 9, "capacity": 9}
+      ]}]'''

--- a/types/f14_fast_set.toml
+++ b/types/f14_fast_set.toml
@@ -34,3 +34,70 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
     }
 }
 """
+
+handler = """
+template <typename DB, typename T0, typename T1, typename T2, typename T3>
+struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
+  using type = types::st::Pair<DB,
+    types::st::VarInt<DB>,
+    types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::List<DB,
+        typename TypeHandler<DB, T0>::type>>>;
+
+  static types::st::Unit<DB> getSizeType(
+      const %1%<T0, T1, T2, T3>& container,
+      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
+    size_t memorySize = container.getAllocatedMemorySize();
+    auto tail = returnArg
+      .write(memorySize)
+      .write(container.bucket_count())
+      .write(container.size());
+
+    for (auto &&entry: container) {
+      tail = tail.delegate([&entry](auto ret) {
+        return OIInternal::getSizeType<DB>(entry, ret);
+      });
+    }
+
+    return tail.finish();
+  }
+};
+"""
+
+traversal_func = """
+// TODO: This implementation enables the traversal of the container,
+//       but doesn't report the memory footprint accurately.
+//       Revisit this implementation and fix memory footprint reporting.
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.size());
+
+for (auto &&entry: container) {
+  tail = tail.delegate([&entry](auto ret) {
+    return OIInternal::getSizeType<DB>(entry, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
+
+[[codegen.processor]]
+type = """
+types::st::List<DB, typename TypeHandler<DB, T0>::type>
+"""
+func = """
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr auto childField = make_field<DB, T0>("[]");
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(childField);
+"""

--- a/types/f14_node_set.toml
+++ b/types/f14_node_set.toml
@@ -2,7 +2,7 @@
 type_name = "folly::F14NodeSet"
 stub_template_params = [1,2,3]
 ctype = "F14_SET"
-header = "folly/container/detail/F14SetFallback.h"
+header = "folly/container/F14Set.h"
 
 # Old:
 typeName = "folly::F14NodeSet<"
@@ -33,4 +33,71 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
         getSizeType(it, returnArg);
     }
 }
+"""
+
+handler = """
+template <typename DB, typename T0, typename T1, typename T2, typename T3>
+struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
+  using type = types::st::Pair<DB,
+    types::st::VarInt<DB>,
+    types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::List<DB,
+        typename TypeHandler<DB, T0>::type>>>;
+
+  static types::st::Unit<DB> getSizeType(
+      const %1%<T0, T1, T2, T3>& container,
+      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
+    size_t memorySize = container.getAllocatedMemorySize();
+    auto tail = returnArg
+      .write(memorySize)
+      .write(container.bucket_count())
+      .write(container.size());
+
+    for (auto &&entry: container) {
+      tail = tail.delegate([&entry](auto ret) {
+        return OIInternal::getSizeType<DB>(entry, ret);
+      });
+    }
+
+    return tail.finish();
+  }
+};
+"""
+
+traversal_func = """
+// TODO: This implementation enables the traversal of the container,
+//       but doesn't report the memory footprint accurately.
+//       Revisit this implementation and fix memory footprint reporting.
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.size());
+
+for (auto &&entry: container) {
+  tail = tail.delegate([&entry](auto ret) {
+    return OIInternal::getSizeType<DB>(entry, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
+
+[[codegen.processor]]
+type = """
+types::st::List<DB, typename TypeHandler<DB, T0>::type>
+"""
+func = """
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr auto childField = make_field<DB, T0>("[]");
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(childField);
 """

--- a/types/f14_value_map.toml
+++ b/types/f14_value_map.toml
@@ -1,0 +1,124 @@
+[info]
+type_name = "folly::F14ValueMap"
+stub_template_params = [2,3,4]
+ctype = "F14_MAP"
+header = "folly/container/F14Map.h"
+
+# Old:
+typeName = "folly::F14ValueMap<"
+ns = ["folly::F14ValueMap"]
+numTemplateParams = 2
+replaceTemplateParamIndex = [2, 3]
+allocatorIndex = 4
+
+[codegen]
+decl = """
+template <typename Key, typename Mapped, typename Hasher, typename KeyEqual, typename Alloc>
+void getSizeType(const %1%<Key, Mapped, Hasher, KeyEqual, Alloc> &container, size_t& dataSegOffset);
+"""
+
+func = """
+template <typename Key, typename Mapped, typename Hasher, typename KeyEqual, typename Alloc>
+void getSizeType(const %1%<Key, Mapped, Hasher, KeyEqual, Alloc> &container, size_t& returnArg)
+{
+    size_t memorySize = container.getAllocatedMemorySize();
+    SAVE_SIZE(sizeof(%1%<Key, Mapped, Hasher, KeyEqual>) + memorySize);
+
+    SAVE_DATA(memorySize);
+    SAVE_DATA(container.bucket_count());
+    SAVE_DATA(container.size());
+
+    // The double ampersand is needed otherwise this loop doesn't work with vector<bool>
+    for (auto&& it: container) {
+        getSizeType(it.first, returnArg);
+        getSizeType(it.second, returnArg);
+    }
+}
+"""
+
+handler = """
+template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
+struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
+  using type = types::st::Pair<DB,
+    types::st::VarInt<DB>,
+    types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::List<DB, types::st::Pair<DB,
+        typename TypeHandler<DB, T0>::type,
+        typename TypeHandler<DB, T1>::type>>>>;
+
+  static types::st::Unit<DB> getSizeType(
+      const %1%<T0, T1, T2, T3, T4>& container,
+      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
+    size_t memorySize = container.getAllocatedMemorySize();
+    auto tail = returnArg
+      .write(memorySize)
+      .write(container.bucket_count())
+      .write(container.size());
+
+    for (auto &&entry: container) {
+      tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
+        auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
+          return OIInternal::getSizeType<DB>(key, ret);
+        });
+        return OIInternal::getSizeType<DB>(value, next);
+      });
+    }
+
+    return tail.finish();
+  }
+};
+"""
+
+traversal_func = """
+// TODO: This implementation enables the traversal of the container,
+//       but doesn't report the memory footprint accurately.
+//       Revisit this implementation and fix memory footprint reporting.
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.size());
+
+for (auto &&entry: container) {
+  tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
+    auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
+      return OIInternal::getSizeType<DB>(key, ret);
+    });
+    return OIInternal::getSizeType<DB>(value, next);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
+
+[[codegen.processor]]
+type = """
+types::st::List<DB, types::st::Pair<DB,
+  typename TypeHandler<DB, T0>::type,
+  typename TypeHandler<DB, T1>::type>>
+"""
+func = """
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr std::array<inst::Field, 2> element_fields{
+  make_field<DB, T0>("key"),
+  make_field<DB, T1>("value"),
+};
+
+static constexpr inst::Field element{
+  0, 0, "[]",
+  std::array<std::string_view, 0>{},
+  element_fields,
+  std::array<inst::ProcessorInst, 0>{},
+};
+
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(element);
+"""

--- a/types/f14_value_set.toml
+++ b/types/f14_value_set.toml
@@ -1,0 +1,103 @@
+[info]
+type_name = "folly::F14ValueSet"
+stub_template_params = [1,2,3]
+ctype = "F14_SET"
+header = "folly/container/F14Set.h"
+
+# Old:
+typeName = "folly::F14ValueSet<"
+ns = ["folly::F14ValueSet"]
+numTemplateParams = 1
+replaceTemplateParamIndex = [1, 2]
+allocatorIndex = 3
+
+[codegen]
+decl = """
+template <typename Key, typename Hasher, typename KeyEqual, typename Alloc>
+void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& returnArg);
+"""
+
+func = """
+template <typename Key, typename Hasher, typename KeyEqual, typename Alloc>
+void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& returnArg)
+{
+    size_t memorySize = container.getAllocatedMemorySize();
+    SAVE_SIZE(sizeof(%1%<Key, Hasher, KeyEqual, Alloc>) + memorySize);
+
+    SAVE_DATA(memorySize);
+    SAVE_DATA(container.bucket_count());
+    SAVE_DATA(container.size());
+
+    // The double ampersand is needed otherwise this loop doesn't work with vector<bool>
+    for (auto&& it: container) {
+        getSizeType(it, returnArg);
+    }
+}
+"""
+
+handler = """
+template <typename DB, typename T0, typename T1, typename T2, typename T3>
+struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
+  using type = types::st::Pair<DB,
+    types::st::VarInt<DB>,
+    types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::List<DB,
+        typename TypeHandler<DB, T0>::type>>>;
+
+  static types::st::Unit<DB> getSizeType(
+      const %1%<T0, T1, T2, T3>& container,
+      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
+    size_t memorySize = container.getAllocatedMemorySize();
+    auto tail = returnArg
+      .write(memorySize)
+      .write(container.bucket_count())
+      .write(container.size());
+
+    for (auto &&entry: container) {
+      tail = tail.delegate([&entry](auto ret) {
+        return OIInternal::getSizeType<DB>(entry, ret);
+      });
+    }
+
+    return tail.finish();
+  }
+};
+"""
+
+traversal_func = """
+// TODO: This implementation enables the traversal of the container,
+//       but doesn't report the memory footprint accurately.
+//       Revisit this implementation and fix memory footprint reporting.
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.size());
+
+for (auto &&entry: container) {
+  tail = tail.delegate([&entry](auto ret) {
+    return OIInternal::getSizeType<DB>(entry, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
+
+[[codegen.processor]]
+type = """
+types::st::List<DB, typename TypeHandler<DB, T0>::type>
+"""
+func = """
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr auto childField = make_field<DB, T0>("[]");
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(childField);
+"""

--- a/types/f14_vector_set.toml
+++ b/types/f14_vector_set.toml
@@ -34,3 +34,70 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
     }
 }
 """
+
+handler = """
+template <typename DB, typename T0, typename T1, typename T2, typename T3>
+struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
+  using type = types::st::Pair<DB,
+    types::st::VarInt<DB>,
+    types::st::Pair<DB,
+      types::st::VarInt<DB>,
+      types::st::List<DB,
+        typename TypeHandler<DB, T0>::type>>>;
+
+  static types::st::Unit<DB> getSizeType(
+      const %1%<T0, T1, T2, T3>& container,
+      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
+    size_t memorySize = container.getAllocatedMemorySize();
+    auto tail = returnArg
+      .write(memorySize)
+      .write(container.bucket_count())
+      .write(container.size());
+
+    for (auto &&entry: container) {
+      tail = tail.delegate([&entry](auto ret) {
+        return OIInternal::getSizeType<DB>(entry, ret);
+      });
+    }
+
+    return tail.finish();
+  }
+};
+"""
+
+traversal_func = """
+// TODO: This implementation enables the traversal of the container,
+//       but doesn't report the memory footprint accurately.
+//       Revisit this implementation and fix memory footprint reporting.
+auto tail = returnArg
+  .write((uintptr_t)&container)
+  .write(container.size());
+
+for (auto &&entry: container) {
+  tail = tail.delegate([&entry](auto ret) {
+    return OIInternal::getSizeType<DB>(entry, ret);
+  });
+}
+
+return tail.finish();
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
+
+[[codegen.processor]]
+type = """
+types::st::List<DB, typename TypeHandler<DB, T0>::type>
+"""
+func = """
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = list.length,
+  .length = list.length,
+});
+
+static constexpr auto childField = make_field<DB, T0>("[]");
+for (size_t i = 0; i < list.length; i++)
+  ins.emplace(childField);
+"""


### PR DESCRIPTION
## Summary
Implement Container V2 for `folly::F14ValueSet`, `folly::F14VectorSet`, `folly::F14NodeSet`, and `folly::F14FastSet`. I've also sneaked in an implementation for `folly::F14ValueMap`, which was still missing.
Note that these implementation don't report byte-accurate footprint for the containers. They will need to be revisited to implement proper accounting.

## Test plan
`make test`
