### PR TITLE
oilgen: avoid demangling empty symbols

### DIFF
--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -21,6 +21,7 @@
 #include <boost/core/demangle.hpp>
 #include <fstream>
 #include <iostream>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 
@@ -44,6 +45,8 @@ OIGenerator::oilStrongToWeakSymbolsMap(drgnplusplus::program& prog) {
   auto symbols = prog.find_all_symbols();
   for (drgn_symbol* sym : *symbols) {
     auto symName = drgnplusplus::symbol::name(sym);
+    if (symName == nullptr || *symName == '\0')
+      continue;
     auto demangled = boost::core::demangle(symName);
 
     if (demangled.starts_with(strongSymbolPrefix)) {


### PR DESCRIPTION
## Summary

oilgen currently attempts to demangle all symbols it gets from drgn, even if they're empty. If the symbol is empty this causes ASAN to fail in some libiberty (I think) function. Check first if the symbol is empty and skip it which solves the ASAN problems.

## Test plan

- CI
- Tested with [D49413028](https://www.internalfb.com/diff/D49413028)
