### PR TITLE
compiler: update to c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,11 +251,6 @@ if (STATIC_LINK)
   set_property(TARGET glog PROPERTY INTERFACE_LINK_LIBRARIES "gflags_static")
 endif()
 
-# FIXME: LLVM 12's source code is not compatible with C++20.
-# We should check with the compiler team if we could apply a fix to our LLVM.
-# In the meantime, we can compile OICompiler with C++17.
-set_source_files_properties(oi/OICompiler.cpp PROPERTIES COMPILE_FLAGS -std=c++17 SKIP_PRECOMPILE_HEADERS ON)
-
 
 
 ## OI Dependencies (linked to by output libraries and executables)

--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -121,7 +121,7 @@ OICompiler::Disassembler::operator()() {
   };
 
   offset += instSize;
-  funcText.remove_prefix(instSize);
+  funcText = funcText.subspan(instSize);
 
   return inst;
 }


### PR DESCRIPTION
## Summary

`OICompiler.cpp` was stuck on C++17 while the rest of the project is C++20. This is annoying and complicates things, like not being able to use `std::span`s in this single file. Remove this restriction as LLVM15 doesn't have any problems with it, and replace the `std::string_view<uint8_t>` with a proper `std::span<uint8_t>`.

## Test plan

- CI
- `make test`

