### PR TITLE
collapse TreeBuilderV2 features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,20 +21,6 @@ workflows:
           oid_test_args: "-ftype-graph"
           tests_regex: "OidIntegration\\..*"
           exclude_regex: ".*inheritance_polymorphic.*|.*arrays_member_int0"
-      - test:
-          name: test-typed-data-segment-gcc
-          requires:
-            - build-gcc
-          oid_test_args: "-ftyped-data-segment"
-          tests_regex: "OidIntegration\\..*"
-          exclude_regex: ".*inheritance_polymorphic.*|.*pointers.*|.*arrays_member_int0|.*cycles_.*"
-      - test:
-          name: test-tree-builder-type-checking-gcc
-          requires:
-            - build-gcc
-          oid_test_args: "-ftree-builder-type-checking"
-          tests_regex: "OidIntegration\\..*"
-          exclude_regex: ".*inheritance_polymorphic.*|.*pointers.*|.*arrays_member_int0|.*cycles_.*"
       - coverage:
           name: coverage
           requires:
@@ -43,14 +29,6 @@ workflows:
           name: coverage-type-graph
           requires:
             - test-type-graph-gcc
-      - coverage:
-          name: coverage-typed-data-segment
-          requires:
-            - test-typed-data-segment-gcc
-      - coverage:
-          name: coverage-tree-builder-type-checking
-          requires:
-            - test-tree-builder-type-checking-gcc
 
       - build:
           name: build-clang

--- a/oi/ContainerInfo.cpp
+++ b/oi/ContainerInfo.cpp
@@ -275,10 +275,6 @@ ContainerInfo::ContainerInfo(const fs::path& path) {
     throw ContainerInfoError(path, "`codegen.decl` is a required field");
   }
   if (std::optional<std::string> str =
-          codegenToml["handler"].value<std::string>()) {
-    codegen.handler = std::move(*str);
-  }
-  if (std::optional<std::string> str =
           codegenToml["traversal_func"].value<std::string>()) {
     codegen.traversalFunc = std::move(*str);
   }
