### PR TITLE
add portability.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
-add_compile_definitions(OSS_ENABLE)
-
 include(FetchContent)
 set(FETCHCONTENT_QUIET FALSE)
 

--- a/oi/OICache.cpp
+++ b/oi/OICache.cpp
@@ -23,9 +23,10 @@
 
 #include "oi/Descs.h"
 #include "oi/OICodeGen.h"
+#include "oi/Portability.h"
 #include "oi/Serialize.h"
 
-#ifndef OSS_ENABLE
+#if OI_PORTABILITY_META_INTERNAL()
 #include "object-introspection/internal/GobsService.h"
 #include "object-introspection/internal/ManifoldCache.h"
 #endif
@@ -163,7 +164,7 @@ INSTANTIATE_ARCHIVE(std::map<std::string, PaddingInfo>)
 
 // Upload all contents of cache for this request
 bool OICache::upload([[maybe_unused]] const irequest& req) {
-#ifndef OSS_ENABLE
+#if OI_PORTABILITY_META_INTERNAL()
   if (!isEnabled() || downloadedRemote || !enableUpload)
     return true;
   std::vector<std::filesystem::path> files;
@@ -197,7 +198,7 @@ bool OICache::upload([[maybe_unused]] const irequest& req) {
 
 // Try to fetch contents of cache
 bool OICache::download([[maybe_unused]] const irequest& req) {
-#ifndef OSS_ENABLE
+#if OI_PORTABILITY_META_INTERNAL()
   if (!isEnabled() || !enableDownload)
     return true;
 
@@ -244,7 +245,7 @@ std::string OICache::generateRemoteHash(const irequest& req) {
 
   std::string remote_cache_id = *buildID + "/" + req.func + "/" + req.arg +
                                 "/" + generatorConfig.toString();
-#ifndef OSS_ENABLE
+#if OI_PORTABILITY_META_INTERNAL()
   auto version_pair = ObjectIntrospection::GobsService::getOidRpmVersions();
   remote_cache_id += "/" + version_pair.first + "/" + version_pair.second;
 #endif

--- a/oi/OID.cpp
+++ b/oi/OID.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
@@ -37,8 +36,13 @@ extern "C" {
 #include "oi/OIDebugger.h"
 #include "oi/OIOpts.h"
 #include "oi/PaddingHunter.h"
+#include "oi/Portability.h"
 #include "oi/TimeUtils.h"
 #include "oi/TreeBuilder.h"
+
+#if OI_PORTABILITY_META_INTERNAL()
+#include <folly/init/Init.h>
+#endif
 
 namespace oi::detail {
 
@@ -480,7 +484,8 @@ int main(int argc, char* argv[]) {
   bool dumpDataSegment = false;
 
   metrics::Tracing _("main");
-#ifndef OSS_ENABLE
+
+#if OI_PORTABILITY_META_INTERNAL()
   folly::InitOptions init;
   init.useGFlags(false);
   init.removeFlags(false);

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -51,11 +51,12 @@ extern "C" {
 #include "oi/Metrics.h"
 #include "oi/OILexer.h"
 #include "oi/PaddingHunter.h"
+#include "oi/Portability.h"
 #include "oi/Syscall.h"
 #include "oi/type_graph/DrgnParser.h"
 #include "oi/type_graph/TypeGraph.h"
 
-#ifndef OSS_ENABLE
+#if OI_PORTABILITY_META_INTERNAL()
 #include "object-introspection/internal/GobsService.h"
 #endif
 
@@ -2147,7 +2148,7 @@ bool OIDebugger::compileCode() {
     if (cache.isEnabled()) {
       // try to download cache artifacts if present
       if (!downloadCache()) {
-#ifndef OSS_ENABLE
+#if OI_PORTABILITY_META_INTERNAL()
         // Send a request to the GOBS service
         char buf[PATH_MAX];
         const std::string procpath =

--- a/oi/Portability.h
+++ b/oi/Portability.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace oi::detail {
+
+#ifdef OI_META_INTERNAL
+
+#define OI_PORTABILITY_META_INTERNAL() 1
+static constexpr bool kIsMetaInternal = true;
+
+#else
+
+#define OI_PORTABILITY_META_INTERNAL() 0
+static constexpr bool kIsMetaInternal = false;
+
+#endif
+
+}  // namespace oi::detail


### PR DESCRIPTION
Summary:
Spin around our open/closed source checks. Previously we defined `OSS_ENABLE` in open source builds. This change defines `OI_META_INTERNAL` instead. This is nicer, as external users don't have to do anything special to get a working build.

Use this new macro to define a boolean constant in a new header `Portability.h`. This is inspired by Folly, and makes the internal build easier - definitions in Buck2 have to propagate up from a dependency instead of down from one. Annoyingly we can't use `if constexpr` for a lot of the previous `#ifdef` blocks as we conditionally include the headers. Longer term we could fix this by exposing a header interface but no source, allowing these to build but not be compiled in. For now I did something weird: I defined a function style macro in `Portability.h` based on the compile time macro. This forces you to have included `Portability.h` before using it to ensure the definition is everywhere. Open to feedback as I haven't seen anyone else do this.

Differential Revision: D50000454


