### PR TITLE
oil: add support for std::list

### DIFF
--- a/test/integration/std_list.toml
+++ b/test/integration/std_list.toml
@@ -1,0 +1,59 @@
+includes = ["list"]
+
+definitions = '''
+  struct SimpleStruct {
+    int a;
+    char b;
+    long long c;
+  };
+'''
+
+[cases]
+  [cases.int_empty]
+    param_types = ["const std::list<int>&"]
+    setup = "return {};"
+    expect_json = '[{"staticSize":24, "dynamicSize":0, "length":0, "capacity":0, "elementStaticSize":4}]'
+    expect_json_v2 = '[{"staticSize":24, "exclusiveSize":24, "length":0, "capacity":0, "members":[]}]'
+  [cases.int_some]
+    param_types = ["const std::list<int>&"]
+    setup = "return {{1,2,3}};"
+    expect_json = '[{"staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4}]'
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "length":3, "capacity":3, "members":[
+      {"staticSize":4, "exclusiveSize":4},
+      {"staticSize":4, "exclusiveSize":4},
+      {"staticSize":4, "exclusiveSize":4}
+    ]}]'''
+  [cases.struct_some]
+    param_types = ["const std::list<SimpleStruct>&"]
+    setup = "return {{{}, {}, {}}};"
+    expect_json = '[{"staticSize":24, "dynamicSize":48, "length":3, "capacity":3, "elementStaticSize":16}]'
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "length":3, "capacity":3, "members":[
+      {"staticSize":16, "exclusiveSize":3},
+      {"staticSize":16, "exclusiveSize":3},
+      {"staticSize":16, "exclusiveSize":3}
+    ]}]'''
+  [cases.list_int_empty]
+    param_types = ["const std::list<std::list<int>>&"]
+    setup = "return {};"
+    expect_json = '[{"staticSize":24, "dynamicSize":0, "length":0, "capacity":0, "elementStaticSize":24}]'
+    expect_json_v2 = '[{"staticSize":24, "exclusiveSize":24, "length":0, "capacity":0, "members":[]}]'
+  [cases.list_int_some]
+    param_types = ["const std::list<std::list<int>>&"]
+    setup = "return {{{1,2,3},{4},{5,6}}};"
+    expect_json = '''[{
+      "staticSize":24,
+      "dynamicSize":96,
+      "exclusiveSize":24,
+      "length":3,
+      "capacity":3,
+      "elementStaticSize":24,
+      "members":[
+        {"staticSize":24, "dynamicSize":12, "exclusiveSize":36, "length":3, "capacity":3, "elementStaticSize":4},
+        {"staticSize":24, "dynamicSize":4, "exclusiveSize":28, "length":1, "capacity":1, "elementStaticSize":4},
+        {"staticSize":24, "dynamicSize":8, "exclusiveSize":32, "length":2, "capacity":2, "elementStaticSize":4}
+      ]}]'''
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "length":3, "capacity": 3, "members":[
+      {"staticSize":24, "exclusiveSize":24, "length":3, "capacity": 3, "members":[]},
+      {"staticSize":24, "exclusiveSize":24, "length":1, "capacity": 1, "members":[]},
+      {"staticSize":24, "exclusiveSize":24, "length":2, "capacity": 2, "members":[]}
+    ]}]'''

--- a/test/integration/std_list_del_allocator.toml
+++ b/test/integration/std_list_del_allocator.toml
@@ -27,7 +27,6 @@ includes = ["list"]
 
 [cases]
   [cases.a]
-    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/315
     param_types = ["const Foo&"]
     setup = '''
       Foo foo;
@@ -57,4 +56,11 @@ includes = ["list"]
                 {"name":"b", "typeName": "int", "staticSize":4, "dynamicSize":0}
               ]}
           ]}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize": 48,
