### PR TITLE
oil: update iterator for range based for loops

### DIFF
--- a/include/oi/IntrospectionResult-inl.h
+++ b/include/oi/IntrospectionResult-inl.h
@@ -41,8 +41,14 @@ inline IntrospectionResult::const_iterator::const_iterator(
     std::vector<uint8_t>::const_iterator data)
     : data_(data) {
 }
+inline IntrospectionResult::const_iterator IntrospectionResult::begin() const {
+  return cbegin();
+}
 inline IntrospectionResult::const_iterator IntrospectionResult::cbegin() const {
   return ++const_iterator{buf_.cbegin(), inst_};
+}
+inline IntrospectionResult::const_iterator IntrospectionResult::end() const {
+  return cend();
 }
 inline IntrospectionResult::const_iterator IntrospectionResult::cend() const {
   return {buf_.cend()};

--- a/include/oi/IntrospectionResult.h
+++ b/include/oi/IntrospectionResult.h
@@ -56,7 +56,10 @@ class IntrospectionResult {
 
   IntrospectionResult(std::vector<uint8_t> buf, exporters::inst::Inst inst);
 
+  const_iterator begin() const;
   const_iterator cbegin() const;
+
+  const_iterator end() const;
   const_iterator cend() const;
 
  private:


### PR DESCRIPTION
## Summary

IntrospectionResult did not support range based for loops (`for (const auto& el : result) { ... }`) because it was missing a `begin()` and `end()` implementation. Add these, forwarding to the `cbegin()` and `cend()` implementations because this iterator is always constant.

## Test plan

- CI
- https://www.internalfb.com/diff/D49234918
