### PR TITLE
tbv2: add dynamic context passed through all functions

### DIFF
--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -3049,6 +3049,12 @@ bool OICodeGen::generateJitCode(std::string& code) {
     #define SAVE_DATA(val)    StoreData(val, returnArg)
   )");
 
+  code.append("namespace {\n");
+  code.append("static struct Context {\n");
+  code.append("  PointerHashSet<> pointers;\n");
+  code.append("} ctx;\n");
+  code.append("} // namespace\n");
+
   FuncGen::DefineJitLog(code, config.features);
 
   // The purpose of the anonymous namespace within `OIInternal` is that
@@ -3267,7 +3273,7 @@ bool OICodeGen::generateJitCode(std::string& code) {
       JLOG("ptr val @");
       JLOGPTR(s_ptr);
       StoreData((uintptr_t)(s_ptr), returnArg);
-      if (s_ptr && pointers.add((uintptr_t)s_ptr)) {
+      if (s_ptr && ctx.pointers.add((uintptr_t)s_ptr)) {
         StoreData(1, returnArg);
         getSizeType(*(s_ptr), returnArg);
       } else {

--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -40,10 +40,11 @@ constexpr int oidMagicId = 0x01DE8;
 
 namespace {
 
-class {
+template <size_t Size = (1 << 20) / sizeof(uintptr_t)>
+class PointerHashSet {
  private:
   // 1 MiB of pointers
-  std::array<uintptr_t, (1 << 20) / sizeof(uintptr_t)> data;
+  std::array<uintptr_t, Size> data;
   size_t numEntries;
 
   /*
@@ -107,7 +108,7 @@ class {
   bool add(const auto* p) {
     return add((uintptr_t)p);
   }
-} static pointers;
+};
 
 }  // namespace
 

--- a/types/array_type.toml
+++ b/types/array_type.toml
@@ -33,8 +33,8 @@ traversal_func = """
     auto tail = returnArg.write(container.size());
 
     for (auto & it: container) {
-        tail = tail.delegate([&it](auto ret) {
-            return TypeHandler<Ctx, T0>::getSizeType(it, ret);
+        tail = tail.delegate([&ctx, &it](auto ret) {
+            return TypeHandler<Ctx, T0>::getSizeType(ctx, it, ret);
         });
     }
 

--- a/types/cxx11_list_type.toml
+++ b/types/cxx11_list_type.toml
@@ -38,8 +38,8 @@ auto tail = returnArg.write((uintptr_t)&container)
                 .write(container.size());
 
 for (auto&& it : container) {
-  tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 

--- a/types/f14_fast_map.toml
+++ b/types/f14_fast_map.toml
@@ -43,11 +43,11 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&entry: container) {
-  tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
-      return OIInternal::getSizeType<Ctx>(key, ret);
+  tail = tail.delegate([&ctx, &key = entry.first, &value = entry.second](auto ret) {
+    auto next = ret.delegate([&ctx, &key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(ctx, key, ret);
     });
-    return OIInternal::getSizeType<Ctx>(value, next);
+    return OIInternal::getSizeType<Ctx>(ctx, value, next);
   });
 }
 

--- a/types/f14_fast_set.toml
+++ b/types/f14_fast_set.toml
@@ -42,8 +42,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&entry: container) {
-  tail = tail.delegate([&entry](auto ret) {
-    return OIInternal::getSizeType<Ctx>(entry, ret);
+  tail = tail.delegate([&ctx, &entry](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, entry, ret);
   });
 }
 

--- a/types/f14_node_map.toml
+++ b/types/f14_node_map.toml
@@ -43,11 +43,11 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&entry: container) {
-  tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
-      return OIInternal::getSizeType<Ctx>(key, ret);
+  tail = tail.delegate([&ctx, &key = entry.first, &value = entry.second](auto ret) {
+    auto next = ret.delegate([&ctx, &key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(ctx, key, ret);
     });
-    return OIInternal::getSizeType<Ctx>(value, next);
+    return OIInternal::getSizeType<Ctx>(ctx, value, next);
   });
 }
 

--- a/types/f14_node_set.toml
+++ b/types/f14_node_set.toml
@@ -42,8 +42,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&entry: container) {
-  tail = tail.delegate([&entry](auto ret) {
-    return OIInternal::getSizeType<Ctx>(entry, ret);
+  tail = tail.delegate([&ctx, &entry](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, entry, ret);
   });
 }
 

--- a/types/f14_value_map.toml
+++ b/types/f14_value_map.toml
@@ -43,11 +43,11 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&entry: container) {
-  tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
-      return OIInternal::getSizeType<Ctx>(key, ret);
+  tail = tail.delegate([&ctx, &key = entry.first, &value = entry.second](auto ret) {
+    auto next = ret.delegate([&ctx, &key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(ctx, key, ret);
     });
-    return OIInternal::getSizeType<Ctx>(value, next);
+    return OIInternal::getSizeType<Ctx>(ctx, value, next);
   });
 }
 

--- a/types/f14_value_set.toml
+++ b/types/f14_value_set.toml
@@ -42,8 +42,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&entry: container) {
-  tail = tail.delegate([&entry](auto ret) {
-    return OIInternal::getSizeType<Ctx>(entry, ret);
+  tail = tail.delegate([&ctx, &entry](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, entry, ret);
   });
 }
 

--- a/types/f14_vector_map.toml
+++ b/types/f14_vector_map.toml
@@ -43,11 +43,11 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&entry: container) {
-  tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
-      return OIInternal::getSizeType<Ctx>(key, ret);
+  tail = tail.delegate([&ctx, &key = entry.first, &value = entry.second](auto ret) {
+    auto next = ret.delegate([&ctx, &key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(ctx, key, ret);
     });
-    return OIInternal::getSizeType<Ctx>(value, next);
+    return OIInternal::getSizeType<Ctx>(ctx, value, next);
   });
 }
 

--- a/types/f14_vector_set.toml
+++ b/types/f14_vector_set.toml
@@ -42,8 +42,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&entry: container) {
-  tail = tail.delegate([&entry](auto ret) {
-    return OIInternal::getSizeType<Ctx>(entry, ret);
+  tail = tail.delegate([&ctx, &entry](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, entry, ret);
   });
 }
 

--- a/types/fb_string_type.toml
+++ b/types/fb_string_type.toml
@@ -29,7 +29,7 @@ void getSizeType(const %1%<E, T, A, Storage> &container, size_t& returnArg)
         &&
       ((uintptr_t)container.data() >= (uintptr_t)&container);
 
-    if (!inlined && pointers.add((uintptr_t)container.data())) {
+    if (!inlined && ctx.pointers.add((uintptr_t)container.data())) {
       SAVE_SIZE(container.capacity() * sizeof(T));
       SAVE_DATA(1);
     } else {
@@ -60,7 +60,7 @@ if (isStorageInline(container)) {
   category = Category::InlinedStorage;
 } else if (capacity < minLargeSize) {
   category = Category::OwnedHeapStorage;
-} else if (pointers.add(container.data())) {
+} else if (ctx.pointers.add(container.data())) {
   category = Category::ReferenceCountedStorage;
 } else {
   category = Category::AlreadyAttributed;

--- a/types/folly_iobuf_queue_type.toml
+++ b/types/folly_iobuf_queue_type.toml
@@ -22,7 +22,7 @@ void getSizeType(const %1% &container, size_t& returnArg)
 
     const folly::IOBuf *head = container.front();
     SAVE_DATA((uintptr_t)head);
-    if (head && pointers.add((uintptr_t)head)) {
+    if (head && ctx.pointers.add((uintptr_t)head)) {
         SAVE_DATA(1);
         getSizeType(*head, returnArg);
     } else {

--- a/types/list_type.toml
+++ b/types/list_type.toml
@@ -38,8 +38,8 @@ auto tail = returnArg.write((uintptr_t)&container)
                 .write(container.size());
 
 for (auto&& it : container) {
-  tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 

--- a/types/map_seq_type.toml
+++ b/types/map_seq_type.toml
@@ -42,12 +42,12 @@ traversal_func = '''
                     .write(container.size());
 
     for (const auto& kv : container) {
-      tail = tail.delegate([&kv](auto ret) {
-        auto start = maybeCaptureKey<captureKeys, Ctx, T0>(kv.first, ret);
-        auto next = start.delegate([&kv](typename TypeHandler<Ctx, T0>::type ret) {
-          return OIInternal::getSizeType<Ctx>(kv.first, ret);
+      tail = tail.delegate([&ctx, &kv](auto ret) {
+        auto start = maybeCaptureKey<captureKeys, Ctx, T0>(ctx, kv.first, ret);
+        auto next = start.delegate([&ctx, &kv](typename TypeHandler<Ctx, T0>::type ret) {
+          return OIInternal::getSizeType<Ctx>(ctx, kv.first, ret);
         });
-        return OIInternal::getSizeType<Ctx>(kv.second, next);
+        return OIInternal::getSizeType<Ctx>(ctx, kv.second, next);
       });
     }
 

--- a/types/multi_map_type.toml
+++ b/types/multi_map_type.toml
@@ -39,11 +39,11 @@ auto tail = returnArg
   .write(container.size());
 
 for (const auto &entry: container) {
-  tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto next = ret.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
-      return OIInternal::getSizeType<Ctx>(key, ret);
+  tail = tail.delegate([&ctx, &key = entry.first, &value = entry.second](auto ret) {
+    auto next = ret.delegate([&ctx, &key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(ctx, key, ret);
     });
-    return OIInternal::getSizeType<Ctx>(value, next);
+    return OIInternal::getSizeType<Ctx>(ctx, value, next);
   });
 }
 

--- a/types/multi_set_type.toml
+++ b/types/multi_set_type.toml
@@ -42,8 +42,8 @@ auto tail = returnArg.write((uintptr_t)&container)
 // The double ampersand is needed otherwise this loop doesn't work with
 // vector<bool>
 for (auto&& it : container) {
-  tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 

--- a/types/optional_type.toml
+++ b/types/optional_type.toml
@@ -30,8 +30,8 @@ void getSizeType(const %1%<T>& container, size_t& returnArg) {
 
 traversal_func = """
 if (container.has_value()) {
-  return returnArg.template delegate<1>([&container](auto ret) {
-    return OIInternal::getSizeType<Ctx>(*container, ret);
+  return returnArg.template delegate<1>([&ctx, &container](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, *container, ret);
   });
 } else {
   return returnArg.template delegate<0>(std::identity());

--- a/types/pair_type.toml
+++ b/types/pair_type.toml
@@ -27,10 +27,10 @@ void getSizeType(const %1%<P,Q> &container, size_t& returnArg)
 """
 
 traversal_func = """
-    return OIInternal::getSizeType<Ctx>(
+    return OIInternal::getSizeType<Ctx>(ctx, 
         container.second,
-        returnArg.delegate([&container](auto ret) {
-            return OIInternal::getSizeType<Ctx>(container.first, ret);
+        returnArg.delegate([&ctx, &container](auto ret) {
+            return OIInternal::getSizeType<Ctx>(ctx, container.first, ret);
         })
     );
 """

--- a/types/ref_wrapper_type.toml
+++ b/types/ref_wrapper_type.toml
@@ -21,7 +21,7 @@ void getSizeType(const %1%<T> &ref, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<T>));
     SAVE_DATA((uintptr_t)&(ref.get()));
-    if (pointers.add((uintptr_t)&ref.get())) {
+    if (ctx.pointers.add((uintptr_t)&ref.get())) {
         SAVE_DATA(1);
         getSizeType(ref.get(), returnArg);
     } else {

--- a/types/seq_type.toml
+++ b/types/seq_type.toml
@@ -43,8 +43,8 @@ auto tail = returnArg.write((uintptr_t)&container)
 // The double ampersand is needed otherwise this loop doesn't work with
 // vector<bool>
 for (auto&& it : container) {
-  tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 

--- a/types/set_type.toml
+++ b/types/set_type.toml
@@ -43,8 +43,8 @@ auto tail = returnArg.write((uintptr_t)&container)
 // The double ampersand is needed otherwise this loop doesn't work with
 // vector<bool>
 for (auto&& it : container) {
-  tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 

--- a/types/shrd_ptr_type.toml
+++ b/types/shrd_ptr_type.toml
@@ -24,7 +24,7 @@ void getSizeType(const %1%<T> &s_ptr, size_t& returnArg)
     if constexpr (!std::is_void<T>::value) {
         SAVE_DATA((uintptr_t)(s_ptr.get()));
 
-        if (s_ptr && pointers.add((uintptr_t)(s_ptr.get()))) {
+        if (s_ptr && ctx.pointers.add((uintptr_t)(s_ptr.get()))) {
             SAVE_DATA(1);
             getSizeType(*(s_ptr.get()), returnArg);
         } else {
@@ -40,12 +40,12 @@ auto tail = returnArg.write((uintptr_t)container.get());
 if constexpr (std::is_void<T0>::value) {
   return tail.template delegate<0>(std::identity());
 } else {
-  bool do_visit = container && pointers.add((uintptr_t)container.get());
+  bool do_visit = container && ctx.pointers.add((uintptr_t)container.get());
   if (!do_visit)
     return tail.template delegate<0>(std::identity());
 
-  return tail.template delegate<1>([&container](auto ret) {
-    return OIInternal::getSizeType<Ctx>(*container, ret);
+  return tail.template delegate<1>([&ctx, &container](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, *container, ret);
   });
 }
 """

--- a/types/small_vec_type.toml
+++ b/types/small_vec_type.toml
@@ -56,8 +56,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (auto &&it: container) {
-  tail = tail.delegate([&it](typename TypeHandler<Ctx, T0>::type ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](typename TypeHandler<Ctx, T0>::type ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 

--- a/types/sorted_vec_set_type.toml
+++ b/types/sorted_vec_set_type.toml
@@ -37,8 +37,8 @@ auto tail = returnArg.write((uintptr_t)&container)
                 .write(container.size());
 
 for (const auto& el : container) {
-  tail = tail.delegate([&el](auto ret) {
-    return OIInternal::getSizeType<Ctx>(el, ret);
+  tail = tail.delegate([&ctx, &el](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, el, ret);
   });
 }
 

--- a/types/std_map_type.toml
+++ b/types/std_map_type.toml
@@ -43,12 +43,12 @@ auto tail = returnArg
   .write(container.size());
 
 for (const auto &entry: container) {
-  tail = tail.delegate([&key = entry.first, &value = entry.second](auto ret) {
-    auto start = maybeCaptureKey<captureKeys, Ctx, T0>(key, ret);
-    auto next =  start.delegate([&key](typename TypeHandler<Ctx, T0>::type ret) {
-      return OIInternal::getSizeType<Ctx>(key, ret);
+  tail = tail.delegate([&ctx, &key = entry.first, &value = entry.second](auto ret) {
+    auto start = maybeCaptureKey<captureKeys, Ctx, T0>(ctx, key, ret);
+    auto next =  start.delegate([&ctx, &key](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(ctx, key, ret);
     });
-    return OIInternal::getSizeType<Ctx>(value, next);
+    return OIInternal::getSizeType<Ctx>(ctx, value, next);
   });
 }
 

--- a/types/std_unordered_map_type.toml
+++ b/types/std_unordered_map_type.toml
@@ -46,12 +46,12 @@ auto tail = returnArg
   .write(container.size());
 
 for (const auto& kv : container) {
-  tail = tail.delegate([&kv](auto ret) {
-    auto start = maybeCaptureKey<captureKeys, Ctx, T0>(kv.first, ret);
-    auto next = start.delegate([&kv](typename TypeHandler<Ctx, T0>::type ret) {
-      return OIInternal::getSizeType<Ctx>(kv.first, ret);
+  tail = tail.delegate([&ctx, &kv](auto ret) {
+    auto start = maybeCaptureKey<captureKeys, Ctx, T0>(ctx, kv.first, ret);
+    auto next = start.delegate([&ctx, &kv](typename TypeHandler<Ctx, T0>::type ret) {
+      return OIInternal::getSizeType<Ctx>(ctx, kv.first, ret);
     });
-    return OIInternal::getSizeType<Ctx>(kv.second, next);
+    return OIInternal::getSizeType<Ctx>(ctx, kv.second, next);
   });
 }
 

--- a/types/std_unordered_multimap_type.toml
+++ b/types/std_unordered_multimap_type.toml
@@ -46,8 +46,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (const auto &it : container) {
-  tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 

--- a/types/uniq_ptr_type.toml
+++ b/types/uniq_ptr_type.toml
@@ -25,7 +25,7 @@ void getSizeType(const %1%<T,Deleter> &u_ptr, size_t& returnArg)
     if constexpr (!std::is_void<T>::value) {
         SAVE_DATA((uintptr_t)(u_ptr.get()));
 
-        if (u_ptr && pointers.add((uintptr_t)(u_ptr.get()))) {
+        if (u_ptr && ctx.pointers.add((uintptr_t)(u_ptr.get()))) {
             SAVE_DATA(1);
             getSizeType(*(u_ptr.get()), returnArg);
         } else {
@@ -41,12 +41,12 @@ auto tail = returnArg.write((uintptr_t)container.get());
 if constexpr (std::is_void<T0>::value) {
   return tail.template delegate<0>(std::identity());
 } else {
-  bool do_visit = container && pointers.add((uintptr_t)container.get());
+  bool do_visit = container && ctx.pointers.add((uintptr_t)container.get());
   if (!do_visit)
     return tail.template delegate<0>(std::identity());
 
-  return tail.template delegate<1>([&container](auto ret) {
-    return OIInternal::getSizeType<Ctx>(*container, ret);
+  return tail.template delegate<1>([&ctx, &container](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, *container, ret);
   });
 }
 """

--- a/types/unordered_multiset_type.toml
+++ b/types/unordered_multiset_type.toml
@@ -44,8 +44,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (const auto &it : container) {
-  tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 

--- a/types/unordered_set_type.toml
+++ b/types/unordered_set_type.toml
@@ -44,8 +44,8 @@ auto tail = returnArg
   .write(container.size());
 
 for (const auto &it : container) {
-  tail = tail.delegate([&it](auto ret) {
-    return OIInternal::getSizeType<Ctx>(it, ret);
+  tail = tail.delegate([&ctx, &it](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, it, ret);
   });
 }
 


### PR DESCRIPTION
tbv2: add dynamic context passed through all functions

Previously for we had some shared state between all requests, noticeably the
pointers set. This change adds a by reference value to all requests which can
hold additional mutable state. The pointers set is moved into this mutable
state for OIL, which means each concurrent request will have its own pointer
set. Doing things this way allows more features to be added in the future
without such a big code modification.

Closes #404

Test plan:
- CI
