### PR TITLE
json: fix bug where a past the end iterator would be dereferenced

### DIFF
--- a/oi/exporters/Json.cpp
+++ b/oi/exporters/Json.cpp
@@ -114,7 +114,7 @@ void Json::print(IntrospectionResult::const_iterator& it,
     }
 
     out_ << tab << "\"members\":" << space;
-    if ((++it)->type_path.size() > firstTypePath.size()) {
+    if (++it != end && it->type_path.size() > firstTypePath.size()) {
       print(it, end);
     } else {
       out_ << "[]" << endl;


### PR DESCRIPTION
Summary: The iterator was incremented without checking it in the JSON exporter. This caused an assertion to trigger on the last run in debug mode (weirdly no crashes). This change should fix that by checking the iterator at the increment site and not just when the loop rolls around.

Differential Revision: D49151482


