### PR TITLE
prevent name collision between uintptr_t and uint64_t

### DIFF
--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -143,3 +143,5 @@ struct validate_offset {
   static constexpr bool value = true;
   static_assert(ExpectedOffset == ActualOffset);
 };
+
+enum class StubbedPointer : uintptr_t {};

--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -464,13 +464,13 @@ static drgn_type* getPtrUnderlyingType(drgn_type* type) {
 
 Type& DrgnParser::enumeratePointer(struct drgn_type* type) {
   if (!chasePointer()) {
-    return makeType<Primitive>(type, Primitive::Kind::UIntPtr);
+    return makeType<Primitive>(type, Primitive::Kind::StubbedPointer);
   }
 
   struct drgn_type* pointeeType = drgn_type_type(type).type;
 
   if (drgn_type_kind(getPtrUnderlyingType(type)) == DRGN_TYPE_FUNCTION) {
-    return makeType<Primitive>(type, Primitive::Kind::UIntPtr);
+    return makeType<Primitive>(type, Primitive::Kind::StubbedPointer);
   }
 
   Type& t = enumerateType(pointeeType);

--- a/oi/type_graph/TypeGraph.cpp
+++ b/oi/type_graph/TypeGraph.cpp
@@ -59,9 +59,9 @@ Primitive& TypeGraph::makeType<Primitive>(Primitive::Kind kind) {
     case Primitive::Kind::Bool:
       static Primitive pBool{kind};
       return pBool;
-    case Primitive::Kind::UIntPtr:
-      static Primitive pUIntPtr{kind};
-      return pUIntPtr;
+    case Primitive::Kind::StubbedPointer:
+      static Primitive pStubbedPointer{kind};
+      return pStubbedPointer;
     case Primitive::Kind::Void:
       static Primitive pVoid{kind};
       return pVoid;

--- a/oi/type_graph/Types.cpp
+++ b/oi/type_graph/Types.cpp
@@ -57,12 +57,19 @@ std::string Primitive::getName(Kind kind) {
       return "long double";
     case Kind::Bool:
       return "bool";
-    case Kind::UIntPtr:
-      return "uintptr_t";
+    case Kind::StubbedPointer:
+      return "StubbedPointer";
     case Kind::Void:
     case Kind::Incomplete:
       return "void";
   }
+}
+
+std::string_view Primitive::inputName() const {
+  static const std::string kStubbedPointer = "uintptr_t (stubbed)";
+  if (kind_ == Kind::StubbedPointer)
+    return kStubbedPointer;
+  return name_;
 }
 
 std::size_t Primitive::size() const {
@@ -93,7 +100,7 @@ std::size_t Primitive::size() const {
       return 16;
     case Kind::Bool:
       return 1;
-    case Kind::UIntPtr:
+    case Kind::StubbedPointer:
       return sizeof(uintptr_t);
     case Kind::Void:
     case Kind::Incomplete:

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -485,8 +485,7 @@ class Primitive : public Type {
     Float128,  // TODO can we generate this?
     Bool,
 
-    UIntPtr,  // Really an alias, but useful to have as its own primitive
-
+    StubbedPointer,
     Void,
     Incomplete,  // Behaves the same as Void, but alerts us that the type was
                  // stubbed out due to incomplete DWARF
@@ -502,9 +501,7 @@ class Primitive : public Type {
   virtual const std::string& name() const override {
     return name_;
   }
-  virtual std::string_view inputName() const override {
-    return name_;
-  }
+  virtual std::string_view inputName() const override;
   virtual size_t size() const override;
   virtual uint64_t align() const override {
     return size();

--- a/test/TypeGraphParser.cpp
+++ b/test/TypeGraphParser.cpp
@@ -45,8 +45,8 @@ Primitive::Kind getKind(std::string_view kindStr) {
     return Primitive::Kind::Float128;
   if (kindStr == "bool")
     return Primitive::Kind::Bool;
-  if (kindStr == "uintptr_t")
-    return Primitive::Kind::UIntPtr;
+  if (kindStr == "StubbedPointer")
+    return Primitive::Kind::StubbedPointer;
   if (kindStr == "void")
     return Primitive::Kind::Void;
   if (kindStr == "void (incomplete)")

--- a/test/integration/std_pair.toml
+++ b/test/integration/std_pair.toml
@@ -1,7 +1,6 @@
 includes = ["vector", "utility", "cstdint"]
 [cases]
   [cases.uint64_uint64]
-    oil_skip = 'tests need updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/310
     param_types = ["std::pair<std::uint64_t, std::uint64_t>&"]
     setup = "return {{0, 1}};"
     expect_json = '''
@@ -14,8 +13,13 @@ includes = ["vector", "utility", "cstdint"]
       }
     ]
     '''
+    expect_json_v2 = '''[
+      {"staticSize": 16, "exclusiveSize": 0, "members": [
+        {"typeNames": ["uint64_t"], "staticSize": 8, "exclusiveSize": 8},
+        {"typeNames": ["uint64_t"], "staticSize": 8, "exclusiveSize": 8}
+      ]}
+    ]'''
   [cases.uint64_uint32]
-    oil_skip = 'tests need updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/310
     param_types = ["std::pair<std::uint64_t, std::uint32_t>&"]
     setup = "return {{0, 1}};"
     # Should still have static size of 16 due to padding
@@ -29,8 +33,28 @@ includes = ["vector", "utility", "cstdint"]
       }
     ]
     '''
+    expect_json_v2 = '''[
+      {"staticSize": 16, "exclusiveSize": 4, "members": [
+        {"typeNames": ["uint64_t"], "staticSize": 8, "exclusiveSize": 8},
+        {"typeNames": ["uint32_t"], "staticSize": 4, "exclusiveSize": 4}
+      ]}
+    ]'''
+
+  [cases.uint64_uint64_ptr]
+    # Stubbed pointers were previously generated as a uintptr_t. Now they're
+    # generated as a special StubbedPointer type. This previously caused
+    # codegen problems as uintptr_t is a typedef of uint64_t and they'd both
+    # be specialised on a template.
+    param_types = ["std::pair<uint64_t, uint64_t*>&"]
+    setup = "return {{0, nullptr}};"
+    expect_json_v2 = '''[
+      {"staticSize": 16, "exclusiveSize": 0, "members": [
+        {"typeNames": ["uint64_t"], "staticSize": 8, "exclusiveSize": 8},
+        {"typeNames": ["uintptr_t (stubbed)"], "staticSize": 8, "exclusiveSize": 8}
+      ]}
+    ]'''
+
   [cases.vector_vector]
-    oil_skip = 'tests need updating for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/310
     param_types = ["std::pair<std::vector<std::uint64_t>, std::vector<std::uint64_t>>&"]
     setup = "return {{std::initializer_list<std::uint64_t>({0,1,2}), std::initializer_list<std::uint64_t>({3,4,5,6})}};"
     expect_json = '''
@@ -57,3 +81,9 @@ includes = ["vector", "utility", "cstdint"]
       }
     ]
     '''
+    expect_json_v2 = '''[
+      {"staticSize": 48, "exclusiveSize": 0, "members": [
+        {"typeNames": ["std::vector<uint64_t, std::allocator<uint64_t>>"], "staticSize": 24, "exclusiveSize": 24},
+        {"typeNames": ["std::vector<uint64_t, std::allocator<uint64_t>>"], "staticSize": 24, "exclusiveSize": 24}
+      ]}
+    ]'''

--- a/test/test_add_children.cpp
+++ b/test/test_add_children.cpp
@@ -70,7 +70,7 @@ TEST_F(AddChildrenTest, InheritancePolymorphic) {
 [1]  Pointer
 [0]    Class: A (size: 16)
          Member: _vptr$A (offset: 0)
-           Primitive: uintptr_t
+           Primitive: StubbedPointer
          Member: int_a (offset: 8)
            Primitive: int32_t
          Function: ~A (virtual)
@@ -124,7 +124,7 @@ TEST_F(AddChildrenTest, InheritancePolymorphic) {
 [1]  Pointer
 [0]    Class: A (size: 16)
          Member: _vptr.A (offset: 0)
-           Primitive: uintptr_t
+           Primitive: StubbedPointer
          Member: int_a (offset: 8)
            Primitive: int32_t
          Function: operator=

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -356,9 +356,9 @@ TEST_F(DrgnParserTest, PointerNoFollow) {
         Member: a (offset: 0)
           Primitive: int32_t
         Member: b (offset: 8)
-          Primitive: uintptr_t
+          Primitive: StubbedPointer
         Member: c (offset: 16)
-          Primitive: uintptr_t
+          Primitive: StubbedPointer
 )",
        options);
 }
@@ -586,7 +586,7 @@ TEST_F(DrgnParserTest, VirtualFunctions) {
 [1] Pointer
 [0]   Class: A (size: 16)
         Member: _vptr$A (offset: 0)
-          Primitive: uintptr_t
+          Primitive: StubbedPointer
         Member: int_a (offset: 8)
           Primitive: int32_t
         Function: ~A (virtual)
@@ -598,7 +598,7 @@ TEST_F(DrgnParserTest, VirtualFunctions) {
 [1] Pointer
 [0]   Class: A (size: 16)
         Member: _vptr.A (offset: 0)
-          Primitive: uintptr_t
+          Primitive: StubbedPointer
         Member: int_a (offset: 8)
           Primitive: int32_t
         Function: operator=


### PR DESCRIPTION
## Summary

`uintptr_t` is a typedef of `uint64_t` but doesn't appear as such in the type graph. This meant if we generated a `uintptr_t` and also had a `uint64_t` in the output, they would get a `NameProvider<T>` each and this would cause a compilation failure.

Stop generating `uintptr_t` for these cases where we're stubbing pointers (the only cases it gets generated in). Change this to a special enum class called `StubbedPointer` with the same memory footprint. This will make stubbed pointers easier to search for in the output and prevents the type collision of the primitives.

## Test plan

- CI
- `make test`
