### PR TITLE
static types: add consume function similar to delegate

### DIFF
--- a/include/oi/types/st.h
+++ b/include/oi/types/st.h
@@ -80,7 +80,7 @@ class Unit {
   }
 
   template <typename F>
-  Unit<DataBuffer> delegate(F const& cb) {
+  Unit<DataBuffer> consume(F const& cb) {
     return cb(*this);
   }
 
@@ -131,6 +131,11 @@ class VarInt {
     return Unit<DataBuffer>(_buf);
   }
 
+  template <typename F>
+  Unit<DataBuffer> consume(F const& cb) {
+    return cb(*this);
+  }
+
 #ifdef DEFINE_DESCRIBE
   static constexpr types::dy::VarInt describe{};
 #endif
@@ -163,6 +168,11 @@ class Pair {
     T1 first = T1(_buf);
     Unit<DataBuffer> second = cb(first);
     return second.template cast<T2>();
+  }
+
+  template <typename F>
+  Unit<DataBuffer> consume(F const& cb) {
+    return cb(*this);
   }
 
 #ifdef DEFINE_DESCRIBE
@@ -215,6 +225,11 @@ class Sum {
   Unit<DataBuffer> delegate(F const& cb) {
     auto tail = write<I>();
     return cb(tail);
+  }
+
+  template <typename F>
+  Unit<DataBuffer> consume(F const& cb) {
+    return cb(*this);
   }
 
 #ifdef DEFINE_DESCRIBE
@@ -272,6 +287,11 @@ class List
  public:
   List(DataBuffer db)
       : Pair<DataBuffer, VarInt<DataBuffer>, ListContents<DataBuffer, T>>(db) {
+  }
+
+  template <typename F>
+  Unit<DataBuffer> consume(F const& cb) {
+    return cb(*this);
   }
 
 #ifdef DEFINE_DESCRIBE


### PR DESCRIPTION
## Summary

The generated code for traversing a class uses almost entirely the delegate form on the static type. However, for the last element, it drops the form as `delegate()` doesn't have the right behaviour. If left with a Pair or Sum delegate would behave incorrectly for the last element.

Add a new `consume()` function to the static types that works in the same way as delegate but always returns a `Unit`. This allows changing the class traversal function to be entirely fluent, neatening it up.

## Test plan

- CI

Before:
```cpp
  static types::st::Unit<DB> getSizeType(
      const SimpleStruct_0& t,
      typename TypeHandler<DB, SimpleStruct_0>::type returnArg) {
    auto ret = returnArg
      .delegate([&t](auto ret) { return OIInternal::getSizeType<DB>(t.a_0, ret); })
      .delegate([&t](auto ret) { return OIInternal::getSizeType<DB>(t.b_1, ret); });
    return OIInternal::getSizeType<DB>(t.c_3, ret);
  }
```

After:
```cpp
  static types::st::Unit<DB> getSizeType(
      const SimpleStruct_0& t,
      typename TypeHandler<DB, SimpleStruct_0>::type returnArg) {
    return returnArg
      .delegate([&t](auto ret) { return OIInternal::getSizeType<DB>(t.a_0, ret); })
      .delegate([&t](auto ret) { return OIInternal::getSizeType<DB>(t.b_1, ret); })
      .consume([&t](auto ret) { return OIInternal::getSizeType<DB>(t.c_3, ret); });
  }
```
