### PR TITLE
OICodeGen: Respect ContainerInfo::requiredFeatures

### DIFF
--- a/oi/ContainerInfo.h
+++ b/oi/ContainerInfo.h
@@ -58,6 +58,7 @@ struct ContainerInfo {
                 std::optional<size_t> allocatorIndex_,
                 std::optional<size_t> underlyingContainerIndex_,
                 std::vector<size_t> stubTemplateParams_,
+                oi::detail::FeatureSet requiredFeatures,
                 ContainerInfo::Codegen codegen_)
       : typeName(std::move(typeName_)),
         matcher(std::move(matcher_)),
@@ -69,6 +70,7 @@ struct ContainerInfo {
         allocatorIndex(allocatorIndex_),
         underlyingContainerIndex(underlyingContainerIndex_),
         stubTemplateParams(std::move(stubTemplateParams_)),
+        requiredFeatures(requiredFeatures),
         codegen(std::move(codegen_)) {
   }
 

--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -85,6 +85,10 @@ bool OICodeGen::registerContainer(const fs::path& path) {
   if (!info) {
     return false;
   }
+  if (info->requiredFeatures != (config.features & info->requiredFeatures)) {
+    VLOG(1) << "Skipping container (feature conflict): " << info->typeName;
+    return true;
+  }
 
   VLOG(1) << "registered container, type: " << info->typeName;
   containerInfoList.emplace_back(std::move(info));


### PR DESCRIPTION
CodeGen v1 and CodeGen v2 must be in sync in order for CodeGen v2 and TreeBuilder v1 to be compatible. This change updates CodeGen v1 to use the same set of containers as CodeGen v2.

This specifically fixes "-ftype-graph -Ftree-builder-v2 -Fcapture-thrift-isset" for Thrift types.

The integration test "thrift_isset_no_capture" covers this, but this bug was missed as the Thrift tests do not run in CI.