### PR TITLE
oilgen: add missing gflags header

### DIFF
--- a/tools/OILGen.cpp
+++ b/tools/OILGen.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include <cstdlib>


### PR DESCRIPTION
## Summary

Although #348 built fine internally and on the CI, it fails on my devserver. Add the `gflags.h` header to satisfy a missing symbol.

## Test plan
- `make clobber; make configure-devel && make test`
