### PR TITLE
add range-v3 library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,15 @@ FetchContent_Declare(
 )
 FetchContent_Populate(folly)
 
+### range-v3
+FetchContent_Declare(
+  range-v3
+  GIT_REPOSITORY https://github.com/ericniebler/range-v3.git
+  GIT_TAG        a81477931a8aa2ad025c6bda0609f38e09e4d7ec # 0.12.0
+  GIT_PROGRESS   TRUE
+)
+FetchContent_MakeAvailable(range-v3)
+
 set_project_warnings()
 
 if (ASAN)
@@ -291,6 +300,7 @@ target_link_libraries(oicore
   ${Boost_LIBRARIES}
   Boost::headers
   glog::glog
+  range-v3
   resources
 )
 if (FORCE_LLVM_STATIC)

--- a/oi/OICompiler.h
+++ b/oi/OICompiler.h
@@ -20,6 +20,8 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <range/v3/algorithm/find_if.hpp>
+#include <range/v3/algorithm/starts_with.hpp>
 #include <ranges>
 #include <set>
 #include <span>
@@ -204,19 +206,9 @@ std::optional<std::vector<uintptr_t>> OICompiler::locateOpcodes(
 
   std::vector<uintptr_t> locs;
   while (auto inst = DG()) {
-    auto it = std::find_if(
-        std::begin(needles), std::end(needles), [&](const auto& needle) {
-          // std::ranges::starts_with(inst->opcodes, needle)
-          if (std::ranges::size(needle) > std::ranges::size(inst->opcodes))
-            return false;
-          auto it1 = std::ranges::begin(inst->opcodes);
-          auto it2 = std::ranges::begin(needle);
-          for (; it2 != std::ranges::end(needle); ++it1, ++it2) {
-            if (*it1 != *it2)
-              return false;
-          }
-          return true;
-        });
+    auto it = ranges::find_if(needles, [&](const auto& needle) {
+      return ranges::starts_with(inst->opcodes, needle);
+    });
 
     if (it != std::end(needles)) {
       locs.push_back(inst->offset);

--- a/oi/type_graph/KeyCapture.cpp
+++ b/oi/type_graph/KeyCapture.cpp
@@ -66,8 +66,7 @@ void KeyCapture::visit(Class& c) {
       continue;
     if (!keyToCapture.member.has_value())
       continue;
-    for (size_t i = 0; i < c.members.size(); i++) {
-      auto& member = c.members[i];
+    for (auto& member : c.members) {
       if (member.name != *keyToCapture.member)
         continue;
 


### PR DESCRIPTION
add range-v3 library

Adds the range-v3 library which supports features that otherwise wouldn't be
available until C++23 or C++26. I caught a couple of uses that suit it but this
will allow us to use more in future.

Test Plan:
- CI
