### PR TITLE
incomplete: handle drgn returning a nullptr name

### DIFF
--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -125,12 +125,14 @@ Type& DrgnParser::enumerateType(struct drgn_type* type) {
   } catch (const DrgnParserError& e) {
     depth_--;
     if (isTypeIncomplete) {
-      const char* typeName = "<incomplete>";
+      const char* typeName = nullptr;
       if (drgn_type_has_name(type)) {
         typeName = drgn_type_name(type);
       } else if (drgn_type_has_tag(type)) {
         typeName = drgn_type_tag(type);
       }
+      if (typeName == nullptr)
+        typeName = "<incomplete>";
 
       return makeType<Incomplete>(nullptr, typeName);
     } else {


### PR DESCRIPTION
## Summary

The `drgn` calls sometimes set this cstr to `nullptr`. If this happens the implicit `std::string` constructor in `makeType` throws `std::logic_error`. Explicitly check for `nullptr` after the calls and set `"<incomplete>"` accordingly.

## Test plan

\<redacted\> (I tested it I promise)