+      "exclusiveSize": 0,
+      "members": [
+        {"name": "v1", "staticSize": 24, "exclusiveSize": 24, "length": 1, "capacity": 1},
+        {"name": "v2", "staticSize": 24, "exclusiveSize": 24, "length": 2, "capacity": 2}
       ]}]'''

--- a/types/cxx11_list_type.toml
+++ b/types/cxx11_list_type.toml
@@ -1,10 +1,10 @@
 [info]
 type_name = "std::__cxx11::list"
 stub_template_params = [1]
-ctype = "LIST_TYPE"
 header = "list"
 
 # Old:
+ctype = "LIST_TYPE"
 typeName = "std::__cxx11::list"
 ns = ["namespace std"]
 numTemplateParams = 1
@@ -33,28 +33,53 @@ void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1>
-struct TypeHandler<DB, %1% <T0, T1>> {
-  using type = types::st::Pair<DB,
-        types::st::VarInt<DB>,
-        types::st::List<DB, typename TypeHandler<DB, T0>::type>>;
+traversal_func = """
+auto tail = returnArg.write((uintptr_t)&container)
+                .write(container.size());
 
-  static types::st::Unit<DB> getSizeType(
-      const %1% <T0, T1> & container,
-      typename TypeHandler<DB, %1% <T0, T1>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container)
-                    .write(container.size());
+for (auto&& it : container) {
+  tail = tail.delegate([&it](auto ret) {
+    return OIInternal::getSizeType<DB>(it, ret);
+  });
+}
 
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it, ret);
-      });
-    }
+return tail.finish();
+"""
 
-    return tail.finish();
-  }
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+func = """
+#ifdef __GLIBCXX__
+static constexpr size_t element_size = sizeof(std::_List_node<T0>);
+#else
+static_assert(false && "No known element_size for list. See types/cxx11_list_type.toml");
+#endif
+
+static constexpr std::array<inst::Field, 1> child_field{
+  make_field<DB, T0>("*"),
 };
+static constexpr inst::Field element{
+  element_size,
+  element_size - sizeof(T0),
+  "[]",
+  std::array<std::string_view, 0>{},
+  child_field,
+  std::array<inst::ProcessorInst, 0>{},
+};
+static constexpr auto childField = make_field<DB, T0>("[]");
+
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats{
+  .capacity = list.length,
+  .length = list.length,
+});
+el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(T0);
+
+stack_ins(inst::Repeat{ list.length, childField });
 """

--- a/types/list_type.toml
+++ b/types/list_type.toml
@@ -33,28 +33,53 @@ void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1>
-struct TypeHandler<DB, %1% <T0, T1>> {
-  using type = types::st::Pair<DB,
-        types::st::VarInt<DB>,
-        types::st::List<DB, typename TypeHandler<DB, T0>::type>>;
+traversal_func = """
+auto tail = returnArg.write((uintptr_t)&container)
+                .write(container.size());
 
-  static types::st::Unit<DB> getSizeType(
-      const %1% <T0, T1> & container,
-      typename TypeHandler<DB, %1% <T0, T1>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container)
-                    .write(container.size());
+for (auto&& it : container) {
+  tail = tail.delegate([&it](auto ret) {
+    return OIInternal::getSizeType<DB>(it, ret);
+  });
+}
 
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it, ret);
-      });
-    }
+return tail.finish();
+"""
 
-    return tail.finish();
-  }
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+func = """
+#ifdef __GLIBCXX__
+static constexpr size_t element_size = sizeof(std::_List_node<T0>);
+#else
+static_assert(false && "No known element_size for list. See types/cxx11_list_type.toml");
+#endif
+
+static constexpr std::array<inst::Field, 1> child_field{
+  make_field<DB, T0>("*"),
 };
+static constexpr inst::Field element{
+  element_size,
+  element_size - sizeof(T0),
+  "[]",
+  std::array<std::string_view, 0>{},
+  child_field,
+  std::array<inst::ProcessorInst, 0>{},
+};
+static constexpr auto childField = make_field<DB, T0>("[]");
+
+auto list = std::get<ParsedData::List>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats{
+  .capacity = list.length,
+  .length = list.length,
+});
+el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(T0);
+
+stack_ins(inst::Repeat{ list.length, childField });
 """


### PR DESCRIPTION
oil: add support for std::list

Summary:

Remove the now useless `handler` and adds the `traversal_func` and `processor`
entries for `std::list`. This type is a bit weird as most of our sequential
containers don't have any overhead on storing the element. I went for the same
approach we take for maps where we have a shared `[]` element covering the map
overhead and below that a `key` & `value`. As we only have a single element
under it which doesn't have a logical name I went for `*`.

Closes #315.

Test Plan:
- CI
- Copied the relevant `std::vector` tests and updated the existing one.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/407).
* #410
* #409
* #408
* __->__ #407