### PR TITLE
TypeGraph: Delete unused function in IdentifyContainers pass

### DIFF
--- a/oi/type_graph/IdentifyContainers.cpp
+++ b/oi/type_graph/IdentifyContainers.cpp
@@ -34,21 +34,6 @@ Pass IdentifyContainers::createPass(
   return Pass("IdentifyContainers", fn);
 }
 
-bool IdentifyContainers::isAllocator(Type& t) {
-  auto* c = dynamic_cast<Class*>(&t);
-  if (!c)
-    return false;
-
-  // Maybe add more checks for an allocator.
-  // For now, just test for the presence of an "allocate" function
-  for (const auto& func : c->functions) {
-    if (func.name == "allocate") {
-      return true;
-    }
-  }
-  return false;
-}
-
 IdentifyContainers::IdentifyContainers(
     TypeGraph& typeGraph,
     const std::vector<std::unique_ptr<ContainerInfo>>& containers)

--- a/oi/type_graph/IdentifyContainers.h
+++ b/oi/type_graph/IdentifyContainers.h
@@ -39,7 +39,6 @@ class IdentifyContainers : public RecursiveMutator {
  public:
   static Pass createPass(
       const std::vector<std::unique_ptr<ContainerInfo>>& containers);
-  static bool isAllocator(Type& t);
 
   IdentifyContainers(
       TypeGraph& typeGraph,


### PR DESCRIPTION
It was accidentally copied from the TypeIdentifier pass.