### PR TITLE
types: remove now unused handlers

### DIFF
--- a/types/array_type.toml
+++ b/types/array_type.toml
@@ -29,27 +29,6 @@ void getSizeType(const %1%<T,N> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template<typename DB, typename T0, long unsigned int N>
-struct TypeHandler<DB, %1%<T0, N>> {
-  using type = types::st::List<DB, typename TypeHandler<DB, T0>::type>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, N> &container,
-      typename TypeHandler<DB, %1%<T0,N>>::type returnArg) {
-    auto tail = returnArg.write(container.size());
-
-    for (auto & it: container) {
-        tail = tail.delegate([&it](auto ret) {
-            return TypeHandler<DB, T0>::getSizeType(it, ret);
-        });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
     auto tail = returnArg.write(container.size());
 

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -36,24 +36,6 @@ void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0>
-struct TypeHandler<DB, %1% <T0>> {
-  using type =
-      types::st::Pair<DB, types::st::VarInt<DB>, types::st::VarInt<DB>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1% <T0> & container,
-      typename TypeHandler<DB, %1% <T0>>::type returnArg) {
-    bool sso = ((uintptr_t)container.data() <
-                (uintptr_t)(&container + sizeof(%1% <T0>))) &&
-               ((uintptr_t)container.data() >= (uintptr_t)&container);
-
-    return returnArg.write(container.capacity()).write(container.size());
-  }
-};
-"""
-
 extra = """
 template <typename DB, typename CharT, typename Traits, typename Allocator>
 class CaptureKeyHandler<DB, std::__cxx11::basic_string<CharT, Traits, Allocator>> {

--- a/types/deque_list_type.toml
+++ b/types/deque_list_type.toml
@@ -33,28 +33,3 @@ void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1>
-struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB, typename TypeHandler<DB, T0>::type>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1>& container,
-      typename TypeHandler<DB, %1%<T0, T1>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container)
-                    .write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return TypeHandler<DB, T0>::getSizeType(it, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""

--- a/types/f14_fast_map.toml
+++ b/types/f14_fast_map.toml
@@ -36,40 +36,6 @@ void getSizeType(const %1%<Key, Mapped, Hasher, KeyEqual, Alloc> &container, siz
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = types::st::Pair<DB,
-    types::st::VarInt<DB>,
-    types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB, types::st::Pair<DB,
-        typename TypeHandler<DB, T0>::type,
-        typename TypeHandler<DB, T1>::type>>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3, T4>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
-    size_t memorySize = container.getAllocatedMemorySize();
-    auto tail = returnArg
-      .write(memorySize)
-      .write(container.bucket_count())
-      .write(container.size());
-
-    for (auto &&entry: container) {
-      tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-        auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-          return OIInternal::getSizeType<DB>(key, ret);
-        });
-        return OIInternal::getSizeType<DB>(value, next);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)container.getAllocatedMemorySize())

--- a/types/f14_fast_set.toml
+++ b/types/f14_fast_set.toml
@@ -35,36 +35,6 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::Pair<DB,
-    types::st::VarInt<DB>,
-    types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB,
-        typename TypeHandler<DB, T0>::type>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    size_t memorySize = container.getAllocatedMemorySize();
-    auto tail = returnArg
-      .write(memorySize)
-      .write(container.bucket_count())
-      .write(container.size());
-
-    for (auto &&entry: container) {
-      tail = tail.delegate([&entry](auto ret) {
-        return OIInternal::getSizeType<DB>(entry, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)container.getAllocatedMemorySize())

--- a/types/f14_node_map.toml
+++ b/types/f14_node_map.toml
@@ -36,40 +36,6 @@ void getSizeType(const %1%<Key, Mapped, Hasher, KeyEqual, Alloc> &container, siz
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = types::st::Pair<DB,
-    types::st::VarInt<DB>,
-    types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB, types::st::Pair<DB,
-        typename TypeHandler<DB, T0>::type,
-        typename TypeHandler<DB, T1>::type>>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3, T4>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
-    size_t memorySize = container.getAllocatedMemorySize();
-    auto tail = returnArg
-      .write(memorySize)
-      .write(container.bucket_count())
-      .write(container.size());
-
-    for (auto &&entry: container) {
-      tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-        auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-          return OIInternal::getSizeType<DB>(key, ret);
-        });
-        return OIInternal::getSizeType<DB>(value, next);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)container.getAllocatedMemorySize())

--- a/types/f14_node_set.toml
+++ b/types/f14_node_set.toml
@@ -35,36 +35,6 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::Pair<DB,
-    types::st::VarInt<DB>,
-    types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB,
-        typename TypeHandler<DB, T0>::type>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    size_t memorySize = container.getAllocatedMemorySize();
-    auto tail = returnArg
-      .write(memorySize)
-      .write(container.bucket_count())
-      .write(container.size());
-
-    for (auto &&entry: container) {
-      tail = tail.delegate([&entry](auto ret) {
-        return OIInternal::getSizeType<DB>(entry, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)container.getAllocatedMemorySize())

--- a/types/f14_value_map.toml
+++ b/types/f14_value_map.toml
@@ -36,40 +36,6 @@ void getSizeType(const %1%<Key, Mapped, Hasher, KeyEqual, Alloc> &container, siz
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = types::st::Pair<DB,
-    types::st::VarInt<DB>,
-    types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB, types::st::Pair<DB,
-        typename TypeHandler<DB, T0>::type,
-        typename TypeHandler<DB, T1>::type>>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3, T4>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
-    size_t memorySize = container.getAllocatedMemorySize();
-    auto tail = returnArg
-      .write(memorySize)
-      .write(container.bucket_count())
-      .write(container.size());
-
-    for (auto &&entry: container) {
-      tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-        auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-          return OIInternal::getSizeType<DB>(key, ret);
-        });
-        return OIInternal::getSizeType<DB>(value, next);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)container.getAllocatedMemorySize())

--- a/types/f14_value_set.toml
+++ b/types/f14_value_set.toml
@@ -35,36 +35,6 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::Pair<DB,
-    types::st::VarInt<DB>,
-    types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB,
-        typename TypeHandler<DB, T0>::type>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    size_t memorySize = container.getAllocatedMemorySize();
-    auto tail = returnArg
-      .write(memorySize)
-      .write(container.bucket_count())
-      .write(container.size());
-
-    for (auto &&entry: container) {
-      tail = tail.delegate([&entry](auto ret) {
-        return OIInternal::getSizeType<DB>(entry, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)container.getAllocatedMemorySize())

--- a/types/f14_vector_map.toml
+++ b/types/f14_vector_map.toml
@@ -36,40 +36,6 @@ void getSizeType(const %1%<Key, Mapped, Hasher, KeyEqual, Alloc> &container, siz
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = types::st::Pair<DB,
-    types::st::VarInt<DB>,
-    types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB, types::st::Pair<DB,
-        typename TypeHandler<DB, T0>::type,
-        typename TypeHandler<DB, T1>::type>>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3, T4>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
-    size_t memorySize = container.getAllocatedMemorySize();
-    auto tail = returnArg
-      .write(memorySize)
-      .write(container.bucket_count())
-      .write(container.size());
-
-    for (auto &&entry: container) {
-      tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-        auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-          return OIInternal::getSizeType<DB>(key, ret);
-        });
-        return OIInternal::getSizeType<DB>(value, next);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)container.getAllocatedMemorySize())

--- a/types/f14_vector_set.toml
+++ b/types/f14_vector_set.toml
@@ -35,36 +35,6 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::Pair<DB,
-    types::st::VarInt<DB>,
-    types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB,
-        typename TypeHandler<DB, T0>::type>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    size_t memorySize = container.getAllocatedMemorySize();
-    auto tail = returnArg
-      .write(memorySize)
-      .write(container.bucket_count())
-      .write(container.size());
-
-    for (auto &&entry: container) {
-      tail = tail.delegate([&entry](auto ret) {
-        return OIInternal::getSizeType<DB>(entry, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)container.getAllocatedMemorySize())

--- a/types/fb_string_type.toml
+++ b/types/fb_string_type.toml
@@ -38,38 +38,6 @@ void getSizeType(const %1%<E, T, A, Storage> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::Pair<DB,
-        types::st::VarInt<DB>,
-        types::st::Pair<DB,
-          types::st::VarInt<DB>,
-          types::st::VarInt<DB>
-      >>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    auto last = returnArg.write((uintptr_t)container.data())
-                    .write(container.capacity())
-                    .write(container.size());
-
-    bool inlined = ((uintptr_t)container.data() < (uintptr_t)(&container + sizeof(%1%<T0, T1, T2, T3>)))
-        &&
-      ((uintptr_t)container.data() >= (uintptr_t)&container);
-
-    if (!inlined && pointers.add((uintptr_t)container.data())) {
-      return last.write(1);
-    } else {
-      return last.write(0);
-    }
-  }
-};
-"""
-
 traversal_func = """
 // fbstring has inlining (SSO) and allocates large strings as
 // reference counted strings. Reference counted strings have an

--- a/types/map_seq_type.toml
+++ b/types/map_seq_type.toml
@@ -35,37 +35,6 @@ void getSizeType(const %1%<Key, Value, Compare, Allocator, GrowthPolicy, Contain
     }
 }
 """
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4, T5>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::Pair<DB,
-        types::st::VarInt<DB>,
-        types::st::List<DB, types::st::Pair<DB,
-          typename TypeHandler<DB, T0>::type,
-          typename TypeHandler<DB, T1>::type
-    >>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3, T4, T5>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4, T5>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container)
-                    .write(container.capacity())
-                    .write(container.size());
-
-    for (const auto& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it.second, ret.delegate([&it](auto ret) {
-            return OIInternal::getSizeType<DB>(it.first, ret);
-        }));
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
 
 traversal_func = '''
     auto tail = returnArg.write((uintptr_t)&container)

--- a/types/multi_map_type.toml
+++ b/types/multi_map_type.toml
@@ -33,34 +33,6 @@ void getSizeType(const %1%<Key,T,Compare,Allocator> &container, size_t& returnAr
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::List<DB, types::st::Pair<DB,
-      typename TypeHandler<DB, T0>::type,
-      typename TypeHandler<DB, T1>::type
-    >>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    auto tail = returnArg.write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it.second, ret.delegate([&it](auto ret) {
-            return OIInternal::getSizeType<DB>(it.first, ret);
-        }));
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)&container)

--- a/types/multi_set_type.toml
+++ b/types/multi_set_type.toml
@@ -35,31 +35,6 @@ void getSizeType(const %1%<Key, Compare, Alloc> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2>
-struct TypeHandler<DB, %1% <T0, T1, T2>> {
-  using type = types::st::List<DB, typename TypeHandler<DB, T0>::type>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2>>::type returnArg) {
-    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2>::node_type);
-
-    auto tail = returnArg.write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg.write((uintptr_t)&container)
                 .write(container.size());

--- a/types/optional_type.toml
+++ b/types/optional_type.toml
@@ -28,28 +28,6 @@ void getSizeType(const %1%<T>& container, size_t& returnArg) {
 }
 """
 
-handler = """
-template <typename DB, typename T0>
-struct TypeHandler<DB, %1%<T0>> {
-    using type = types::st::Sum<DB,
-      types::st::Unit<DB>,
-      typename TypeHandler<DB, T0>::type
-    >;
-
-    static types::st::Unit<DB> getSizeType(
-        const %1%<T0>& container,
-        typename TypeHandler<DB, %1%<T0>>::type returnArg) {
-      if (container) {
-        return returnArg.template delegate<1>([&container](auto ret) {
-          return OIInternal::getSizeType<DB>(*container, ret);
-        });
-      } else {
-        return returnArg.template delegate<0>(std::identity());
-      }
-    }
-};
-"""
-
 traversal_func = """
 if (container.has_value()) {
   return returnArg.template delegate<1>([&container](auto ret) {

--- a/types/pair_type.toml
+++ b/types/pair_type.toml
@@ -26,26 +26,6 @@ void getSizeType(const %1%<P,Q> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1>
-struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = types::st::Pair<DB,
-      typename TypeHandler<DB, T0>::type,
-      typename TypeHandler<DB, T1>::type>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1> & container,
-      typename TypeHandler<DB, %1%<T0, T1>>::type returnArg) {
-    return OIInternal::getSizeType<DB>(
-        container.second,
-        returnArg.delegate([&container](auto ret) {
-            return OIInternal::getSizeType<DB>(container.first, ret);
-        })
-    );
-  }
-};
-"""
-
 traversal_func = """
     return OIInternal::getSizeType<DB>(
         container.second,

--- a/types/priority_queue_container_adapter_type.toml
+++ b/types/priority_queue_container_adapter_type.toml
@@ -32,21 +32,3 @@ void getSizeType(const %1%<T, Container, Cmp> &containerAdapter, size_t& returnA
     getSizeType(container, returnArg);
 }
 """
-
-handler = """
-template <typename DB, typename T0, typename T1, typename T2>
-struct TypeHandler<DB, %1%<T0, T1, T2>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      typename TypeHandler<DB, T1>::type>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container);
-
-    const T1 &underlyingContainer = get_container(container);
-    return OIInternal::getSizeType<DB>(underlyingContainer, tail);
-  }
-};
-"""

--- a/types/queue_container_adapter_type.toml
+++ b/types/queue_container_adapter_type.toml
@@ -32,20 +32,3 @@ void getSizeType(const %1%<T, Container> &containerAdapter, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1>
-struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      typename TypeHandler<DB, T1>::type>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1% <T0, T1> & container,
-      typename TypeHandler<DB, %1% <T0, T1>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container);
-
-    const T1 &underlyingContainer = get_container(container);
-    return OIInternal::getSizeType<DB>(underlyingContainer, tail);
-  }
-};
-"""

--- a/types/ref_wrapper_type.toml
+++ b/types/ref_wrapper_type.toml
@@ -29,29 +29,3 @@ void getSizeType(const %1%<T> &ref, size_t& returnArg)
     }
 }
 """
