### PR TITLE
Add the `Incomplete` Type node

### DIFF
--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -123,10 +123,17 @@ Type& DrgnParser::enumerateType(struct drgn_type* type) {
                               std::to_string(kind)};
     }
   } catch (const DrgnParserError& e) {
+    depth_--;
     if (isTypeIncomplete) {
-      t = &makeType<Primitive>(type, Primitive::Kind::Incomplete);
+      const char* typeName = "<incomplete>";
+      if (drgn_type_has_name(type)) {
+        typeName = drgn_type_name(type);
+      } else if (drgn_type_has_tag(type)) {
+        typeName = drgn_type_tag(type);
+      }
+
+      return makeType<Incomplete>(nullptr, typeName);
     } else {
-      depth_--;
       throw e;
     }
   }

--- a/oi/type_graph/EnforceCompatibility.cpp
+++ b/oi/type_graph/EnforceCompatibility.cpp
@@ -78,6 +78,12 @@ void EnforceCompatibility::visit(Class& c) {
       return true;
 
     if (auto* ptr = dynamic_cast<Pointer*>(&member.type())) {
+      if (auto* incomplete = dynamic_cast<Incomplete*>(&ptr->pointeeType())) {
+        // This is a pointer to an incomplete type. CodeGen v1 does not record
+        // the pointer's address in this case.
+        return true;
+      }
+
       if (auto* primitive = dynamic_cast<Primitive*>(&ptr->pointeeType())) {
         if (primitive->kind() == Primitive::Kind::Incomplete) {
           // This is a pointer to an incomplete type. CodeGen v1 does not record

--- a/oi/type_graph/EnforceCompatibility.cpp
+++ b/oi/type_graph/EnforceCompatibility.cpp
@@ -83,14 +83,6 @@ void EnforceCompatibility::visit(Class& c) {
         // the pointer's address in this case.
         return true;
       }
-
-      if (auto* primitive = dynamic_cast<Primitive*>(&ptr->pointeeType())) {
-        if (primitive->kind() == Primitive::Kind::Incomplete) {
-          // This is a pointer to an incomplete type. CodeGen v1 does not record
-          // the pointer's address in this case.
-          return true;
-        }
-      }
     }
 
     return false;

--- a/oi/type_graph/Flattener.cpp
+++ b/oi/type_graph/Flattener.cpp
@@ -56,9 +56,7 @@ void flattenParent(const Parent& parent,
     // Create a new member to represent this parent container
     flattenedMembers.emplace_back(*parentContainer, Flattener::ParentPrefix,
                                   parent.bitOffset);
-  } else if (auto* parentPrimitive = dynamic_cast<Primitive*>(&parentType);
-             parentPrimitive &&
-             parentPrimitive->kind() == Primitive::Kind::Incomplete) {
+  } else if (auto* parentPrimitive = dynamic_cast<Incomplete*>(&parentType)) {
     // Bad DWARF can lead to us seeing incomplete parent types. Just ignore
     // these as there is nothing we can do to recover the missing info.
   } else {

--- a/oi/type_graph/Printer.cpp
+++ b/oi/type_graph/Printer.cpp
@@ -36,6 +36,12 @@ void Printer::print(const Type& type) {
   depth_--;
 }
 
+void Printer::visit(const Incomplete& i) {
+  prefix();
+  out_ << "Incomplete:" << std::endl;
+  print(i.underlyingType());
+}
+
 void Printer::visit(const Class& c) {
   if (prefix(c))
     return;

--- a/oi/type_graph/Printer.cpp
+++ b/oi/type_graph/Printer.cpp
@@ -38,8 +38,13 @@ void Printer::print(const Type& type) {
 
 void Printer::visit(const Incomplete& i) {
   prefix();
-  out_ << "Incomplete:" << std::endl;
-  print(i.underlyingType());
+  out_ << "Incomplete";
+  if (auto underlyingType = i.underlyingType()) {
+    out_ << std::endl;
+    print(underlyingType.value().get());
+  } else {
+    out_ << ": [" << i.inputName() << "]" << std::endl;
+  }
 }
 
 void Printer::visit(const Class& c) {
@@ -97,10 +102,7 @@ void Printer::visit(const Container& c) {
 
 void Printer::visit(const Primitive& p) {
   prefix();
-  out_ << "Primitive: " << p.name();
-  if (p.kind() == Primitive::Kind::Incomplete)
-    out_ << " (incomplete)";
-  out_ << std::endl;
+  out_ << "Primitive: " << p.name() << std::endl;
 }
 
 void Printer::visit(const Enum& e) {

--- a/oi/type_graph/Printer.h
+++ b/oi/type_graph/Printer.h
@@ -32,6 +32,7 @@ class Printer : public ConstVisitor {
 
   void print(const Type& type);
 
+  void visit(const Incomplete& i) override;
   void visit(const Class& c) override;
   void visit(const Container& c) override;
   void visit(const Primitive& p) override;

--- a/oi/type_graph/TypeGraph.cpp
+++ b/oi/type_graph/TypeGraph.cpp
@@ -65,9 +65,6 @@ Primitive& TypeGraph::makeType<Primitive>(Primitive::Kind kind) {
     case Primitive::Kind::Void:
       static Primitive pVoid{kind};
       return pVoid;
-    case Primitive::Kind::Incomplete:
-      static Primitive pIncomplete{kind};
-      return pIncomplete;
   }
 }
 

--- a/oi/type_graph/Types.cpp
+++ b/oi/type_graph/Types.cpp
@@ -29,6 +29,8 @@ namespace oi::detail::type_graph {
 OI_TYPE_LIST
 #undef X
 
+const std::string Incomplete::kName = "void";
+
 std::string Primitive::getName(Kind kind) {
   switch (kind) {
     case Kind::Int8:

--- a/oi/type_graph/Types.cpp
+++ b/oi/type_graph/Types.cpp
@@ -62,7 +62,6 @@ std::string Primitive::getName(Kind kind) {
     case Kind::StubbedPointer:
       return "StubbedPointer";
     case Kind::Void:
-    case Kind::Incomplete:
       return "void";
   }
 }
@@ -105,7 +104,6 @@ std::size_t Primitive::size() const {
     case Kind::StubbedPointer:
       return sizeof(uintptr_t);
     case Kind::Void:
-    case Kind::Incomplete:
       return 0;
   }
 }

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -40,6 +40,7 @@
 #include "oi/EnumBitset.h"
 
 #define OI_TYPE_LIST \
+  X(Incomplete)      \
   X(Class)           \
   X(Container)       \
   X(Primitive)       \
@@ -173,6 +174,49 @@ struct TemplateParam {
  public:
   QualifierSet qualifiers;
   std::optional<std::string> value;
+};
+
+/*
+ * Incomplete
+ *
+ * A wrapper around a type we couldn't determine the size of.
+ */
+class Incomplete : public Type {
+ public:
+  Incomplete(Type& underlyingType) : underlyingType_(underlyingType) {
+  }
+
+  static inline constexpr bool has_node_id = false;
+
+  DECLARE_ACCEPT
+
+  const std::string& name() const override {
+    return kName;
+  }
+
+  std::string_view inputName() const override {
+    return underlyingType_.inputName();
+  }
+
+  size_t size() const override {
+    return 0;
+  }
+
+  uint64_t align() const override {
+    return 0;
+  }
+
+  NodeId id() const override {
+    return -1;
+  }
+
+  Type& underlyingType() const {
+    return underlyingType_;
+  }
+
+ private:
+  Type& underlyingType_;
+  static const std::string kName;
 };
 
 /*

--- a/oi/type_graph/Visitor.h
+++ b/oi/type_graph/Visitor.h
@@ -71,6 +71,8 @@ class RecursiveVisitor : public Visitor {
     if (type)
       accept(*type);
   }
+  virtual void visit(Incomplete&) {
+  }
   virtual void visit(Class& c) {
     for (const auto& param : c.templateParams) {
       accept(param.type());

--- a/test/TypeGraphParser.cpp
+++ b/test/TypeGraphParser.cpp
@@ -211,6 +211,9 @@ Type& TypeGraphParser::parseType(std::string_view& input, size_t rootIndent) {
                                  std::to_string(refId)};
 
     type = &it->second.get();
+  } else if (nodeTypeName == "Incomplete") {
+    auto& underlyingType = parseType(input, indent + 2);
+    type = &typeGraph_.makeType<Incomplete>(underlyingType);
   } else if (nodeTypeName == "Class" || nodeTypeName == "Struct" ||
              nodeTypeName == "Union") {
     // Format: "Class: MyClass (size: 12)"

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -367,8 +367,7 @@ TEST_F(DrgnParserTest, PointerNoFollow) {
 TEST_F(DrgnParserTest, PointerIncomplete) {
   test("oid_test_case_pointers_incomplete_raw", R"(
 [0] Pointer
-      Incomplete:
-        Primitive: void (incomplete)
+      Incomplete: [IncompleteType]
 )");
 }
 

--- a/test/test_drgn_parser.cpp
+++ b/test/test_drgn_parser.cpp
@@ -367,7 +367,8 @@ TEST_F(DrgnParserTest, PointerNoFollow) {
 TEST_F(DrgnParserTest, PointerIncomplete) {
   test("oid_test_case_pointers_incomplete_raw", R"(
 [0] Pointer
-      Primitive: void (incomplete)
+      Incomplete:
+        Primitive: void (incomplete)
 )");
 }
 

--- a/test/test_enforce_compatibility.cpp
+++ b/test/test_enforce_compatibility.cpp
@@ -36,7 +36,8 @@ TEST(EnforceCompatibilityTest, VoidPointer) {
 [0] Class: MyClass (size: 8)
       Member: p (offset: 0)
 [1]     Pointer
-          Primitive: void (incomplete)
+          Incomplete
+            Primitive: void
 )",
        R"(
 [0] Class: MyClass (size: 8)

--- a/test/test_flattener.cpp
+++ b/test/test_flattener.cpp
@@ -958,7 +958,7 @@ TEST(FlattenerTest, IncompleteParent) {
   test(Flattener::createPass(), R"(
 [0] Class: MyClass (size: 4)
       Parent (offset: 0)
-        Primitive: void (incomplete)
+        Incomplete: [IncompleteParent]
 )",
        R"(
 [0] Class: MyClass (size: 4)


### PR DESCRIPTION
## Summary
Any Incomplete type encountered by the DrgnReader gets effectively turned into a Primitive::Kind::Void. This makes debugging these issues fairly difficult, as we lose all information regarding the Incomplete type.

This PR changes this behaviour, so that we can still identify the type that got classified as Incomplete.

## Test plan
Update the test "DrgnParserTest.PointerIncomplete" to take the new `Incomplete` node into account.
Update the `TypeGraphParser` to rebuild the `Incomplete` node.
