### PR TITLE
codegen: generate enums as enum class

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -190,7 +190,9 @@ void genDeclsClass(const Class& c, std::string& code) {
 }
 
 void genDeclsEnum(const Enum& e, std::string& code) {
-  code += "using " + e.name() + " = ";
+  code += "enum class ";
+  code += e.name();
+  code += " : ";
   switch (e.size()) {
     case 8:
       code += "uint64_t";
@@ -207,7 +209,7 @@ void genDeclsEnum(const Enum& e, std::string& code) {
     default:
       abort();  // TODO
   }
-  code += ";\n";
+  code += " {};\n";
 }
 
 void genDecls(const TypeGraph& typeGraph, std::string& code) {

--- a/test/integration/enums.toml
+++ b/test/integration/enums.toml
@@ -5,7 +5,7 @@ definitions = '''
     CaseC,
   };
 
-  enum class ScopedEnumInt8 : int8_t {
+  enum class ScopedEnumUint8 : uint8_t {
     CaseA = 2,
     CaseB = 3,
     CaseC = 4,
@@ -24,16 +24,24 @@ definitions = '''
       Two,
     } e;
   };
+
+  template <typename T1, typename T2>
+  struct Pair {
+    T1 first;
+    T2 second;
+  };
 '''
 [cases]
   [cases.scoped]
     param_types = ["ScopedEnum"]
     setup = "return {};"
     expect_json = '[{"staticSize":4, "dynamicSize":0}]'
-  [cases.scoped_int8]
-    param_types = ["ScopedEnumInt8"]
+    expect_json_v2 = '[{"typeNames": ["ScopedEnum"], "staticSize":4, "exclusiveSize":4}]'
+  [cases.scoped_uint8]
+    param_types = ["ScopedEnumUint8"]
     setup = "return {};"
     expect_json = '[{"staticSize":1, "dynamicSize":0}]'
+    expect_json_v2 = '[{"typeNames": ["ScopedEnumUint8"], "staticSize":1, "exclusiveSize":1}]'
   [cases.unscoped]
     param_types = ["UNSCOPED_ENUM"]
     setup = "return {};"
@@ -46,3 +54,13 @@ definitions = '''
       {"staticSize":4, "dynamicSize":0, "exclusiveSize":0, "members":[
         {"name":"e", "staticSize":4, "dynamicSize":0, "exclusiveSize":4}
     ]}]'''
+  [cases.paired_with_element]
+    param_types = ["Pair<ScopedEnumUint8, uint8_t>"]
+    setup = "return {};"
+    expect_json = '[{"staticSize":2, "dynamicSize":0}]'
+    expect_json_v2 = '''[
+      {"staticSize": 2, "exclusiveSize": 0, "members": [
+        {"typeNames": ["ScopedEnumUint8"], "staticSize":1, "exclusiveSize":1},
+        {"typeNames": ["uint8_t"], "staticSize":1, "exclusiveSize":1}
+      ]}
+    ]'''

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -260,9 +260,9 @@ TEST_F(DrgnParserTest, Enum) {
 )");
 }
 
-TEST_F(DrgnParserTest, EnumInt8) {
-  test("oid_test_case_enums_scoped_int8", R"(
-    Enum: ScopedEnumInt8 (size: 1)
+TEST_F(DrgnParserTest, EnumUint8) {
+  test("oid_test_case_enums_scoped_uint8", R"(
+    Enum: ScopedEnumUint8 (size: 1)
       Enumerator: 2:CaseA
       Enumerator: 3:CaseB
       Enumerator: 4:CaseC


### PR DESCRIPTION
## Summary

Enum classes were previously generated as their integer type. Generate them as enum classes with that integer type as the base so they can be identified separately in `NameProvider` for OIL.

## Test plan

- CI

Updated the enum tests to check names are generated correctly. Added a new test which generates both the enum and its base type in one codegen CU. This failed to compile previously as it created two different copies of `NameHandler<uint8_t>`.
