### PR TITLE
support 0 to many config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,11 +278,11 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(oi)
 add_subdirectory(resources)
 add_library(oicore
+  oi/Config.cpp
   oi/Descs.cpp
   oi/Metrics.cpp
   oi/OICache.cpp
   oi/OICompiler.cpp
-  oi/OIUtils.cpp
   oi/PaddingHunter.cpp
   oi/Serialize.cpp
 )

--- a/include/oi/oi-jit.h
+++ b/include/oi/oi-jit.h
@@ -34,7 +34,7 @@ class OILibraryImpl;
 namespace oi {
 
 struct GeneratorOptions {
-  std::filesystem::path configFilePath;
+  std::vector<std::filesystem::path> configFilePaths;
   std::filesystem::path sourceFileDumpPath;
   int debugLevel = 0;
 };

--- a/oi/Config.h
+++ b/oi/Config.h
@@ -15,18 +15,21 @@
  */
 #pragma once
 
+#include <filesystem>
 #include <optional>
 #include <set>
+#include <span>
 
 #include "oi/Features.h"
 #include "oi/OICodeGen.h"
 #include "oi/OICompiler.h"
 
-namespace oi::detail::utils {
+namespace oi::detail::config {
 
-std::optional<FeatureSet> processConfigFile(const std::string& configFilePath,
-                                            std::map<Feature, bool> featureMap,
-                                            OICompiler::Config& compilerConfig,
-                                            OICodeGen::Config& generatorConfig);
+std::optional<FeatureSet> processConfigFiles(
+    std::span<const std::filesystem::path> configFilePaths,
+    std::map<Feature, bool> featureMap,
+    OICompiler::Config& compilerConfig,
+    OICodeGen::Config& generatorConfig);
 
-}  // namespace oi::detail::utils
+}  // namespace oi::detail::config

--- a/oi/EnumBitset.h
+++ b/oi/EnumBitset.h
@@ -47,6 +47,11 @@ class EnumBitset {
     return bitset.none();
   }
 
+  EnumBitset<T, N>& operator|=(const EnumBitset<T, N>& that) {
+    bitset |= that.bitset;
+    return *this;
+  }
+
  private:
   BitsetType bitset;
 };

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -45,11 +45,11 @@ extern "C" {
 #include <glog/logging.h>
 
 #include "oi/CodeGen.h"
+#include "oi/Config.h"
 #include "oi/ContainerInfo.h"
 #include "oi/Headers.h"
 #include "oi/Metrics.h"
 #include "oi/OILexer.h"
-#include "oi/OIUtils.h"
 #include "oi/PaddingHunter.h"
 #include "oi/Syscall.h"
 #include "oi/type_graph/DrgnParser.h"

--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -26,9 +26,9 @@
 #include <variant>
 
 #include "oi/CodeGen.h"
+#include "oi/Config.h"
 #include "oi/DrgnUtils.h"
 #include "oi/Headers.h"
-#include "oi/OIUtils.h"
 
 namespace oi::detail {
 
@@ -193,8 +193,9 @@ int OIGenerator::generate(fs::path& primaryObject, SymbolService& symbols) {
   OICompiler::Config compilerConfig{};
   compilerConfig.usePIC = pic;
 
-  auto features = utils::processConfigFile(configFilePath, featuresMap,
-                                           compilerConfig, generatorConfig);
+  auto features =
+      config::processConfigFiles(std::vector<fs::path>{configFilePath},
+                                 featuresMap, compilerConfig, generatorConfig);
   if (!features) {
     LOG(ERROR) << "failed to process config file";
     return -1;

--- a/oi/OILibraryImpl.cpp
+++ b/oi/OILibraryImpl.cpp
@@ -25,9 +25,9 @@
 #include <fstream>
 #include <stdexcept>
 
+#include "oi/Config.h"
 #include "oi/DrgnUtils.h"
 #include "oi/Headers.h"
-#include "oi/OIUtils.h"
 
 namespace oi::detail {
 namespace {
@@ -94,8 +94,8 @@ std::pair<void*, const exporters::inst::Inst&> OILibraryImpl::init() {
 
 void OILibraryImpl::processConfigFile() {
   auto features =
-      utils::processConfigFile(opts_.configFilePath, requestedFeatures_,
-                               compilerConfig_, generatorConfig_);
+      config::processConfigFiles(opts_.configFilePaths, requestedFeatures_,
+                                 compilerConfig_, generatorConfig_);
   if (!features)
     throw std::runtime_error("failed to process configuration");
 

--- a/test/integration/runner_common.h
+++ b/test/integration/runner_common.h
@@ -9,6 +9,7 @@
 #include <future>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 struct OidOpts {
   boost::asio::io_context& ctx;
@@ -42,8 +43,8 @@ class IntegrationBase : public ::testing::Test {
   void TearDown() override;
   void SetUp() override;
   int exit_code(Proc& proc);
-  std::filesystem::path createCustomConfig(const std::string& prefix,
-                                           const std::string& suffix);
+  std::optional<std::filesystem::path> writeCustomConfig(
+      std::string_view filePrefix, std::string_view content);
 
   std::filesystem::path workingDir;
 


### PR DESCRIPTION
## Summary

Previously OID/OIL required exactly one configuration file. This change makes it so you can supply 0 or more configuration files. 0 is useful if you have pre-generated the cache or use some sort of remote generation system. 1 is useful for the common case, where you have a configuration file that describes your entire source and use just that. More are useful if you have supplemental bits of config you wish to apply/override - see the changes to the integration test framework where we do exactly this.

## Test plan

This isn't super well tested. It works for the test cases which add features via the config or enable `codegen.ignore`.

- CI
