### PR TITLE
OID: Don't run tree builder if we are dumping the data segment

### DIFF
--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -2869,6 +2869,9 @@ bool OIDebugger::processTargetData() {
       if (!dumpDataSegment(req, outVec)) {
         LOG(ERROR) << "Failed to dump data-segment for " << req.arg;
       }
+
+      // Skip running Tree Builder
+      continue;
     }
 
     auto typeInfo = typeInfos.find(req);
@@ -2908,6 +2911,11 @@ bool OIDebugger::processTargetData() {
     if (treeBuilderConfig.features[Feature::GenPaddingStats]) {
       paddingHunter.processLocalPaddingInfo();
     }
+  }
+
+  if (treeBuilderConfig.dumpDataSegment) {
+    // Tree Builder was not run
+    return true;
   }
 
   if (typeTree.emptyOutput()) {


### PR DESCRIPTION
We generally only dump the data segment when there is some issue running tree builder and we want to process it off-host.

## Test plan
Manual testing:
- Confirmed that tree builder is still run by default and that no data segment is dumped
- Confirmed that tree builder is not run and a data segment is dumped when using "-B"