### PR TITLE
tbv2: change instruction stack from deque to vector

### DIFF
--- a/include/oi/IntrospectionResult.h
+++ b/include/oi/IntrospectionResult.h
@@ -44,12 +44,15 @@ class IntrospectionResult {
     const_iterator operator++(int);
 
    private:
+    using stack_t =
+        std::stack<exporters::inst::Inst, std::vector<exporters::inst::Inst>>;
+
     const_iterator(std::vector<uint8_t>::const_iterator data,
                    exporters::inst::Inst type);
     const_iterator(std::vector<uint8_t>::const_iterator data);
 
     std::vector<uint8_t>::const_iterator data_;
-    std::stack<exporters::inst::Inst> stack_;
+    stack_t stack_;
     std::optional<result::Element> next_;
 
     std::vector<std::string_view> type_path_;


### PR DESCRIPTION
## Summary

Changes the implementation of the iterator instruction stack from `std::deque` to `std::vector`. This means a few things:
- No reference stability. We don't currently use it and it will stop us accidentally using it.
- Smaller allocations with few elements. `std::deque` allocates a tonne of memory when it contains even a single element, so is inefficient with small sizes.
- Better spatial locality. The contiguous nature of a vector is good for spatial locality, which makes sense here as we use this as a stack.

## Test plan

- CI
