### PR TITLE
Make oitb actually log TB output

### DIFF
--- a/tools/OITB.cpp
+++ b/tools/OITB.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include <boost/archive/text_iarchive.hpp>
@@ -145,6 +146,7 @@ int main(int argc, char* argv[]) {
   google::LogToStderr();
   google::SetStderrLogging(google::INFO);
   google::SetVLOGLevel("TreeBuilder", 3);
+  gflags::SetCommandLineOption("minloglevel", "0");
 
   /* Reflects `oid`'s defaults for TreeBuilder::Config */
   TreeBuilder::Config tbConfig{


### PR DESCRIPTION
## Summary
Without this change we get no output on what TB is doing. The code is setup to do this but it also needs this gflag addition.

## Test plan
Tested locally and now produces debug:

```
$ ./oitb -ftype-graph cache/9239701056552067599.th cache/9239701056552067599.pd /tmp/dataseg.2046912.arg0.dump
I1120 04:12:31.586973 2091285 OITB.cpp:198] Loading type infos...
I1120 04:12:31.587174 2091285 OITB.cpp:202] Loading data segment dump...
I1120 04:12:36.891196 2091285 OITB.cpp:208] Setting-up PaddingHunter...
I1120 04:12:36.891220 2091285 OITB.cpp:212] Running TreeBuilder...
I1120 04:12:36.891225 2091285 TreeBuilder.cpp:235] Building tree...
I1120 04:12:36.891237 2091285 TreeBuilder.cpp:426] Processing node [1024] (name: 'B', typeName: 'unique_ptr<XX, std::default_delete<XX> >', kind: CLASS)
I1120 04:12:36.891245 2091285 TreeBuilder.cpp:575] Processing container [1024] of type 'unique_ptr<XX, std::default_delete<XX> >'
I1120 04:12:36.891252 2091285 TreeBuilder.cpp:376] next = 0x7f6a380008d0
I1120 04:12:36.891253 2091285 TreeBuilder.cpp:376] next = 0x1
I1120 04:12:36.891258 2091285 TreeBuilder.cpp:902] Container [1024]'s children cover range [1025, 1026)
I1120 04:12:36.891261 2091285 TreeBuilder.cpp:426] Processing node [1025] (name: '', typeName: 'XX', kind: STRUCT)
I1120 04:12:36.891264 2091285 TreeBuilder.cpp:426] Processing node [1026] (name: 'foo', typeName: 'int', kind: INT)
I1120 04:12:36.891292 2091285 TreeBuilder.cpp:426] Processing node [1027] (name: 'bar', typeName: 'int', kind: INT)
I1120 04:12:36.891304 2091285 TreeBuilder.cpp:249] Finished building tree
I1120 04:12:38.307518 2091285 TreeBuilder.cpp:255] Finished compacting db
I1120 04:12:38.307535 2091285 TreeBuilder.cpp:269] Consumed all object sizes: 6
```
