### PR TITLE
oilgen: hash linkage names in output path

### DIFF
--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -152,7 +152,8 @@ fs::path OIGenerator::generateForType(const OICodeGen::Config& generatorConfig,
 
   // TODO: Revert to outputPath and remove printing when typegraph is done.
   fs::path tmpObject = outputPath;
-  tmpObject.replace_extension("." + linkageName + ".o");
+  tmpObject.replace_extension(
+      "." + std::to_string(std::hash<std::string>{}(linkageName)) + ".o");
 
   if (!compiler.compile(code, sourcePath, tmpObject)) {
     return {};


### PR DESCRIPTION
## Summary

OIGenerator appends linkage (symbol) names to paths. With particularly long symbols, this throws because the filesystem won't accept a filename that long. Hash them so the length is consistent.

This will go away eventually when I change OILGen to support multiple entrypoints in a single object file. This hasn't happened yet though, so this is a stop gap.

## Test plan

Tested it internally. Errors early on a big symbol beforehand, gets to codegen properly afterwards.
