### PR TITLE
oilgen: accept multiple config files

### DIFF
--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -193,9 +193,8 @@ int OIGenerator::generate(fs::path& primaryObject, SymbolService& symbols) {
   OICompiler::Config compilerConfig{};
   compilerConfig.usePIC = pic;
 
-  auto features =
-      config::processConfigFiles(std::vector<fs::path>{configFilePath},
-                                 featuresMap, compilerConfig, generatorConfig);
+  auto features = config::processConfigFiles(configFilePaths, featuresMap,
+                                             compilerConfig, generatorConfig);
   if (!features) {
     LOG(ERROR) << "failed to process config file";
     return -1;

--- a/oi/OIGenerator.h
+++ b/oi/OIGenerator.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <filesystem>
+#include <vector>
 
 #include "oi/DrgnUtils.h"
 #include "oi/OICodeGen.h"
@@ -31,8 +32,8 @@ class OIGenerator {
   void setOutputPath(fs::path _outputPath) {
     outputPath = std::move(_outputPath);
   }
-  void setConfigFilePath(fs::path _configFilePath) {
-    configFilePath = std::move(_configFilePath);
+  void setConfigFilePaths(std::vector<fs::path> _configFilePaths) {
+    configFilePaths = std::move(_configFilePaths);
   }
   void setSourceFileDumpPath(fs::path _sourceFileDumpPath) {
     sourceFileDumpPath = std::move(_sourceFileDumpPath);
@@ -46,7 +47,7 @@ class OIGenerator {
 
  private:
   std::filesystem::path outputPath;
-  std::filesystem::path configFilePath;
+  std::vector<std::filesystem::path> configFilePaths;
   std::filesystem::path sourceFileDumpPath;
   bool failIfNothingGenerated = false;
   bool pic = false;

--- a/tools/OILGen.cpp
+++ b/tools/OILGen.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
+#include <vector>
 
 #include "oi/OICodeGen.h"
 #include "oi/OIGenerator.h"
@@ -61,7 +62,7 @@ int main(int argc, char* argv[]) {
   FLAGS_stderrthreshold = 0;
 
   fs::path outputPath = "a.o";
-  fs::path configFilePath = "/usr/local/share/oi/base.oid.toml";
+  std::vector<fs::path> configFilePaths;
   fs::path sourceFileDumpPath = "";
   bool exitCode = false;
   bool pic = false;
@@ -77,7 +78,7 @@ int main(int argc, char* argv[]) {
         outputPath = optarg;
         break;
       case 'c':
-        configFilePath = optarg;
+        configFilePaths.emplace_back(optarg);
         break;
       case 'd':
         google::LogToStderr();
@@ -114,7 +115,7 @@ int main(int argc, char* argv[]) {
   OIGenerator oigen;
 
   oigen.setOutputPath(std::move(outputPath));
-  oigen.setConfigFilePath(std::move(configFilePath));
+  oigen.setConfigFilePaths(std::move(configFilePaths));
   oigen.setSourceFileDumpPath(sourceFileDumpPath);
   oigen.setFailIfNothingGenerated(exitCode);
   oigen.setUsePIC(pic);


### PR DESCRIPTION
Summary: Extend the multiple config files system to OILGen, the piece it was originally designed for. This allows for specifying additional configs which say which keys of maps to capture.

Differential Revision: D50105138


