### PR TITLE
TypeGraph: Stop identifying containers in DrgnParser

### DIFF
--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -53,6 +53,7 @@ class CodeGen {
                        std::string linkageName,
                        std::string& code);
 
+  void registerContainer(std::unique_ptr<ContainerInfo> containerInfo);
   void registerContainer(const std::filesystem::path& path);
   void addDrgnRoot(struct drgn_type* drgnType,
                    type_graph::TypeGraph& typeGraph);

--- a/oi/type_graph/DrgnParser.cpp
+++ b/oi/type_graph/DrgnParser.cpp
@@ -25,8 +25,6 @@ extern "C" {
 #include <drgn.h>
 }
 
-#include <regex>
-
 namespace oi::detail::type_graph {
 namespace {
 
@@ -148,31 +146,7 @@ Type& DrgnParser::enumerateType(struct drgn_type* type) {
   return *t;
 }
 
-/*
- * enumerateContainer
- *
- * Attempts to parse a drgn_type as a Container. Returns nullptr if not
- * sucessful.
- */
-Container* DrgnParser::enumerateContainer(struct drgn_type* type,
-                                          const std::string& fqName) {
-  auto size = get_drgn_type_size(type);
-
-  for (const auto& containerInfo : containers_) {
-    if (!std::regex_search(fqName, containerInfo->matcher)) {
-      continue;
-    }
-
-    VLOG(2) << "Matching container `" << containerInfo->typeName << "` from `"
-            << fqName << "`" << std::endl;
-    auto& c = makeType<Container>(type, *containerInfo, size);
-    enumerateClassTemplateParams(type, c.templateParams);
-    return &c;
-  }
-  return nullptr;
-}
-
-Type& DrgnParser::enumerateClass(struct drgn_type* type) {
+Class& DrgnParser::enumerateClass(struct drgn_type* type) {
   std::string fqName;
   char* nameStr = nullptr;
   size_t length = 0;
@@ -180,10 +154,6 @@ Type& DrgnParser::enumerateClass(struct drgn_type* type) {
   if (err == nullptr && nameStr != nullptr) {
     fqName = nameStr;
   }
-
-  auto* container = enumerateContainer(type, fqName);
-  if (container)
-    return *container;
 
   const char* typeTag = drgn_type_tag(type);
   std::string name = typeTag ? typeTag : "";

--- a/oi/type_graph/DrgnParser.h
+++ b/oi/type_graph/DrgnParser.h
@@ -46,25 +46,19 @@ struct DrgnParserOptions {
  * - Performance: reading no more info from drgn than necessary
  *
  * For the most part we try to move logic out of DrgnParser and have later
- * passes clean up the type graph, e.g. flattening parents. However, we do
- * incorporate some extra logic here when it would allow us to read less DWARF
- * information, e.g. matching containers in DrngParser means we don't read
- * details about container internals.
+ * passes clean up the type graph, e.g. flattening parents and identifying
+ * containers.
  */
 class DrgnParser {
  public:
-  DrgnParser(TypeGraph& typeGraph,
-             const std::vector<std::unique_ptr<ContainerInfo>>& containers,
-             DrgnParserOptions options)
-      : typeGraph_(typeGraph), containers_(containers), options_(options) {
+  DrgnParser(TypeGraph& typeGraph, DrgnParserOptions options)
+      : typeGraph_(typeGraph), options_(options) {
   }
   Type& parse(struct drgn_type* root);
 
  private:
   Type& enumerateType(struct drgn_type* type);
-  Container* enumerateContainer(struct drgn_type* type,
-                                const std::string& fqName);
-  Type& enumerateClass(struct drgn_type* type);
+  Class& enumerateClass(struct drgn_type* type);
   Enum& enumerateEnum(struct drgn_type* type);
   Typedef& enumerateTypedef(struct drgn_type* type);
   Type& enumeratePointer(struct drgn_type* type);
@@ -98,7 +92,6 @@ class DrgnParser {
       drgn_types_;
 
   TypeGraph& typeGraph_;
-  const std::vector<std::unique_ptr<ContainerInfo>>& containers_;
   int depth_;
   DrgnParserOptions options_;
 };

--- a/oi/type_graph/TypeIdentifier.cpp
+++ b/oi/type_graph/TypeIdentifier.cpp
@@ -86,6 +86,7 @@ void TypeIdentifier::visit(Container& c) {
           }
           c.templateParams[i] = *dummy;
           replaced = true;
+          break;
         }
       }
 

--- a/test/test_add_children.cpp
+++ b/test/test_add_children.cpp
@@ -66,7 +66,7 @@ TEST_F(AddChildrenTest, InheritanceStatic) {
 }
 
 TEST_F(AddChildrenTest, InheritancePolymorphic) {
-  testMultiCompiler("oid_test_case_inheritance_polymorphic_a_as_a", R"(
+  testMultiCompilerGlob("oid_test_case_inheritance_polymorphic_a_as_a", R"(
 [1]  Pointer
 [0]    Class: A (size: 16)
          Member: _vptr$A (offset: 0)
@@ -78,11 +78,11 @@ TEST_F(AddChildrenTest, InheritancePolymorphic) {
          Function: A
          Function: A
          Child
-[8]        Class: B (size: 40)
+[17]       Class: B (size: 40)
              Parent (offset: 0)
                [0]
              Member: vec_b (offset: 16)
-[4]            Container: std::vector (size: 24)
+[4]            Class: vector<int, std::allocator<int> > (size: 24)
                  Param
                    Primitive: int32_t
                  Param
@@ -105,14 +105,15 @@ TEST_F(AddChildrenTest, InheritancePolymorphic) {
                      Function: ~allocator
                      Function: allocate
                      Function: deallocate
+                 *
              Function: ~B (virtual)
              Function: myfunc (virtual)
              Function: B
              Function: B
              Child
-[10]           Class: C (size: 48)
+[19]           Class: C (size: 48)
                  Parent (offset: 0)
-                   [8]
+                   [17]
                  Member: int_c (offset: 40)
                    Primitive: int32_t
                  Function: ~C (virtual)
@@ -120,7 +121,7 @@ TEST_F(AddChildrenTest, InheritancePolymorphic) {
                  Function: C
                  Function: C
 )",
-                    R"(
+                        R"(
 [1]  Pointer
 [0]    Class: A (size: 16)
          Member: _vptr.A (offset: 0)
@@ -133,11 +134,11 @@ TEST_F(AddChildrenTest, InheritancePolymorphic) {
          Function: ~A (virtual)
          Function: myfunc (virtual)
          Child
-[7]        Class: B (size: 40)
+[13]       Class: B (size: 40)
              Parent (offset: 0)
                [0]
              Member: vec_b (offset: 16)
-[4]            Container: std::vector (size: 24)
+[4]            Class: vector<int, std::allocator<int> > (size: 24)
                  Param
                    Primitive: int32_t
                  Param
@@ -157,15 +158,16 @@ TEST_F(AddChildrenTest, InheritancePolymorphic) {
                      Function: ~allocator
                      Function: allocate
                      Function: deallocate
+                 *
              Function: operator=
              Function: B
              Function: B
              Function: ~B (virtual)
              Function: myfunc (virtual)
              Child
-[9]            Class: C (size: 48)
+[15]           Class: C (size: 48)
                  Parent (offset: 0)
-                   [7]
+                   [13]
                  Member: int_c (offset: 40)
                    Primitive: int32_t
                  Function: operator=

--- a/test/test_drgn_parser.h
+++ b/test/test_drgn_parser.h
@@ -16,13 +16,8 @@ using namespace oi::detail;
 
 class DrgnParserTest : public ::testing::Test {
  protected:
-  static void SetUpTestSuite() {
-    symbols_ = new SymbolService{TARGET_EXE_PATH};
-  }
-
-  static void TearDownTestSuite() {
-    delete symbols_;
-  }
+  static void SetUpTestSuite();
+  static void TearDownTestSuite();
 
   static type_graph::DrgnParser getDrgnParser(
       type_graph::TypeGraph& typeGraph, type_graph::DrgnParserOptions options);


### PR DESCRIPTION
Leave it to the new mutator pass IdentifyContainers to replace Class
nodes with Container nodes where appropriate.

This will allow us to run passes over the type graph before identifying
containers, and therefore before we have lost information about the
internal details of the container (e.g. alignment of member variables).