### PR TITLE
tbv2: add a repeat instruction

### DIFF
--- a/include/oi/exporters/inst.h
+++ b/include/oi/exporters/inst.h
@@ -32,14 +32,24 @@ namespace oi::exporters::inst {
 
 struct PopTypePath;
 struct Field;
+struct Repeat;
 
-using Inst = std::variant<PopTypePath, std::reference_wrapper<const Field>>;
+using Inst =
+    std::variant<PopTypePath, Repeat, std::reference_wrapper<const Field>>;
 using Processor = void (*)(result::Element&,
                            std::function<void(Inst)>,
                            ParsedData);
 using ProcessorInst = std::pair<types::dy::Dynamic, Processor>;
 
 struct PopTypePath {};
+
+struct Repeat {
+  constexpr Repeat(size_t n_, const Field& field_) : n(n_), field(field_) {
+  }
+
+  size_t n;
+  std::reference_wrapper<const Field> field;
+};
 
 struct Field {
   template <size_t N0, size_t N1, size_t N2>

--- a/oi/IntrospectionResult.cpp
+++ b/oi/IntrospectionResult.cpp
@@ -44,6 +44,12 @@ IntrospectionResult::const_iterator::operator++() {
           type_path_.pop_back();
           dynamic_type_path_.pop_back();
           return operator++();
+        } else if constexpr (std::is_same_v<U, exporters::inst::Repeat>) {
+          if (r.n-- != 0) {
+            stack_.emplace(r);
+            stack_.emplace(r.field);
+          }
+          return operator++();
         } else {
           // reference wrapper
           auto ty = r.get();

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -101,6 +101,5 @@ auto list = std::get<ParsedData::List>(d.val);
 el.container_stats->length = list.length;
 el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(T0);
 
-for (size_t i = 0; i < list.length; i++)
-  stack_ins(childField);
+stack_ins(inst::Repeat{ list.length, childField });
 """


### PR DESCRIPTION
## Summary

Currently a container type has to do many instruction stack pushes depending on the number of fields. This might cause several allocations and wastes a lot of memory. Add a `Repeat` type which stores a field and a number of times it should be repeated. This causes the instruction stack size to grow by O(1) for a very large container instead of O(n).

The downside is this is a double sized instruction and increases the instruction variant from 16 bytes to 24. An alternative would be heap allocating it, but that can be complicated by the JIT boundary and feels slow. Go with this for now and profile it later if necessary.

Converted vector, the simplest sequence type, to have its tests run.

## Test plan

- CI
