### PR TITLE
tbv2: fix exclusive size of elements in containers

### DIFF
--- a/test/integration/std_vector.toml
+++ b/test/integration/std_vector.toml
@@ -1,4 +1,13 @@
 includes = ["vector"]
+
+definitions = '''
+  struct SimpleStruct {
+    int a;
+    char b;
+    long long c;
+  };
+'''
+
 [cases]
   [cases.int_empty]
     param_types = ["const std::vector<int>&"]
@@ -13,6 +22,15 @@ includes = ["vector"]
       {"staticSize":4, "exclusiveSize":4},
       {"staticSize":4, "exclusiveSize":4},
       {"staticSize":4, "exclusiveSize":4}
+    ]}]'''
+  [cases.struct_some]
+    param_types = ["const std::vector<SimpleStruct>&"]
+    setup = "return {{{}, {}, {}}};"
+    expect_json = '[{"staticSize":24, "dynamicSize":48, "length":3, "capacity":3, "elementStaticSize":16}]'
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "length":3, "capacity":3, "members":[
+      {"staticSize":16, "exclusiveSize":3},
+      {"staticSize":16, "exclusiveSize":3},
+      {"staticSize":16, "exclusiveSize":3}
     ]}]'''
   [cases.bool_empty]
     skip = true # https://github.com/facebookexperimental/object-introspection/issues/14

--- a/test/integration/std_vector_del_allocator.toml
+++ b/test/integration/std_vector_del_allocator.toml
@@ -27,7 +27,6 @@ includes = ["vector"]
 
 [cases]
   [cases.a]
-    oil_skip = "oil gets the exclusive size of vector subfields wrong" # https://github.com/facebookexperimental/object-introspection/issues/301
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;


### PR DESCRIPTION
## Summary

Exclusive size of fields in containers was previously incomplete, assuming the exclusive size to be static size. This is incorrect for classes as the exclusive size should be set to the size of the class less the size of each member, in other words the padding of the class.

Add an `ExclusiveSizeProvider` similar to `NameProvider`, which defaults to `sizeof(T)` but allows overriding for types which need it.

Closes #301

## Test plan

- CI
- Added a new test for vector containing struct
- Enabled skipped test
