### PR TITLE
integration: move pid back to end

### DIFF
--- a/test/integration/runner_common.cpp
+++ b/test/integration/runner_common.cpp
@@ -188,7 +188,6 @@ OidProc OidIntegration::runOidOnProcess(OidOpts opts,
       "--dump-json"s,
       "--script-source"s, opts.scriptSource,
       "--mode=strict"s,
-      "--pid"s, std::to_string(targetProcess.id()),
   };
   // clang-format on
 
@@ -211,6 +210,9 @@ OidProc OidIntegration::runOidOnProcess(OidOpts opts,
     oid_args.emplace_back("--config-file");
     oid_args.emplace_back(*suffix);
   }
+
+  oid_args.emplace_back("--pid");
+  oid_args.emplace_back(std::to_string(targetProcess.id()));
 
   if (verbose) {
     std::cerr << "Running: " << targetExe << "\n";


### PR DESCRIPTION
## Summary

A change was made a while ago to put the PID at the end of the integration test output line to make it easier to change when running manually. I regressed this when adding multiple config files. Put the PID at the end of the line again.

## Test plan

- `stest OidIntegration.simple_struct` - it's at the end again
- CI