-
-handler = """
-template <typename DB, typename T0>
-struct TypeHandler<DB, %1%<T0>> {
-    using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::Sum<DB,
-        types::st::Unit<DB>,
-        typename TypeHandler<DB, T0>::type
-    >>;
-
-    static types::st::Unit<DB> getSizeType(
-        const %1%<T0>& container,
-        typename TypeHandler<DB, %1%<T0>>::type returnArg) {
-      auto r0 = returnArg.write((uintptr_t)&(container.get()));
-
-      if (pointers.add((uintptr_t)&container.get())) {
-        return r0.template delegate<1>([&container](auto ret) {
-          return OIInternal::getSizeType<DB>(container.get(), ret);
-        });
-      } else {
-        return r0.template delegate<0>(std::identity());
-      }
-    }
-};
-"""

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -35,35 +35,6 @@ void getSizeType(const %1%<T, Allocator> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1>
-struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = types::st::Pair<
-      DB, types::st::VarInt<DB>,
-      types::st::Pair<
-          DB, types::st::VarInt<DB>,
-          types::st::List<DB, typename TypeHandler<DB, T0>::type>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1> & container,
-      typename TypeHandler<DB, %1%<T0, T1>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container)
-                    .write(container.capacity())
-                    .write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg.write((uintptr_t)&container)
                 .write(container.capacity())

