### PR TITLE
codegenv2: improve multi argument generation

### DIFF
--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -53,22 +53,30 @@ class FuncGen {
   static void DeclareGetSize(std::string& testCode, const std::string& type);
 
   static void DefineTopLevelIntrospect(std::string& code,
-                                       const std::string& type);
-  static void DefineTopLevelIntrospectNamed(std::string& code,
-                                            const std::string& type,
-                                            const std::string& linkageName);
+                                       const std::string& type,
+                                       const std::string& idToHash);
+  static void DefineTopLevelIntrospectNamed(
+      std::string& code,
+      const std::string& type,
+      const std::string& linkageName,
+      size_t exclusiveSize,
+      std::span<const std::string_view> typeNames);
 
   static void DefineTopLevelGetSizeRef(std::string& testCode,
-                                       const std::string& rawType,
+                                       const std::string& type,
+                                       const std::string& idToHash,
                                        FeatureSet features);
   static void DefineTopLevelGetSizeRefTyped(std::string& testCode,
-                                            const std::string& rawType,
+                                            const std::string& type,
+                                            const std::string& idToHash,
                                             FeatureSet features);
   static void DefineOutputType(std::string& testCode,
-                               const std::string& rawType);
+                               const std::string& type,
+                               const std::string& idToHash);
   static void DefineTreeBuilderInstructions(
       std::string& testCode,
-      const std::string& rawType,
+      const std::string& type,
+      const std::string& idToHash,
       size_t exclusiveSize,
       std::span<const std::string_view> typeNames);
 

--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -3331,8 +3331,8 @@ bool OICodeGen::generateJitCode(std::string& code) {
       funcGen.DefineTopLevelGetSizeSmartPtr(functionsCode, rawTypeName,
                                             config.features);
     } else {
-      funcGen.DefineTopLevelGetSizeRef(functionsCode, rawTypeName,
-                                       config.features);
+      funcGen.DefineTopLevelGetSizeRef(functionsCode, "__ROOT_TYPE__",
+                                       rawTypeName, config.features);
     }
   }
 

--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <memory>
+#include <span>
 #include <unordered_map>
 #include <vector>
 
@@ -54,7 +55,7 @@ struct DrgnParserOptions {
 class DrgnParser {
  public:
   DrgnParser(TypeGraph& typeGraph,
-             const std::vector<std::unique_ptr<ContainerInfo>>& containers,
+             std::span<const std::unique_ptr<ContainerInfo>> containers,
              DrgnParserOptions options)
       : typeGraph_(typeGraph), containers_(containers), options_(options) {
   }
@@ -90,6 +91,7 @@ class DrgnParser {
     drgn_types_.insert({drgnType, newType});
     return newType;
   }
+
   bool chasePointer() const;
 
   // Store a mapping of drgn types to type graph nodes for deduplication during
@@ -98,7 +100,7 @@ class DrgnParser {
       drgn_types_;
 
   TypeGraph& typeGraph_;
-  const std::vector<std::unique_ptr<ContainerInfo>>& containers_;
+  std::span<const std::unique_ptr<ContainerInfo>> containers_;
   int depth_;
   DrgnParserOptions options_;
 };


### PR DESCRIPTION
## Summary

Adds a new function `CodeGen::codegenFromDrgns` which runs multiple drgn root types through one `DrgnParser`. Stores the naming for the output within this function as we previously decided that when doing the actual codegen, which is too late with multiple root types.

This new function is used in `OIGenerator` when you have multiple OIL calls within one input object. Rather than producing separate `.o`s with likely duplicate code for each callsite, we produce a single `.o` that contains both calls. For calls with types with significant overlap this should be a significant reduction in work. The downside is the calls can't have different features, but this could be solved in the future by namespacing the code based on features/config within the generated `.cpp` - the pros seem to outweigh the con.

This should also be used with `oid` in multi probe mode as it would again significantly reduce the work it has to do. I didn't do this yet as it requires changing the cache. As I've got a big cache refactor ongoing at the minute it makes sense to wait until after that's landed to make this change.

## Test plan

- CI for existing behaviour
- [D50835153](https://www.internalfb.com/diff/D50835153) for new behaviour
