### PR TITLE
oil: add fallible build option

### DIFF
--- a/include/oi/oi.h
+++ b/include/oi/oi.h
@@ -20,6 +20,7 @@
 #include <oi/types/dy.h>
 
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -30,9 +31,6 @@ enum class Feature {
   CaptureThriftIsset,
   GenJitDebug,
 };
-
-template <typename T, Feature... Fs>
-IntrospectionResult __attribute__((noinline)) introspect(const T& objectAddr);
 
 #ifdef OIL_AOT_COMPILATION
 
@@ -46,6 +44,16 @@ IntrospectionResult introspect(const T& objectAddr) {
         "OIL is expecting AoT compilation but it doesn't appear to have run.");
 
   return introspectImpl<T, Fs...>(objectAddr);
+}
+
+template <typename T, Feature... Fs>
+std::optional<IntrospectionResult> tryIntrospect(const T& objectAddr) {
+  if (!introspectImpl<T, Fs...>)
+    return std::nullopt;
+
+  // This checks twice but is necessary for compile time as it currently
+  // depends on the presence of the strong symbol.
+  return introspect(objectAddr);
 }
 
 #endif


### PR DESCRIPTION
Summary: Add a second form for OIL AoT compilation which returns a `std::optional` instead of throwing. This is preferred if it's possible for the symbol to not be defined and you must not throw, instead preferring to handle the failure a different way. This still calls the throwing interface as that's what oilgen depends on, but makes sure the precondition is true first such that it won't throw.

Differential Revision: D50363926


