### PR TITLE
jit logging: fix for codegen v1

### DIFF
--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -30,6 +30,7 @@ namespace oi::detail {
 class FuncGen {
  public:
   static void DeclareExterns(std::string& code);
+  static void DefineJitLog(std::string& code, FeatureSet features);
 
   static void DeclareStoreData(std::string& testCode);
   static void DefineStoreData(std::string& testCode);

--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -3031,29 +3031,6 @@ bool OICodeGen::generateJitCode(std::string& code) {
       #define SAVE_SIZE(val)
       #define SAVE_DATA(val)    StoreData(val, returnArg)
     )");
-
-    if (config.features[Feature::JitLogging]) {
-      code.append(R"(
-        #define JLOG(str)                           \
-          do {                                      \
-            if (__builtin_expect(logFile, 0)) {     \
-              write(logFile, str, sizeof(str) - 1); \
-            }                                       \
-          } while (false)
-
-        #define JLOGPTR(ptr)                    \
-          do {                                  \
-            if (__builtin_expect(logFile, 0)) { \
-              __jlogptr((uintptr_t)ptr);        \
-            }                                   \
-          } while (false)
-      )");
-    } else {
-      code.append(R"(
-        #define JLOG(str)
-        #define JLOGPTR(ptr)
-      )");
-    }
   } else {
     code.append(R"(
       #define SAVE_SIZE(val)    AddData(val, returnArg)
@@ -3062,6 +3039,8 @@ bool OICodeGen::generateJitCode(std::string& code) {
       #define JLOGPTR(ptr)
     )");
   }
+
+  FuncGen::DefineJitLog(code, config.features);
 
   // The purpose of the anonymous namespace within `OIInternal` is that
   // anything defined within an anonymous namespace has internal-linkage,


### PR DESCRIPTION
## Summary

JIT logging was broken in codegen v1 after removing externs from `OITraceCode.cpp`. Move the logic into `FuncGen` so it can be shared between v1 and v2.

## Test plan

- CI

```
$ oid --script-source entry:oid_test_case_simple_struct:arg0 -fjit-logging --pid 2609805
...
$ cat /tmp/*jit*log
SimpleStruct @00007ffeed0a6f00
a @00007ffeed0a6f00
obj @00007ffeed0a6f00
b @00007ffeed0a6f04
obj @00007ffeed0a6f04
c @00007ffeed0a6f08
obj @00007ffeed0a6f08
```

```
$ oid --script-source entry:oid_test_case_simple_struct:arg0 -fjit-logging -ftype-graph --pid 2609805
...
$ cat /tmp/*jit*log
SimpleStruct @00007ffeed0a6f00
a @00007ffeed0a6f00
obj @00007ffeed0a6f00
b @00007ffeed0a6f04
obj @00007ffeed0a6f04
c @00007ffeed0a6f08
obj @00007ffeed0a6f08
```