--- a/types/set_type.toml
+++ b/types/set_type.toml
@@ -36,34 +36,6 @@ void getSizeType(const %1%<Key, Compare, Alloc> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2>
-struct TypeHandler<DB, %1% <T0, T1, T2>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB, typename TypeHandler<DB, T0>::type>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2>>::type returnArg) {
-    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2>::node_type);
-
-    auto tail = returnArg.write(nodeSize)
-                    .write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg.write((uintptr_t)&container)
                 .write(container.size());

--- a/types/shrd_ptr_type.toml
+++ b/types/shrd_ptr_type.toml
@@ -34,38 +34,6 @@ void getSizeType(const %1%<T> &s_ptr, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0>
-struct TypeHandler<DB, %1%<T0>> {
-    using type = typename std::conditional<
-      std::is_void<T0>::value,
-      types::st::Unit<DB>,
-      types::st::Pair<DB,
-        types::st::VarInt<DB>,
-        types::st::Sum<DB,
-          types::st::Unit<DB>,
-          typename TypeHandler<DB, T0>::type
-      >>>::type;
-
-    static types::st::Unit<DB> getSizeType(
-        const %1%<T0>& container,
-        typename TypeHandler<DB, %1%<T0>>::type returnArg) {
-      if constexpr (!std::is_void<T0>::value) {
-        auto r0 = returnArg.write((uintptr_t)(container.get()));
-        if (container && pointers.add((uintptr_t)(container.get()))) {
-          return r0.template delegate<1>([&container](auto ret) {
-            return OIInternal::getSizeType<DB>(*(container.get()), ret);
-          });
-        } else {
-          return r0.template delegate<0>(std::identity());
-        }
-      } else {
-        return returnArg;
-      }
-    }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg.write((uintptr_t)container.get());
 

--- a/types/small_vec_type.toml
+++ b/types/small_vec_type.toml
@@ -42,33 +42,6 @@ void getSizeType(const %1%<V, N, P> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, std::size_t N0, typename T1>
-struct TypeHandler<DB, %1%<T0, N0, T1>> {
-  using type = types::st::Pair<
-      DB, types::st::VarInt<DB>,
-      types::st::Pair<
-          DB, types::st::VarInt<DB>,
-          types::st::List<DB, typename TypeHandler<DB, T0>::type>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, N0, T1> & container,
-      typename TypeHandler<DB, %1%<T0, N0, T1>>::type returnArg) {
-    auto tail = returnArg.write(N0)
-                    .write(container.capacity())
-                    .write(container.size());
-
-    for (auto& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 // If `container.data()` pointer is within the container struct,
 // then the container's storage is inlined and doesn't uses the heap.

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -31,23 +31,6 @@ void getSizeType(const %1%<T,Compare, Allocator, GrowthPolicy, Container> &conta
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      typename TypeHandler<DB, T4>::type>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3, T4>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container);
-    const T4 &underlyingContainer = container.get_container();
-    return OIInternal::getSizeType<DB>(underlyingContainer, tail);
-  }
-};
-"""
-
 traversal_func = '''
 auto tail = returnArg.write((uintptr_t)&container)
                 .write(container.capacity())

--- a/types/stack_container_adapter_type.toml
+++ b/types/stack_container_adapter_type.toml
@@ -31,21 +31,3 @@ void getSizeType(const %1%<T, Container> &containerAdapter, size_t& returnArg)
     getSizeType(container, returnArg);
 }
 """
-
-handler = """
-template <typename DB, typename T0, typename T1>
-struct TypeHandler<DB, %1%<T0, T1>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      typename TypeHandler<DB, T1>::type>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1% <T0, T1> & container,
-      typename TypeHandler<DB, %1% <T0, T1>>::type returnArg) {
-    auto tail = returnArg.write((uintptr_t)&container);
-
-    const T1 &underlyingContainer = get_container(container);
-    return OIInternal::getSizeType<DB>(underlyingContainer, tail);
-  }
-};
-"""

--- a/types/std_map_type.toml
+++ b/types/std_map_type.toml
@@ -37,38 +37,6 @@ void getSizeType(const %1%<K, T, C, A> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::List<DB, types::st::Pair<DB,
-        typename TypeHandler<DB, T0>::type,
-        typename TypeHandler<DB, T1>::type
-    >>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3>::node_type);
-
-    auto tail = returnArg.write(nodeSize).write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (const auto& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it.second, ret.delegate([&it](auto ret) {
-            return OIInternal::getSizeType<DB>(it.first, ret);
-        }));
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)&container)

--- a/types/std_unordered_map_type.toml
+++ b/types/std_unordered_map_type.toml
@@ -39,42 +39,6 @@ void getSizeType(const %1%<K, T, H, KE, A> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::Pair<DB,
-        types::st::VarInt<DB>,
-        types::st::List<DB, types::st::Pair<DB,
-          typename TypeHandler<DB, T0>::type,
-          typename TypeHandler<DB, T1>::type
-    >>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3, T4>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
-    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3, T4>::node_type);
-
-    auto tail = returnArg.write(nodeSize)
-                    .write(container.bucket_count())
-                    .write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (const auto& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it.second, ret.delegate([&it](auto ret) {
-            return OIInternal::getSizeType<DB>(it.first, ret);
-        }));
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)&container)

