### PR TITLE
tbv2: replace DB template param with Ctx

### DIFF
--- a/types/array_type.toml
+++ b/types/array_type.toml
@@ -34,7 +34,7 @@ traversal_func = """
 
     for (auto & it: container) {
         tail = tail.delegate([&it](auto ret) {
-            return TypeHandler<DB, T0>::getSizeType(it, ret);
+            return TypeHandler<Ctx, T0>::getSizeType(it, ret);
         });
     }
 
@@ -42,9 +42,9 @@ traversal_func = """
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 size_t size = std::get<ParsedData::List>(d.val).length;
 el.exclusive_size = N0 == 0 ? 1 : 0;

--- a/types/cxx11_list_type.toml
+++ b/types/cxx11_list_type.toml
@@ -39,7 +39,7 @@ auto tail = returnArg.write((uintptr_t)&container)
 
 for (auto&& it : container) {
   tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -53,7 +53,7 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
 #ifdef __GLIBCXX__
 static constexpr size_t element_size = sizeof(std::_List_node<T0>);
@@ -62,7 +62,7 @@ static_assert(false && "No known element_size for list. See types/cxx11_list_typ
 #endif
 
 static constexpr std::array<inst::Field, 1> child_field{
-  make_field<DB, T0>("*"),
+  make_field<Ctx, T0>("*"),
 };
 static constexpr inst::Field element{
   element_size,
@@ -72,7 +72,7 @@ static constexpr inst::Field element{
   child_field,
   std::array<inst::ProcessorInst, 0>{},
 };
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats.emplace(result::Element::ContainerStats{

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -37,8 +37,9 @@ void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
 """
 
 extra = """
-template <typename DB, typename CharT, typename Traits, typename Allocator>
-class CaptureKeyHandler<DB, std::__cxx11::basic_string<CharT, Traits, Allocator>> {
+template <typename Ctx, typename CharT, typename Traits, typename Allocator>
+class CaptureKeyHandler<Ctx, std::__cxx11::basic_string<CharT, Traits, Allocator>> {
+  using DB = typename Ctx::DataBuffer;
  public:
   // List of characters
   using type = types::st::List<DB, types::st::VarInt<DB>>;

--- a/types/f14_fast_map.toml
+++ b/types/f14_fast_map.toml
@@ -44,10 +44,10 @@ auto tail = returnArg
 
 for (auto &&entry: container) {
   tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-      return OIInternal::getSizeType<DB>(key, ret);
+    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(key, ret);
     });
-    return OIInternal::getSizeType<DB>(value, next);
+    return OIInternal::getSizeType<Ctx>(value, next);
   });
 }
 
@@ -69,8 +69,8 @@ el.container_stats.emplace(result::Element::ContainerStats {
 [[codegen.processor]]
 type = """
 types::st::List<DB, types::st::Pair<DB,
-  typename TypeHandler<DB, T0>::type,
-  typename TypeHandler<DB, T1>::type>>
+  typename TypeHandler<Ctx, T0>::type,
+  typename TypeHandler<Ctx, T1>::type>>
 """
 func = """
 static constexpr size_t element_size = sizeof(typename container_type::value_type);
@@ -84,8 +84,8 @@ el.container_stats->length = list.length;
 el.exclusive_size += allocationSize - list.length * element_size;
 
 static constexpr std::array<inst::Field, 2> element_fields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
 
 static constexpr inst::Field element{

--- a/types/f14_fast_set.toml
+++ b/types/f14_fast_set.toml
@@ -43,7 +43,7 @@ auto tail = returnArg
 
 for (auto &&entry: container) {
   tail = tail.delegate([&entry](auto ret) {
-    return OIInternal::getSizeType<DB>(entry, ret);
+    return OIInternal::getSizeType<Ctx>(entry, ret);
   });
 }
 
@@ -64,7 +64,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
 
 [[codegen.processor]]
 type = """
-types::st::List<DB, typename TypeHandler<DB, T0>::type>
+types::st::List<DB, typename TypeHandler<Ctx, T0>::type>
 """
 func = """
 auto allocationSize = el.pointer.value();
@@ -75,7 +75,7 @@ el.container_stats->length = list.length;
 
 el.exclusive_size += allocationSize - list.length * sizeof(T0);
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 for (size_t i = 0; i < list.length; i++)
   stack_ins(childField);
 """

--- a/types/f14_node_map.toml
+++ b/types/f14_node_map.toml
@@ -44,10 +44,10 @@ auto tail = returnArg
 
 for (auto &&entry: container) {
   tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-      return OIInternal::getSizeType<DB>(key, ret);
+    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(key, ret);
     });
-    return OIInternal::getSizeType<DB>(value, next);
+    return OIInternal::getSizeType<Ctx>(value, next);
   });
 }
 
@@ -69,8 +69,8 @@ el.container_stats.emplace(result::Element::ContainerStats {
 [[codegen.processor]]
 type = """
 types::st::List<DB, types::st::Pair<DB,
-  typename TypeHandler<DB, T0>::type,
-  typename TypeHandler<DB, T1>::type>>
+  typename TypeHandler<Ctx, T0>::type,
+  typename TypeHandler<Ctx, T1>::type>>
 """
 func = """
 static constexpr size_t element_size = sizeof(typename container_type::value_type);
@@ -84,8 +84,8 @@ el.container_stats->length = list.length;
 el.exclusive_size += allocationSize - list.length * element_size;
 
 static constexpr std::array<inst::Field, 2> element_fields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
 
 static constexpr inst::Field element{

--- a/types/f14_node_set.toml
+++ b/types/f14_node_set.toml
@@ -43,7 +43,7 @@ auto tail = returnArg
 
 for (auto &&entry: container) {
   tail = tail.delegate([&entry](auto ret) {
-    return OIInternal::getSizeType<DB>(entry, ret);
+    return OIInternal::getSizeType<Ctx>(entry, ret);
   });
 }
 
@@ -64,7 +64,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
 
 [[codegen.processor]]
 type = """
-types::st::List<DB, typename TypeHandler<DB, T0>::type>
+types::st::List<DB, typename TypeHandler<Ctx, T0>::type>
 """
 func = """
 auto allocationSize = el.pointer.value();
@@ -75,7 +75,7 @@ el.container_stats->length = list.length;
 
 el.exclusive_size += allocationSize - list.length * sizeof(T0);
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 for (size_t i = 0; i < list.length; i++)
   stack_ins(childField);
 """

--- a/types/f14_value_map.toml
+++ b/types/f14_value_map.toml
@@ -44,10 +44,10 @@ auto tail = returnArg
 
 for (auto &&entry: container) {
   tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-      return OIInternal::getSizeType<DB>(key, ret);
+    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(key, ret);
     });
-    return OIInternal::getSizeType<DB>(value, next);
+    return OIInternal::getSizeType<Ctx>(value, next);
   });
 }
 
@@ -69,8 +69,8 @@ el.container_stats.emplace(result::Element::ContainerStats {
 [[codegen.processor]]
 type = """
 types::st::List<DB, types::st::Pair<DB,
-  typename TypeHandler<DB, T0>::type,
-  typename TypeHandler<DB, T1>::type>>
+  typename TypeHandler<Ctx, T0>::type,
+  typename TypeHandler<Ctx, T1>::type>>
 """
 func = """
 static constexpr size_t element_size = sizeof(typename container_type::value_type);
@@ -84,8 +84,8 @@ el.container_stats->length = list.length;
 el.exclusive_size += allocationSize - list.length * element_size;
 
 static constexpr std::array<inst::Field, 2> element_fields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
 
 static constexpr inst::Field element{

--- a/types/f14_value_set.toml
+++ b/types/f14_value_set.toml
@@ -43,7 +43,7 @@ auto tail = returnArg
 
 for (auto &&entry: container) {
   tail = tail.delegate([&entry](auto ret) {
-    return OIInternal::getSizeType<DB>(entry, ret);
+    return OIInternal::getSizeType<Ctx>(entry, ret);
   });
 }
 
@@ -64,7 +64,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
 
 [[codegen.processor]]
 type = """
-types::st::List<DB, typename TypeHandler<DB, T0>::type>
+types::st::List<DB, typename TypeHandler<Ctx, T0>::type>
 """
 func = """
 auto allocationSize = el.pointer.value();
@@ -75,7 +75,7 @@ el.container_stats->length = list.length;
 
 el.exclusive_size += allocationSize - list.length * sizeof(T0);
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 for (size_t i = 0; i < list.length; i++)
   stack_ins(childField);
 """

--- a/types/f14_vector_map.toml
+++ b/types/f14_vector_map.toml
@@ -44,10 +44,10 @@ auto tail = returnArg
 
 for (auto &&entry: container) {
   tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-      return OIInternal::getSizeType<DB>(key, ret);
+    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(key, ret);
     });
-    return OIInternal::getSizeType<DB>(value, next);
+    return OIInternal::getSizeType<Ctx>(value, next);
   });
 }
 
@@ -69,8 +69,8 @@ el.container_stats.emplace(result::Element::ContainerStats {
 [[codegen.processor]]
 type = """
 types::st::List<DB, types::st::Pair<DB,
-  typename TypeHandler<DB, T0>::type,
-  typename TypeHandler<DB, T1>::type>>
+  typename TypeHandler<Ctx, T0>::type,
+  typename TypeHandler<Ctx, T1>::type>>
 """
 func = """
 static constexpr size_t element_size = sizeof(typename container_type::value_type);
@@ -84,8 +84,8 @@ el.container_stats->length = list.length;
 el.exclusive_size += allocationSize - list.length * element_size;
 
 static constexpr std::array<inst::Field, 2> element_fields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
 
 static constexpr inst::Field element{

--- a/types/f14_vector_set.toml
+++ b/types/f14_vector_set.toml
@@ -43,7 +43,7 @@ auto tail = returnArg
 
 for (auto &&entry: container) {
   tail = tail.delegate([&entry](auto ret) {
-    return OIInternal::getSizeType<DB>(entry, ret);
+    return OIInternal::getSizeType<Ctx>(entry, ret);
   });
 }
 
@@ -64,7 +64,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
 
 [[codegen.processor]]
 type = """
-types::st::List<DB, typename TypeHandler<DB, T0>::type>
+types::st::List<DB, typename TypeHandler<Ctx, T0>::type>
 """
 func = """
 auto allocationSize = el.pointer.value();
@@ -75,7 +75,7 @@ el.container_stats->length = list.length;
 
 el.exclusive_size += allocationSize - list.length * sizeof(T0);
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 for (size_t i = 0; i < list.length; i++)
   stack_ins(childField);
 """

--- a/types/list_type.toml
+++ b/types/list_type.toml
@@ -39,7 +39,7 @@ auto tail = returnArg.write((uintptr_t)&container)
 
 for (auto&& it : container) {
   tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -53,7 +53,7 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
 #ifdef __GLIBCXX__
 static constexpr size_t element_size = sizeof(std::_List_node<T0>);
@@ -62,7 +62,7 @@ static_assert(false && "No known element_size for list. See types/cxx11_list_typ
 #endif
 
 static constexpr std::array<inst::Field, 1> child_field{
-  make_field<DB, T0>("*"),
+  make_field<Ctx, T0>("*"),
 };
 static constexpr inst::Field element{
   element_size,
@@ -72,7 +72,7 @@ static constexpr inst::Field element{
   child_field,
   std::array<inst::ProcessorInst, 0>{},
 };
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats.emplace(result::Element::ContainerStats{

--- a/types/map_seq_type.toml
+++ b/types/map_seq_type.toml
@@ -43,11 +43,11 @@ traversal_func = '''
 
     for (const auto& kv : container) {
       tail = tail.delegate([&kv](auto ret) {
-        auto start = maybeCaptureKey<captureKeys, DB, T0>(kv.first, ret);
-        auto next = start.delegate([&kv](typename TypeHandler<DB, T0>::type ret) {
-          return OIInternal::getSizeType<DB>(kv.first, ret);
+        auto start = maybeCaptureKey<captureKeys, Ctx, T0>(kv.first, ret);
+        auto next = start.delegate([&kv](typename TypeHandler<Ctx, T0>::type ret) {
+          return OIInternal::getSizeType<Ctx>(kv.first, ret);
         });
-        return OIInternal::getSizeType<DB>(kv.second, next);
+        return OIInternal::getSizeType<Ctx>(kv.second, next);
       });
     }
 
@@ -68,22 +68,22 @@ el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get
 type = '''
 std::conditional_t<captureKeys,
   types::st::List<DB, types::st::Pair<DB,
-    typename CaptureKeyHandler<DB, T0>::type,
+    typename CaptureKeyHandler<Ctx, T0>::type,
     types::st::Pair<DB,
-      typename TypeHandler<DB, T0>::type,
-      typename TypeHandler<DB, T1>::type>>>,
+      typename TypeHandler<Ctx, T0>::type,
+      typename TypeHandler<Ctx, T1>::type>>>,
   types::st::List<DB, types::st::Pair<DB,
-    typename TypeHandler<DB, T0>::type,
-    typename TypeHandler<DB, T1>::type>>>
+    typename TypeHandler<Ctx, T0>::type,
+    typename TypeHandler<Ctx, T1>::type>>>
 '''
 func = '''
 using element_type = std::pair<T0, T1>;
 
 static constexpr std::array<inst::Field, 2> entryFields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
-static constexpr auto processors = maybeCaptureKeysProcessor<captureKeys, DB, T0>();
+static constexpr auto processors = maybeCaptureKeysProcessor<captureKeys, Ctx, T0>();
 static constexpr auto entry = inst::Field {
   sizeof(element_type),
   sizeof(element_type) - sizeof(T0) - sizeof(T1),

--- a/types/multi_map_type.toml
+++ b/types/multi_map_type.toml
@@ -40,10 +40,10 @@ auto tail = returnArg
 
 for (const auto &entry: container) {
   tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-      return OIInternal::getSizeType<DB>(key, ret);
+    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(key, ret);
     });
-    return OIInternal::getSizeType<DB>(value, next);
+    return OIInternal::getSizeType<Ctx>(value, next);
   });
 }
 
@@ -57,8 +57,8 @@ func = "el.pointer = std::get<ParsedData::VarInt>(d.val).value;"
 [[codegen.processor]]
 type = """
 types::st::List<DB, types::st::Pair<DB,
-  typename TypeHandler<DB, T0>::type,
-  typename TypeHandler<DB, T1>::type>>
+  typename TypeHandler<Ctx, T0>::type,
+  typename TypeHandler<Ctx, T1>::type>>
 """
 func = """
 #ifdef __GLIBCXX__
@@ -108,8 +108,8 @@ static_assert(false && "No known element_size for sets. See types/multi_map_type
 #endif
 
 static constexpr std::array<inst::Field, 2> elementFields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
 static constexpr auto element = inst::Field {
   element_size,

--- a/types/multi_set_type.toml
+++ b/types/multi_set_type.toml
@@ -43,7 +43,7 @@ auto tail = returnArg.write((uintptr_t)&container)
 // vector<bool>
 for (auto&& it : container) {
   tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -57,7 +57,7 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
 #ifdef __GLIBCXX__
 /* We don't have access to the _Rb_tree_node struct, so we manually re-create it
@@ -103,7 +103,7 @@ static constexpr size_t element_size = sizeof(OI__tree_node);
 static_assert(false && "No known element_size for multisets. See types/multi_set_type.toml");
 #endif
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats.emplace(result::Element::ContainerStats {

--- a/types/optional_type.toml
+++ b/types/optional_type.toml
@@ -31,7 +31,7 @@ void getSizeType(const %1%<T>& container, size_t& returnArg) {
 traversal_func = """
 if (container.has_value()) {
   return returnArg.template delegate<1>([&container](auto ret) {
-    return OIInternal::getSizeType<DB>(*container, ret);
+    return OIInternal::getSizeType<Ctx>(*container, ret);
   });
 } else {
   return returnArg.template delegate<0>(std::identity());
@@ -39,15 +39,15 @@ if (container.has_value()) {
 """
 
 [[codegen.processor]]
-type = "types::st::Sum<DB, types::st::Unit<DB>, typename TypeHandler<DB, T0>::type>"
+type = "types::st::Sum<DB, types::st::Unit<DB>, typename TypeHandler<Ctx, T0>::type>"
 func = """
 static constexpr std::array<std::string_view, 1> names{"TODO"};
 static constexpr auto elementField = inst::Field{
   sizeof(T0),
   "el",
   names,
-  TypeHandler<DB, T0>::fields,
-  TypeHandler<DB, T0>::processors,
+  TypeHandler<Ctx, T0>::fields,
+  TypeHandler<Ctx, T0>::processors,
 };
 
 auto sum = std::get<ParsedData::Sum>(d.val);

--- a/types/pair_type.toml
+++ b/types/pair_type.toml
@@ -27,19 +27,19 @@ void getSizeType(const %1%<P,Q> &container, size_t& returnArg)
 """
 
 traversal_func = """
-    return OIInternal::getSizeType<DB>(
+    return OIInternal::getSizeType<Ctx>(
         container.second,
         returnArg.delegate([&container](auto ret) {
-            return OIInternal::getSizeType<DB>(container.first, ret);
+            return OIInternal::getSizeType<Ctx>(container.first, ret);
         })
     );
 """
 
 [[codegen.processor]]
-type = "types::st::Pair<DB, typename TypeHandler<DB, T0>::type, typename TypeHandler<DB, T1>::type>"
+type = "types::st::Pair<DB, typename TypeHandler<Ctx, T0>::type, typename TypeHandler<Ctx, T1>::type>"
 func = """
-static constexpr auto firstField = make_field<DB, T0>("first");
-static constexpr auto secondField = make_field<DB, T1>("second");
+static constexpr auto firstField = make_field<Ctx, T0>("first");
+static constexpr auto secondField = make_field<Ctx, T1>("second");
 
 el.exclusive_size = sizeof(std::pair<T0, T1>) - sizeof(T0) - sizeof(T1);
 stack_ins(secondField);

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -44,7 +44,7 @@ auto tail = returnArg.write((uintptr_t)&container)
 // vector<bool>
 for (auto&& it : container) {
   tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -64,9 +64,9 @@ el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats->length = list.length;

--- a/types/set_type.toml
+++ b/types/set_type.toml
@@ -44,7 +44,7 @@ auto tail = returnArg.write((uintptr_t)&container)
 // vector<bool>
 for (auto&& it : container) {
   tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -58,7 +58,7 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
 #ifdef __GLIBCXX__
 /* We don't have access to the _Rb_tree_node struct, so we manually re-create it
@@ -104,7 +104,7 @@ static constexpr size_t element_size = sizeof(OI__tree_node);
 static_assert(false && "No known element_size for sets. See types/set_type.toml");
 #endif
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats.emplace(result::Element::ContainerStats {

--- a/types/shrd_ptr_type.toml
+++ b/types/shrd_ptr_type.toml
@@ -45,7 +45,7 @@ if constexpr (std::is_void<T0>::value) {
     return tail.template delegate<0>(std::identity());
 
   return tail.template delegate<1>([&container](auto ret) {
-    return OIInternal::getSizeType<DB>(*container, ret);
+    return OIInternal::getSizeType<Ctx>(*container, ret);
   });
 }
 """
@@ -60,7 +60,7 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 type = """
 types::st::Sum<DB,
   types::st::Unit<DB>,
-  typename TypeHandler<DB, T0>::type>
+  typename TypeHandler<Ctx, T0>::type>
 """
 func = """
 #ifdef __GLIBCXX__
@@ -84,10 +84,10 @@ el.container_stats.emplace(result::Element::ContainerStats {
   .length = sum.index, // 0 for empty containers/void, 1 otherwise
 });
 
-// Must be in a `if constexpr` or the compiler will complain about make_field<DB, void>
+// Must be in a `if constexpr` or the compiler will complain about make_field<Ctx, void>
 if constexpr (!std::is_void<T0>::value) {
   if (sum.index == 1) {
-    static constexpr auto element = make_field<DB, T0>("ptr_val");
+    static constexpr auto element = make_field<Ctx, T0>("ptr_val");
     stack_ins(element);
   }
 }

--- a/types/small_vec_type.toml
+++ b/types/small_vec_type.toml
@@ -56,8 +56,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&it: container) {
-  tail = tail.delegate([&it](typename TypeHandler<DB, T0>::type ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+  tail = tail.delegate([&it](typename TypeHandler<Ctx, T0>::type ret) {
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -81,7 +81,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
 // Reading the `uses_intern_storage` boolean that was stored in `pointer` by the processor above.
 bool uses_intern_storage = std::exchange(el.pointer.value(), (uintptr_t)0);
@@ -97,7 +97,7 @@ if (uses_intern_storage) {
   el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(T0);
 }
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 for (size_t i = 0; i < list.length; i++)
   stack_ins(childField);
 """

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -38,7 +38,7 @@ auto tail = returnArg.write((uintptr_t)&container)
 
 for (const auto& el : container) {
   tail = tail.delegate([&el](auto ret) {
-    return OIInternal::getSizeType<DB>(el, ret);
+    return OIInternal::getSizeType<Ctx>(el, ret);
   });
 }
 
@@ -56,9 +56,9 @@ el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get
 '''
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
 el.container_stats->length = list.length;

--- a/types/std_map_type.toml
+++ b/types/std_map_type.toml
@@ -44,11 +44,11 @@ auto tail = returnArg
 
 for (const auto &entry: container) {
   tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto start = maybeCaptureKey<captureKeys, DB, T0>(key, ret);
-    auto next =  start.delegate([&key](typename TypeHandler<DB, T0>::type ret) {
-      return OIInternal::getSizeType<DB>(key, ret);
+    auto start = maybeCaptureKey<captureKeys, Ctx, T0>(key, ret);
+    auto next =  start.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(key, ret);
     });
-    return OIInternal::getSizeType<DB>(value, next);
+    return OIInternal::getSizeType<Ctx>(value, next);
   });
 }
 
@@ -64,14 +64,14 @@ type = """
 std::conditional_t<captureKeys,
   types::st::List<DB,
     types::st::Pair<DB,
-      typename CaptureKeyHandler<DB, T0>::type,
+      typename CaptureKeyHandler<Ctx, T0>::type,
       types::st::Pair<DB,
-        typename TypeHandler<DB, T0>::type,
-        typename TypeHandler<DB, T1>::type>>>,
+        typename TypeHandler<Ctx, T0>::type,
+        typename TypeHandler<Ctx, T1>::type>>>,
   types::st::List<DB,
     types::st::Pair<DB,
-      typename TypeHandler<DB, T0>::type,
-      typename TypeHandler<DB, T1>::type>>
+      typename TypeHandler<Ctx, T0>::type,
+      typename TypeHandler<Ctx, T1>::type>>
 >
 """
 func = """
@@ -122,11 +122,11 @@ static_assert(false && "No known element_size for sets. See types/std_map_type.t
 #endif
 
 static constexpr std::array<inst::Field, 2> element_fields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
 
-static constexpr auto processors = maybeCaptureKeysProcessor<captureKeys, DB, T0>();
+static constexpr auto processors = maybeCaptureKeysProcessor<captureKeys, Ctx, T0>();
 
 static constexpr inst::Field element{
   element_size,

--- a/types/std_unordered_map_type.toml
+++ b/types/std_unordered_map_type.toml
@@ -47,11 +47,11 @@ auto tail = returnArg
 
 for (const auto& kv : container) {
   tail = tail.delegate([&kv](auto ret) {
-    auto start = maybeCaptureKey<captureKeys, DB, T0>(kv.first, ret);
-    auto next = start.delegate([&kv](typename TypeHandler<DB, T0>::type ret) {
-      return OIInternal::getSizeType<DB>(kv.first, ret);
+    auto start = maybeCaptureKey<captureKeys, Ctx, T0>(kv.first, ret);
+    auto next = start.delegate([&kv](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(kv.first, ret);
     });
-    return OIInternal::getSizeType<DB>(kv.second, next);
+    return OIInternal::getSizeType<Ctx>(kv.second, next);
   });
 }
 
@@ -79,13 +79,13 @@ type = """
 std::conditional_t<captureKeys,
  types::st::List<DB,
    types::st::Pair<DB,
-     typename CaptureKeyHandler<DB, T0>::type,
+     typename CaptureKeyHandler<Ctx, T0>::type,
      types::st::Pair<DB,
-       typename TypeHandler<DB, T0>::type,
-       typename TypeHandler<DB, T1>::type>>>,
+       typename TypeHandler<Ctx, T0>::type,
+       typename TypeHandler<Ctx, T1>::type>>>,
  types::st::List<DB, types::st::Pair<DB,
-   typename TypeHandler<DB, T0>::type,
-   typename TypeHandler<DB, T1>::type>>
+   typename TypeHandler<Ctx, T0>::type,
+   typename TypeHandler<Ctx, T1>::type>>
 >
 """
 func = """
@@ -122,11 +122,11 @@ el.container_stats.emplace(result::Element::ContainerStats {
 });
 
 static constexpr std::array<inst::Field, 2> element_fields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
 
-static constexpr auto processors = maybeCaptureKeysProcessor<captureKeys, DB, T0>();
+static constexpr auto processors = maybeCaptureKeysProcessor<captureKeys, Ctx, T0>();
 
 static constexpr auto element = inst::Field{
   element_size,

--- a/types/std_unordered_multimap_type.toml
+++ b/types/std_unordered_multimap_type.toml
@@ -47,7 +47,7 @@ auto tail = returnArg
 
 for (const auto &it : container) {
   tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -73,8 +73,8 @@ el.container_stats.emplace(result::Element::ContainerStats {
 [[codegen.processor]]
 type = """
 types::st::List<DB, types::st::Pair<DB,
-  typename TypeHandler<DB, T0>::type,
-  typename TypeHandler<DB, T1>::type>>
+  typename TypeHandler<Ctx, T0>::type,
+  typename TypeHandler<Ctx, T1>::type>>
 """
 func = """
 #ifdef __GLIBCXX__
@@ -110,8 +110,8 @@ el.container_stats.emplace(result::Element::ContainerStats {
 });
 
 static constexpr std::array<inst::Field, 2> element_fields{
-  make_field<DB, T0>("key"),
-  make_field<DB, T1>("value"),
+  make_field<Ctx, T0>("key"),
+  make_field<Ctx, T1>("value"),
 };
 
 static constexpr auto element = inst::Field{

--- a/types/uniq_ptr_type.toml
+++ b/types/uniq_ptr_type.toml
@@ -46,7 +46,7 @@ if constexpr (std::is_void<T0>::value) {
     return tail.template delegate<0>(std::identity());
 
   return tail.template delegate<1>([&container](auto ret) {
-    return OIInternal::getSizeType<DB>(*container, ret);
+    return OIInternal::getSizeType<Ctx>(*container, ret);
   });
 }
 """
@@ -61,7 +61,7 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 type = """
 types::st::Sum<DB,
   types::st::Unit<DB>,
-  typename TypeHandler<DB, T0>::type>
+  typename TypeHandler<Ctx, T0>::type>
 """
 func = """
 auto sum = std::get<ParsedData::Sum>(d.val);
@@ -70,10 +70,10 @@ el.container_stats.emplace(result::Element::ContainerStats {
   .length = sum.index, // 0 for empty containers/void, 1 otherwise
 });
 
-// Must be in a `if constexpr` or the compiler will complain about make_field<DB, void>
+// Must be in a `if constexpr` or the compiler will complain about make_field<Ctx, void>
 if constexpr (!std::is_void<T0>::value) {
   if (sum.index == 1) {
-    static constexpr auto element = make_field<DB, T0>("ptr_val");
+    static constexpr auto element = make_field<Ctx, T0>("ptr_val");
     stack_ins(element);
   }
 }

--- a/types/unordered_multiset_type.toml
+++ b/types/unordered_multiset_type.toml
@@ -45,7 +45,7 @@ auto tail = returnArg
 
 for (const auto &it : container) {
   tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -69,7 +69,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
 #ifdef __GLIBCXX__
 /* Use libstdc++ implementation __details to compute the size of Nodes and Buckets.
@@ -100,7 +100,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
   .length = list.length,
 });
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 for (size_t i = 0; i < list.length; i++)
   stack_ins(childField);
 """

--- a/types/unordered_set_type.toml
+++ b/types/unordered_set_type.toml
@@ -45,7 +45,7 @@ auto tail = returnArg
 
 for (const auto &it : container) {
   tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<DB>(it, ret);
+    return OIInternal::getSizeType<Ctx>(it, ret);
   });
 }
 
@@ -69,7 +69,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
 """
 
 [[codegen.processor]]
-type = "types::st::List<DB, typename TypeHandler<DB, T0>::type>"
+type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>"
 func = """
 #ifdef __GLIBCXX__
 /* Use libstdc++ implementation __details to compute the size of Nodes and Buckets.
@@ -100,7 +100,7 @@ el.container_stats.emplace(result::Element::ContainerStats {
   .length = list.length,
 });
 
-static constexpr auto childField = make_field<DB, T0>("[]");
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 for (size_t i = 0; i < list.length; i++)
   stack_ins(childField);
 """


### PR DESCRIPTION
tbv2: replace DB template param with Ctx

TreeBuilder v2 adds a DB template parameter to every function. This is used as
part of the static type to decide what type of DataBuffer is being used:
currently `BackInserterDataBuffer<std::vector<uint8_t>>` for OIL and it would
be `DataSegmentDataBuffer` for OID.

This change replaces the `DB` template parameter with a more general `Ctx`. Due
to issues with dependent naming it also adds a `using DB` to each `TypeHandler`
which has the same function as before. This allows us to add more "static
context" (typedefs and constants) to functions without changing this signature
again, because changing the signature of everything is a massive pain.

Currently this change achieves nothing because Ctx contains only DB in a static
wrapper. In the next change I'm going to pass a reference of type Ctx around to
add a "dynamic context" to invocations which will contain the pointer array. In
future we'll then be able to add either static or dynamic context without any
signature adjustments.

Test plan:
- CI

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/409).
* #410
* __->__ #409