### PR TITLE
oil: make AoT introspect noinline

### DIFF
--- a/include/oi/oi.h
+++ b/include/oi/oi.h
@@ -38,7 +38,7 @@ template <class T, Feature... Fs>
 IntrospectionResult __attribute__((weak)) introspectImpl(const T& objectAddr);
 
 template <typename T, Feature... Fs>
-IntrospectionResult introspect(const T& objectAddr) {
+__attribute__((noinline)) IntrospectionResult introspect(const T& objectAddr) {
   if (!introspectImpl<T, Fs...>)
     throw std::logic_error(
         "OIL is expecting AoT compilation but it doesn't appear to have run.");


### PR DESCRIPTION
## Summary

OIL AoT compilation with `oilgen` currently requires the presence of the `introspect` symbol. If the compiler inlines this symbol then generation fails, which is happening when using the `tryIntrospect` method. Add the `noinline` attribute to solve this.

## Test plan

I tested it, really.