--- a/types/std_unordered_multimap_type.toml
+++ b/types/std_unordered_multimap_type.toml
@@ -39,42 +39,6 @@ void getSizeType(const %1%<K, T, H, KE, A> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3, typename T4>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3, T4>> {
-  using type = types::st::Pair<DB,
-      types::st::VarInt<DB>,
-      types::st::Pair<DB,
-        types::st::VarInt<DB>,
-        types::st::List<DB, types::st::Pair<DB,
-          typename TypeHandler<DB, T0>::type,
-          typename TypeHandler<DB, T1>::type
-    >>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3, T4>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3, T4>>::type returnArg) {
-    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3, T4>::node_type);
-
-    auto tail = returnArg.write(nodeSize)
-                    .write(container.bucket_count())
-                    .write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (const auto& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it.second, ret.delegate([&it](auto ret) {
-            return OIInternal::getSizeType<DB>(it.first, ret);
-        }));
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)&container)

--- a/types/std_variant.toml
+++ b/types/std_variant.toml
@@ -36,33 +36,5 @@ void getSizeType(const %1%<Types...> &container, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename... Types>
-struct TypeHandler<DB, %1%<Types...>> {
-    using type = types::st::Sum<DB, typename TypeHandler<DB, Types>::type..., types::st::Unit<DB>>;
-
-    static types::st::Unit<DB> getSizeType(
-        const %1%<Types...>& container,
-        typename TypeHandler<DB, %1%<Types...>>::type returnArg) {
-      return getSizeTypeRecursive(container, returnArg);
-    }
-
-  private:
-    template <size_t I = 0>
-    static types::st::Unit<DB> getSizeTypeRecursive(
-        const %1%<Types...>& container,
-        typename TypeHandler<DB, %1%<Types...>>::type returnArg) {
-      if constexpr (I < sizeof...(Types)) {
-        if (I == container.index()) {
-          return returnArg.template delegate<I>([&container](auto ret) {
-            return OIInternal::getSizeType<DB>(std::get<I>(container), ret);
-          });
-        } else {
-          return getSizeTypeRecursive<I+1>(container, returnArg);
-        }
-      } else {
-        return returnArg.template delegate<sizeof...(Types)>(std::identity());
-      }
-    }
-};
-"""
+# TODO: Add tbv2 definitions. The removed intermediate handler is a good
+# template for this, find it in the git logs.

--- a/types/thrift_isset_type.toml
+++ b/types/thrift_isset_type.toml
@@ -17,9 +17,6 @@ decl = """
 func = """
 // DummyFunc %1%
 """
-handler = """
-// DummyHandler %1%
-"""
 
 traversal_func = """
 return returnArg;

--- a/types/uniq_ptr_type.toml
+++ b/types/uniq_ptr_type.toml
@@ -35,38 +35,6 @@ void getSizeType(const %1%<T,Deleter> &u_ptr, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1>
-struct TypeHandler<DB, %1%<T0,T1>> {
-    using type = typename std::conditional<
-      std::is_void<T0>::value,
-      types::st::Unit<DB>,
-      types::st::Pair<DB,
-        types::st::VarInt<DB>,
-        types::st::Sum<DB,
-          types::st::Unit<DB>,
-          typename TypeHandler<DB, T0>::type
-      >>>::type;
-
-    static types::st::Unit<DB> getSizeType(
-        const %1%<T0,T1>& container,
-        typename TypeHandler<DB, %1%<T0,T1>>::type returnArg) {
-      if constexpr (!std::is_void<T0>::value) {
-        auto r0 = returnArg.write((uintptr_t)(container.get()));
-        if (container && pointers.add((uintptr_t)(container.get()))) {
-          return r0.template delegate<1>([&container](auto ret) {
-            return OIInternal::getSizeType<DB>(*(container.get()), ret);
-          });
-        } else {
-          return r0.template delegate<0>(std::identity());
-        }
-      } else {
-        return returnArg;
-      }
-    }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg.write((uintptr_t)container.get());
 

--- a/types/unordered_multiset_type.toml
+++ b/types/unordered_multiset_type.toml
@@ -37,37 +37,6 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::Pair<
-      DB, types::st::VarInt<DB>,
-      types::st::Pair<
-          DB, types::st::VarInt<DB>,
-          types::st::List<DB, typename TypeHandler<DB, T0>::type>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3>::node_type);
-
-    auto tail = returnArg.write(nodeSize)
-                    .write(container.bucket_count())
-                    .write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)&container)

--- a/types/unordered_set_type.toml
+++ b/types/unordered_set_type.toml
@@ -37,37 +37,6 @@ void getSizeType(const %1%<Key, Hasher, KeyEqual, Alloc> &container, size_t& ret
 }
 """
 
-handler = """
-template <typename DB, typename T0, typename T1, typename T2, typename T3>
-struct TypeHandler<DB, %1%<T0, T1, T2, T3>> {
-  using type = types::st::Pair<
-      DB, types::st::VarInt<DB>,
-      types::st::Pair<
-          DB, types::st::VarInt<DB>,
-          types::st::List<DB, typename TypeHandler<DB, T0>::type>>>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0, T1, T2, T3>& container,
-      typename TypeHandler<DB, %1%<T0, T1, T2, T3>>::type returnArg) {
-    constexpr size_t nodeSize = sizeof(typename %1%<T0, T1, T2, T3>::node_type);
-
-    auto tail = returnArg.write(nodeSize)
-                    .write(container.bucket_count())
-                    .write(container.size());
-
-    // The double ampersand is needed otherwise this loop doesn't work with
-    // vector<bool>
-    for (auto&& it : container) {
-      tail = tail.delegate([&it](auto ret) {
-        return OIInternal::getSizeType<DB>(it, ret);
-      });
-    }
-
-    return tail.finish();
-  }
-};
-"""
-
 traversal_func = """
 auto tail = returnArg
   .write((uintptr_t)&container)

--- a/types/weak_ptr_type.toml
+++ b/types/weak_ptr_type.toml
@@ -24,18 +24,5 @@ void getSizeType(const %1%<T> &s_ptr, size_t& returnArg)
 }
 """
 
-handler = """
-template <typename DB, typename T0>
-struct TypeHandler<DB, %1%<T0>> {
-  using type = types::st::Unit<DB>;
-
-  static types::st::Unit<DB> getSizeType(
-      const %1%<T0>& container,
-      typename TypeHandler<DB, %1%<T0>>::type returnArg) {
-    return returnArg;
-  }
-};
-"""
-
 traversal_func = "return returnArg;"
 


### PR DESCRIPTION
types: remove now unused handlers

Summary:

Handlers were added in an intermediate form of tbv2 but those intermediate
forms have now been removed. Remove all the handlers to make grepping/find and
replaces easier across the types.

Test Plan:

- CI

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/408).
* #410
* #409
* __->__ #408