Disassembly LGTM:
```
$ stest OidIntegration.simple_struct
...
Disassembled Code
I1024 07:37:05.675088 847381 OICompiler.cpp:460] 7f9222a00080:  push    r14
I1024 07:37:05.675093 847381 OICompiler.cpp:460] 7f9222a00082:  push    rbx
I1024 07:37:05.675096 847381 OICompiler.cpp:460] 7f9222a00083:  push    rax
I1024 07:37:05.675101 847381 OICompiler.cpp:460] 7f9222a00084:  mov     rbx, rdi
I1024 07:37:05.675109 847381 OICompiler.cpp:460] 7f9222a00087:  movabs  r14, 0x7f9222a00280
I1024 07:37:05.675113 847381 OICompiler.cpp:460] 7f9222a00091:  movabs  rax, 0x7f92230af3c0
I1024 07:37:05.675117 847381 OICompiler.cpp:460] 7f9222a0009b:  mov     edx, 0x100000
I1024 07:37:05.675120 847381 OICompiler.cpp:460] 7f9222a000a0:  mov     rdi, r14
I1024 07:37:05.675123 847381 OICompiler.cpp:460] 7f9222a000a3:  xor     esi, esi
I1024 07:37:05.675127 847381 OICompiler.cpp:460] 7f9222a000a5:  call    rax
I1024 07:37:05.675129 847381 OICompiler.cpp:460] 7f9222a000a7:  mov     rax, rbx
I1024 07:37:05.675149 847381 OICompiler.cpp:460] 7f9222a000aa:  not     rax
I1024 07:37:05.675153 847381 OICompiler.cpp:460] 7f9222a000ad:  mov     rcx, rbx
I1024 07:37:05.675156 847381 OICompiler.cpp:460] 7f9222a000b0:  shl     rcx, 0x15
I1024 07:37:05.675159 847381 OICompiler.cpp:460] 7f9222a000b4:  add     rcx, rax
I1024 07:37:05.675163 847381 OICompiler.cpp:460] 7f9222a000b7:  mov     rax, rcx
I1024 07:37:05.675165 847381 OICompiler.cpp:460] 7f9222a000ba:  shr     rax, 0x18
I1024 07:37:05.675168 847381 OICompiler.cpp:460] 7f9222a000be:  xor     rax, rcx
I1024 07:37:05.675172 847381 OICompiler.cpp:460] 7f9222a000c1:  imul    rax, rax, 0x109
I1024 07:37:05.675174 847381 OICompiler.cpp:460] 7f9222a000c8:  mov     rcx, rax
I1024 07:37:05.675177 847381 OICompiler.cpp:460] 7f9222a000cb:  shr     rcx, 0xe
I1024 07:37:05.675180 847381 OICompiler.cpp:460] 7f9222a000cf:  xor     rcx, rax
I1024 07:37:05.675185 847381 OICompiler.cpp:460] 7f9222a000d2:  lea     rax, [rcx + 4*rcx]
I1024 07:37:05.675189 847381 OICompiler.cpp:460] 7f9222a000d6:  lea     rcx, [rcx + 4*rax]
I1024 07:37:05.675190 847381 OICompiler.cpp:460] 7f9222a000da:  mov     rax, rcx
I1024 07:37:05.675194 847381 OICompiler.cpp:460] 7f9222a000dd:  shr     rax, 0x1c
I1024 07:37:05.675196 847381 OICompiler.cpp:460] 7f9222a000e1:  xor     eax, ecx
I1024 07:37:05.675200 847381 OICompiler.cpp:460] 7f9222a000e3:  and     eax, 0x1ffff
I1024 07:37:05.675204 847381 OICompiler.cpp:460] 7f9222a000e8:  mov     rcx, qword ptr [r14 + 8*rax]
I1024 07:37:05.675206 847381 OICompiler.cpp:460] 7f9222a000ec:  test    rcx, rcx
I1024 07:37:05.675215 847381 OICompiler.cpp:460] 7f9222a000ef:  je      0x26
I1024 07:37:05.675223 847381 OICompiler.cpp:460] 7f9222a000f1:  nop     word ptr cs:[rax + rax]
I1024 07:37:05.675227 847381 OICompiler.cpp:460] 7f9222a000fb:  nop     dword ptr [rax + rax]
I1024 07:37:05.675230 847381 OICompiler.cpp:460] 7f9222a00100:  cmp     rcx, rbx
I1024 07:37:05.675233 847381 OICompiler.cpp:460] 7f9222a00103:  je      0x19
I1024 07:37:05.675236 847381 OICompiler.cpp:460] 7f9222a00105:  inc     eax
I1024 07:37:05.675240 847381 OICompiler.cpp:460] 7f9222a00107:  and     eax, 0x1ffff
I1024 07:37:05.675242 847381 OICompiler.cpp:460] 7f9222a0010c:  mov     rcx, qword ptr [r14 + 8*rax]
I1024 07:37:05.675244 847381 OICompiler.cpp:460] 7f9222a00110:  test    rcx, rcx
I1024 07:37:05.675248 847381 OICompiler.cpp:460] 7f9222a00113:  jne     0xffffffffffffffed
I1024 07:37:05.675251 847381 OICompiler.cpp:460] 7f9222a00115:  lea     rax, [r14 + 8*rax]
I1024 07:37:05.675254 847381 OICompiler.cpp:460] 7f9222a00119:  mov     qword ptr [rax], rbx
I1024 07:37:05.675257 847381 OICompiler.cpp:460] 7f9222a0011c:  movabs  rax, 0x7f9222a00040
I1024 07:37:05.675261 847381 OICompiler.cpp:460] 7f9222a00126:  mov     rcx, qword ptr [rax]
I1024 07:37:05.675274 847381 OICompiler.cpp:460] 7f9222a00129:  mov     qword ptr [rcx], 0x1de8
I1024 07:37:05.675278 847381 OICompiler.cpp:460] 7f9222a00130:  movabs  rdx, 0x7f9222a00050
I1024 07:37:05.675280 847381 OICompiler.cpp:460] 7f9222a0013a:  mov     rdx, qword ptr [rdx]
I1024 07:37:05.675284 847381 OICompiler.cpp:460] 7f9222a0013d:  mov     qword ptr [rcx + 0x8], rdx
I1024 07:37:05.675287 847381 OICompiler.cpp:460] 7f9222a00141:  mov     qword ptr [rcx + 0x10], 0x0
I1024 07:37:05.675290 847381 OICompiler.cpp:460] 7f9222a00149:  movabs  rsi, 0x7f9222a00048
I1024 07:37:05.675293 847381 OICompiler.cpp:460] 7f9222a00153:  mov     rdi, qword ptr [rsi]
I1024 07:37:05.675297 847381 OICompiler.cpp:460] 7f9222a00156:  mov     edx, 0x24
I1024 07:37:05.675299 847381 OICompiler.cpp:460] 7f9222a0015b:  cmp     rdi, 0x25
I1024 07:37:05.675302 847381 OICompiler.cpp:460] 7f9222a0015f:  jb      0x48
I1024 07:37:05.675305 847381 OICompiler.cpp:460] 7f9222a00161:  mov     edi, 0x75bcd15
I1024 07:37:05.675308 847381 OICompiler.cpp:460] 7f9222a00166:  mov     edx, 0x21
I1024 07:37:05.675312 847381 OICompiler.cpp:460] 7f9222a0016b:  mov     r8d, 0x75bcd15
I1024 07:37:05.675315 847381 OICompiler.cpp:460] 7f9222a00171:  nop     word ptr cs:[rax + rax]
I1024 07:37:05.675318 847381 OICompiler.cpp:460] 7f9222a0017b:  nop     dword ptr [rax + rax]
I1024 07:37:05.675321 847381 OICompiler.cpp:460] 7f9222a00180:  mov     r9d, edi
I1024 07:37:05.675325 847381 OICompiler.cpp:460] 7f9222a00183:  or      r9b, -0x80
I1024 07:37:05.675329 847381 OICompiler.cpp:460] 7f9222a00187:  mov     byte ptr [rcx + rdx - 0x1], r9b
I1024 07:37:05.675333 847381 OICompiler.cpp:460] 7f9222a0018c:  shr     r8, 0x7
I1024 07:37:05.675335 847381 OICompiler.cpp:460] 7f9222a00190:  inc     rdx
I1024 07:37:05.675338 847381 OICompiler.cpp:460] 7f9222a00193:  cmp     rdi, 0x3fff
I1024 07:37:05.675341 847381 OICompiler.cpp:460] 7f9222a0019a:  mov     rdi, r8
I1024 07:37:05.675344 847381 OICompiler.cpp:460] 7f9222a0019d:  ja      0xffffffffffffffe3
I1024 07:37:05.675348 847381 OICompiler.cpp:460] 7f9222a0019f:  mov     byte ptr [rcx + rdx - 0x1], 0x3a
I1024 07:37:05.675351 847381 OICompiler.cpp:460] 7f9222a001a4:  mov     rdi, qword ptr [rsi]
I1024 07:37:05.675354 847381 OICompiler.cpp:460] 7f9222a001a7:  lea     rsi, [rdx + 0x4]
I1024 07:37:05.675357 847381 OICompiler.cpp:460] 7f9222a001ab:  cmp     rsi, rdi
I1024 07:37:05.675360 847381 OICompiler.cpp:460] 7f9222a001ae:  jae     0x46
I1024 07:37:05.675364 847381 OICompiler.cpp:460] 7f9222a001b0:  mov     rdi, qword ptr [rax]
I1024 07:37:05.675365 847381 OICompiler.cpp:460] 7f9222a001b3:  inc     rdx
I1024 07:37:05.675369 847381 OICompiler.cpp:460] 7f9222a001b6:  mov     r8d, 0x75bcd15
I1024 07:37:05.675371 847381 OICompiler.cpp:460] 7f9222a001bc:  mov     rsi, rdx
I1024 07:37:05.675374 847381 OICompiler.cpp:460] 7f9222a001bf:  mov     edx, 0x75bcd15
I1024 07:37:05.675377 847381 OICompiler.cpp:460] 7f9222a001c4:  nop     word ptr cs:[rax + rax]
I1024 07:37:05.675380 847381 OICompiler.cpp:460] 7f9222a001ce:  nop
I1024 07:37:05.675382 847381 OICompiler.cpp:460] 7f9222a001d0:  mov     r9d, r8d
I1024 07:37:05.675385 847381 OICompiler.cpp:460] 7f9222a001d3:  or      r9b, -0x80
I1024 07:37:05.675390 847381 OICompiler.cpp:460] 7f9222a001d7:  mov     byte ptr [rdi + rsi - 0x1], r9b
I1024 07:37:05.675392 847381 OICompiler.cpp:460] 7f9222a001dc:  shr     rdx, 0x7
I1024 07:37:05.675395 847381 OICompiler.cpp:460] 7f9222a001e0:  inc     rsi
I1024 07:37:05.675397 847381 OICompiler.cpp:460] 7f9222a001e3:  cmp     r8, 0x3fff
I1024 07:37:05.675400 847381 OICompiler.cpp:460] 7f9222a001ea:  mov     r8, rdx
I1024 07:37:05.675403 847381 OICompiler.cpp:460] 7f9222a001ed:  ja      0xffffffffffffffe3
I1024 07:37:05.675406 847381 OICompiler.cpp:460] 7f9222a001ef:  mov     byte ptr [rdi + rsi - 0x1], 0x3a
I1024 07:37:05.675410 847381 OICompiler.cpp:460] 7f9222a001f4:  mov     qword ptr [rcx + 0x10], rsi
I1024 07:37:05.675412 847381 OICompiler.cpp:460] 7f9222a001f8:  add     qword ptr [rax], rsi
I1024 07:37:05.675416 847381 OICompiler.cpp:460] 7f9222a001fb:  add     rsp, 0x8
I1024 07:37:05.675419 847381 OICompiler.cpp:460] 7f9222a001ff:  pop     rbx
I1024 07:37:05.675421 847381 OICompiler.cpp:460] 7f9222a00200:  pop     r14
I1024 07:37:05.675424 847381 OICompiler.cpp:460] 7f9222a00202:  ret
...
```