### PR TITLE
remove oil v1 leftovers

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -1258,7 +1258,6 @@ void CodeGen::generate(
     FuncGen::DefineEncodeData(code);
     FuncGen::DefineEncodeDataSize(code);
     FuncGen::DefineStoreData(code);
-    FuncGen::DefineAddData(code);
   }
   FuncGen::DeclareGetContainer(code);
 

--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -35,9 +35,6 @@ class FuncGen {
   static void DeclareStoreData(std::string& testCode);
   static void DefineStoreData(std::string& testCode);
 
-  static void DeclareAddData(std::string& testCode);
-  static void DefineAddData(std::string& testCode);
-
   static void DeclareEncodeData(std::string& testCode);
   static void DefineEncodeData(std::string& testCode);
 
@@ -55,11 +52,6 @@ class FuncGen {
 
   static void DeclareGetSize(std::string& testCode, const std::string& type);
 
-  static void DeclareTopLevelGetSize(std::string& testCode,
-                                     const std::string& type);
-  static void DefineTopLevelGetObjectSize(std::string& testCode,
-                                          const std::string& type,
-                                          const std::string& linkageName);
   static void DefineTopLevelIntrospect(std::string& code,
                                        const std::string& type);
   static void DefineTopLevelIntrospectNamed(std::string& code,
@@ -79,9 +71,6 @@ class FuncGen {
       const std::string& rawType,
       size_t exclusiveSize,
       std::span<const std::string_view> typeNames);
-
-  static void DefineTopLevelGetSizeRefRet(std::string& testCode,
-                                          const std::string& type);
 
   static void DefineTopLevelGetSizeSmartPtr(std::string& testCode,
                                             const std::string& rawType,

--- a/oi/OICodeGen.h
+++ b/oi/OICodeGen.h
@@ -65,7 +65,6 @@ class OICodeGen {
       bool topLevel = false;
     };
 
-    bool useDataSegment;
     FeatureSet features;
     std::set<std::filesystem::path> containerConfigPaths;
     std::set<std::string> defaultHeaders;
@@ -126,9 +125,6 @@ class OICodeGen {
 
   drgn_qualified_type getRootType();
   void setRootType(drgn_qualified_type rt);
-  void setLinkageName(std::string name) {
-    linkageName = name;
-  };
   TypeHierarchy getTypeHierarchy();
   std::map<std::string, PaddingInfo> getPaddingInfo();
 
@@ -157,7 +153,6 @@ class OICodeGen {
   using SortedTypeDefMap = std::vector<std::pair<drgn_type*, drgn_type*>>;
 
   std::string rootTypeStr;
-  std::string linkageName;
   std::map<drgn_type*, std::string> unnamedUnion;
   std::map<std::string, size_t> sizeMap;
   std::map<drgn_type*, ContainerTypeMapEntry> containerTypeMapDrgn;

--- a/oi/OID.cpp
+++ b/oi/OID.cpp
@@ -666,7 +666,6 @@ int main(int argc, char* argv[]) {
   OICompiler::Config compilerConfig{};
 
   OICodeGen::Config codeGenConfig;
-  codeGenConfig.useDataSegment = true;
   codeGenConfig.features = {};  // fill in after processing the config file
 
   TreeBuilder::Config tbConfig{


### PR DESCRIPTION
## Summary

Cleans up some dead code from the OIL v1 -> v2 migration in OICodeGen and FuncGen. OICodeGen doesn't ever generate OIL code now as OIL v2 is exclusively CodeGen v2 and OIL v1 was removed.

## Test plan

- CI

Excited to see the great coverage improvements.
