### PR TITLE
Update Python used by CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/drgn")
 endif()
 
 ### Select Python version
-find_program(PYTHON NAMES python3.8 python3)
+find_program(PYTHON NAMES python3.9 python3.8 python3)
 
 add_library(folly_headers INTERFACE)
 target_include_directories(folly_headers SYSTEM INTERFACE ${folly_SOURCE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,7 +103,7 @@ cpp_unittest(
 if (WITH_FLAKY_TESTS)
   add_test(
     NAME integration_py
-    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/integration.py
+    COMMAND ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/integration.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_tests_properties(integration_py PROPERTIES

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -28,8 +28,6 @@ add_link_options(-no-pie)
 set(INTEGRATION_TEST_TARGET_SRC integration_test_target.cpp)
 set(INTEGRATION_TEST_RUNNER_SRC integration_test_runner.cpp)
 
-find_program(PYTHON_CMD NAMES python3.6 python3)
-
 set(INTEGRATION_TEST_THRIFT_SRCS ${THRIFT_TESTS})
 list(TRANSFORM INTEGRATION_TEST_THRIFT_SRCS APPEND ".thrift")
 
@@ -38,7 +36,7 @@ add_custom_command(
     ${INTEGRATION_TEST_TARGET_SRC}
     ${INTEGRATION_TEST_RUNNER_SRC}
     ${INTEGRATION_TEST_THRIFT_SRCS}
-  COMMAND ${PYTHON_CMD}
+  COMMAND ${PYTHON}
     ${CMAKE_CURRENT_SOURCE_DIR}/gen_tests.py
     ${INTEGRATION_TEST_TARGET_SRC}
     ${INTEGRATION_TEST_RUNNER_SRC}
@@ -49,7 +47,7 @@ add_custom_command(
 add_executable(integration_test_target
   ${INTEGRATION_TEST_TARGET_SRC}
   folly_shims.cpp)
-target_compile_options(integration_test_target PRIVATE -O1)
+target_compile_options(integration_test_target PRIVATE -O1 -g3)
 target_link_libraries(integration_test_target PRIVATE oil_jit exporters_json Boost::headers ${Boost_LIBRARIES})
 
 add_executable(integration_test_runner ${INTEGRATION_TEST_RUNNER_SRC} runner_common.cpp)


### PR DESCRIPTION
## Summary
Add a new Python version used by our CMakeLists.txt.
Also, ensure that `integration_test_target` always has debug information, even for Release build.

## Test plan
```
$ make test
```
