### PR TITLE
Implement Container V2 for folly::sorted_vector_set

### DIFF
--- a/test/integration/sorted_vector_set.toml
+++ b/test/integration/sorted_vector_set.toml
@@ -5,7 +5,6 @@ definitions = '''
 
 [cases]
   [cases.no_ints]
-    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/320
     param_types = ["const sorted_vector_set<int>&"]
     setup = "return {};"
     expect_json = '''[{
@@ -21,9 +20,14 @@ definitions = '''
         "capacity": 0,
         "elementStaticSize": 4
     }]}]'''
+    expect_json_v2 = '''[{
+      "staticSize": 24,
+      "exclusiveSize": 24,
+      "length": 0,
+      "capacity": 0
+    }]'''
 
   [cases.some_ints]
-    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/320
     param_types = ["const sorted_vector_set<int>&"]
     setup = '''
       sorted_vector_set<int> is;
@@ -49,3 +53,9 @@ definitions = '''
         "elementStaticSize": 4
     }]}]
     '''
+    expect_json_v2 = '''[{
+      "staticSize": 24,
+      "exclusiveSize": 28,
+      "length": 3,
+      "capacity": 4
+    }]'''

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -47,3 +47,41 @@ struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
   }
 };
 """
+
+traversal_func = '''
+auto tail = returnArg.write((uintptr_t)&container)
+                .write(container.capacity())
+                .write(container.size());
+
+for (const auto& el : container) {
+  tail = tail.delegate([&el](auto ret) {
+    return OIInternal::getSizeType<DB>(el, ret);
+  });
+}
+
+return tail.finish();
+'''
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = '''
+el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get<ParsedData::VarInt>(d.val).value });
+'''
+
+[[codegen.processor]]
+type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+func = """
+static constexpr auto childField = make_field<DB, T0>("[]");
+
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats->length = list.length;
+el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(T0);
+
+for (size_t i = 0; i < list.length; i++)
+  stack_ins(childField);
+"""
+


### PR DESCRIPTION
## Summary

folly::sorted_vector_set is a nice simple wrapper over a vector. It forwards the size and capacity of the vector properly, so this is a nice and simple container to support. It has minimal testing already.

## Test plan

- CI
