### PR TITLE
DrgnParser: Options should default to false

### DIFF
--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -30,8 +30,8 @@ struct ContainerInfo;
 namespace oi::detail::type_graph {
 
 struct DrgnParserOptions {
-  bool chaseRawPointers = true;
-  bool readEnumValues = true;
+  bool chaseRawPointers = false;
+  bool readEnumValues = false;
 };
 
 /*

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -72,6 +72,16 @@ void DrgnParserTest::test(std::string_view function,
   EXPECT_EQ(expected, actual);
 }
 
+void DrgnParserTest::test(std::string_view function,
+                          std::string_view expected) {
+  // Enable options in unit tests so we get more coverage
+  DrgnParserOptions options = {
+      .chaseRawPointers = true,
+      .readEnumValues = true,
+  };
+  test(function, expected, options);
+}
+
 void DrgnParserTest::testContains(std::string_view function,
                                   std::string_view expected,
                                   DrgnParserOptions options) {

--- a/test/test_drgn_parser.h
+++ b/test/test_drgn_parser.h
@@ -32,7 +32,8 @@ class DrgnParserTest : public ::testing::Test {
                           type_graph::DrgnParserOptions options);
   void test(std::string_view function,
             std::string_view expected,
-            type_graph::DrgnParserOptions options = {});
+            type_graph::DrgnParserOptions options);
+  void test(std::string_view function, std::string_view expected);
   void testContains(std::string_view function,
                     std::string_view expected,
                     type_graph::DrgnParserOptions options = {});


### PR DESCRIPTION
We only want to do the extra work if it's explicitly requested.

chaseRawPointers is already explicitly requested whenever it's needed and readEnumValues currently isn't needed at all.