@@ -323,8 +319,6 @@ ContainerInfo::ContainerInfo(std::string typeName_,
       matcher(getMatcher(typeName)),
       ctype(ctype_),
       header(std::move(header_)),
-      codegen(Codegen{"// DummyDecl %1%\n",
-                      "// DummyFunc %1%\n",
-                      "// DummyHandler %1%\n",
-                      "// DummyFunc\n"}) {
+      codegen(Codegen{
+          "// DummyDecl %1%\n", "// DummyFunc %1%\n", "// DummyFunc\n"}) {
 }

--- a/oi/ContainerInfo.h
+++ b/oi/ContainerInfo.h
@@ -36,7 +36,6 @@ struct ContainerInfo {
   struct Codegen {
     std::string decl;
     std::string func;
-    std::string handler = "";
     std::string traversalFunc = "";
     std::string extra = "";
     std::vector<Processor> processors{};

--- a/oi/Features.cpp
+++ b/oi/Features.cpp
@@ -40,11 +40,6 @@ std::optional<std::string_view> featureHelp(Feature f) {
       return "Use Type Graph for code generation (CodeGen v2).";
     case Feature::PruneTypeGraph:
       return "Prune unreachable nodes from the type graph";
-    case Feature::TypedDataSegment:
-      return "Use Typed Data Segment in generated code.";
-    case Feature::TreeBuilderTypeChecking:
-      return "Use Typed Data Segment to perform runtime Type Checking in "
-             "TreeBuilder.";
     case Feature::Library:
       return std::nullopt;  // Hide in OID help
     case Feature::TreeBuilderV2:
@@ -65,14 +60,8 @@ std::optional<std::string_view> featureHelp(Feature f) {
 
 std::span<const Feature> requirements(Feature f) {
   switch (f) {
-    case Feature::TypedDataSegment:
-      static constexpr std::array tds = {Feature::TypeGraph};
-      return tds;
-    case Feature::TreeBuilderTypeChecking:
-      static constexpr std::array tc = {Feature::TypedDataSegment};
-      return tc;
     case Feature::TreeBuilderV2:
-      static constexpr std::array tb2 = {Feature::TreeBuilderTypeChecking};
+      static constexpr std::array tb2 = {Feature::TypeGraph};
       return tb2;
     case Feature::Library:
       static constexpr std::array lib = {Feature::TreeBuilderV2};

--- a/oi/Features.h
+++ b/oi/Features.h
@@ -22,20 +22,18 @@
 
 #include "oi/EnumBitset.h"
 
-#define OI_FEATURE_LIST                                    \
-  X(ChaseRawPointers, "chase-raw-pointers")                \
-  X(PackStructs, "pack-structs")                           \
-  X(GenPaddingStats, "gen-padding-stats")                  \
-  X(CaptureThriftIsset, "capture-thrift-isset")            \
-  X(TypeGraph, "type-graph")                               \
-  X(PruneTypeGraph, "prune-type-graph")                    \
-  X(TypedDataSegment, "typed-data-segment")                \
-  X(TreeBuilderTypeChecking, "tree-builder-type-checking") \
-  X(Library, "library")                                    \
-  X(TreeBuilderV2, "tree-builder-v2")                      \
-  X(GenJitDebug, "gen-jit-debug")                          \
-  X(JitLogging, "jit-logging")                             \
-  X(JitTiming, "jit-timing")                               \
+#define OI_FEATURE_LIST                         \
+  X(ChaseRawPointers, "chase-raw-pointers")     \
+  X(PackStructs, "pack-structs")                \
+  X(GenPaddingStats, "gen-padding-stats")       \
+  X(CaptureThriftIsset, "capture-thrift-isset") \
+  X(TypeGraph, "type-graph")                    \
+  X(PruneTypeGraph, "prune-type-graph")         \
+  X(Library, "library")                         \
+  X(TreeBuilderV2, "tree-builder-v2")           \
+  X(GenJitDebug, "gen-jit-debug")               \
+  X(JitLogging, "jit-logging")                  \
+  X(JitTiming, "jit-timing")                    \
   X(PolymorphicInheritance, "polymorphic-inheritance")
 
 namespace oi::detail {

--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -61,11 +61,6 @@ class FuncGen {
   static void DefineTopLevelGetSizeRef(std::string& testCode,
                                        const std::string& rawType,
                                        FeatureSet features);
-  static void DefineTopLevelGetSizeRefTyped(std::string& testCode,
-                                            const std::string& rawType,
-                                            FeatureSet features);
-  static void DefineOutputType(std::string& testCode,
-                               const std::string& rawType);
   static void DefineTreeBuilderInstructions(
       std::string& testCode,
       const std::string& rawType,

--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -528,10 +528,8 @@ bool OICompiler::compile(const std::string& code,
   static const auto syntheticHeaders =
       std::array<std::pair<Feature, std::pair<std::string_view, std::string>>,
                  7>{{
-          {Feature::TypedDataSegment,
-           {headers::oi_types_st_h, "oi/types/st.h"}},
-          {Feature::TreeBuilderTypeChecking,
-           {headers::oi_types_dy_h, "oi/types/dy.h"}},
+          {Feature::TreeBuilderV2, {headers::oi_types_st_h, "oi/types/st.h"}},
+          {Feature::TreeBuilderV2, {headers::oi_types_dy_h, "oi/types/dy.h"}},
           {Feature::TreeBuilderV2,
            {headers::oi_exporters_inst_h, "oi/exporters/inst.h"}},
           {Feature::TreeBuilderV2,

--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -184,8 +184,6 @@ int OIGenerator::generate(fs::path& primaryObject, SymbolService& symbols) {
 
   std::map<Feature, bool> featuresMap = {
       {Feature::TypeGraph, true},
-      {Feature::TypedDataSegment, true},
-      {Feature::TreeBuilderTypeChecking, true},
       {Feature::TreeBuilderV2, true},
       {Feature::Library, true},
       {Feature::PackStructs, true},

--- a/oi/OILibraryImpl.cpp
+++ b/oi/OILibraryImpl.cpp
@@ -180,8 +180,6 @@ namespace {
 std::map<Feature, bool> convertFeatures(std::unordered_set<oi::Feature> fs) {
   std::map<Feature, bool> out{
       {Feature::TypeGraph, true},
-      {Feature::TypedDataSegment, true},
-      {Feature::TreeBuilderTypeChecking, true},
       {Feature::TreeBuilderV2, true},
       {Feature::Library, true},
       {Feature::PackStructs, true},

--- a/test/integration/arrays.toml
+++ b/test/integration/arrays.toml
@@ -62,7 +62,7 @@ definitions = '''
       }]}]'''
   [cases.multidim_legacy] # Test for legacy behaviour. Remove with OICodeGen
     oil_disable = 'oil only runs on codegen v2'
-    cli_options = ["-Ftype-graph", "-Ftyped-data-segment", "-Ftree-builder-type-checking", "-Ftree-builder-v2"]
+    cli_options = ["-Ftype-graph", "-Ftree-builder-v2"]
     param_types = ["const MultiDim&"]
     setup = "return {};"
     expect_json = '''[{

--- a/types/README.md
+++ b/types/README.md
@@ -62,14 +62,10 @@ This document describes the format of the container definition files contained i
   will collide if they share the same name.
 
 
-## Changes introduced with Typed Data Segment
-- `decl` and `func` fields are ignored when using `-ftyped-data-segment` and the
-  `handler` field is used instead.
-
 ## Changes introduced with TreeBuilder V2
-- `decl`, `func`, and `handler` fields are ignored when using `-ftree-builder-v2`.
-   The `TypeHandler` is instead constructed from `traversal_func` and `processor`
-   entries.
+- `decl` and `func` fields are ignored when using `-ftree-builder-v2`. The
+  `TypeHandler` is constructed from `traversal_func` field and `processor`
+  entries.
 
 ## Changes introduced with TypeGraph
 - `typeName` and `matcher` fields have been merged into the single field `type_name`.


### PR DESCRIPTION
collapse TreeBuilderV2 features

Summary:

Currently there are two features between CodeGen v2 (TypeGraph) and TreeBuilder
v2. These are TypedDataSegment and TreeBuilderTypeChecking. Each of these
features currently has a full set of tests run in the CI and each have specific
exclusions.

Collapse these features into TreeBuilder v2. This allows for significantly
simplified testing as any OIL tests run under TreeBuilder v2 and any OID tests
run under TreeBuilder v1.

The reasoning behind this is I no longer intend to partially roll out this
feature. Full TreeBuilder v2 applies different conditions to containers than
the intermediate states, and writing these only to have them never deployed is
a waste of time.

Test Plan:
- it builds
- CI
