### PR TITLE
oilgen: add debug flag

### DIFF
--- a/tools/OILGen.cpp
+++ b/tools/OILGen.cpp
@@ -33,7 +33,9 @@ constexpr static OIOpts opts{
           "Write output(s) to file(s) with this prefix."},
     OIOpt{'c', "config-file", required_argument, "<oid.toml>",
           "Path to OI configuration file."},
-    OIOpt{'d', "dump-jit", optional_argument, "<jit.cpp>",
+    OIOpt{'d', "debug-level", required_argument, "<level>",
+          "Verbose level for logging"},
+    OIOpt{'j', "dump-jit", optional_argument, "<jit.cpp>",
           "Write generated code to a file (for debugging)."},
     OIOpt{'e', "exit-code", no_argument, nullptr,
           "Return a bad exit code if nothing is generated."},
@@ -77,6 +79,14 @@ int main(int argc, char* argv[]) {
         configFilePath = optarg;
         break;
       case 'd':
+        google::LogToStderr();
+        google::SetStderrLogging(google::INFO);
+        google::SetVLOGLevel("*", atoi(optarg));
+        // Upstream glog defines `GLOG_INFO` as 0 https://fburl.com/ydjajhz0,
+        // but internally it's defined as 1 https://fburl.com/code/9fwams75
+        gflags::SetCommandLineOption("minloglevel", "0");
+        break;
+      case 'j':
         sourceFileDumpPath = optarg != nullptr ? optarg : "jit.cpp";
         break;
       case 'e':


### PR DESCRIPTION
## Summary

Current output of OILGen is always without debug. This hides things like the printed type graph from the end user, which would be useful in the logs of a build failure. Also rename the `-d` flag which was for jumping JIT code to `-j`, as `-d` is used in all the other tools for debug output level.

## Test plan
- CI
- Tested internally with the BUCK integration in [D49369823](https://www.internalfb.com/diff/D49369823)
