### PR TITLE
CodeGen v2: Enable independent running without CodeGen v1

### DIFF
--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -17,6 +17,7 @@
 
 #include <filesystem>
 #include <functional>
+#include <list>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -25,6 +26,7 @@
 
 #include "ContainerInfo.h"
 #include "OICodeGen.h"
+#include "type_graph/TypeGraph.h"
 
 struct drgn_type;
 namespace oi::detail {
@@ -33,7 +35,6 @@ class SymbolService;
 namespace oi::detail::type_graph {
 class Class;
 class Member;
-class TypeGraph;
 }  // namespace oi::detail::type_graph
 
 namespace oi::detail {
@@ -52,6 +53,9 @@ class CodeGen {
   bool codegenFromDrgn(struct drgn_type* drgnType,
                        std::string linkageName,
                        std::string& code);
+  void exportDrgnTypes(TypeHierarchy& th,
+                       std::list<drgn_type>& drgnTypes,
+                       drgn_type** rootType) const;
 
   void registerContainer(std::unique_ptr<ContainerInfo> containerInfo);
   void registerContainer(const std::filesystem::path& path);
@@ -65,6 +69,7 @@ class CodeGen {
   );
 
  private:
+  type_graph::TypeGraph typeGraph_;
   const OICodeGen::Config& config_;
   SymbolService& symbols_;
   std::vector<std::unique_ptr<ContainerInfo>> containerInfos_;

--- a/oi/ContainerInfo.cpp
+++ b/oi/ContainerInfo.cpp
@@ -325,6 +325,9 @@ ContainerInfo::ContainerInfo(const fs::path& path) {
       }
     });
   }
+
+  // Only used for TreeBuilder v1:
+  numTemplateParams = info["numTemplateParams"].value<size_t>();
 }
 
 ContainerInfo::ContainerInfo(std::string typeName_,

--- a/oi/type_graph/CMakeLists.txt
+++ b/oi/type_graph/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(type_graph
   AddChildren.cpp
   AddPadding.cpp
   AlignmentCalc.cpp
+  DrgnExporter.cpp
   DrgnParser.cpp
   EnforceCompatibility.cpp
   Flattener.cpp

--- a/oi/type_graph/DrgnExporter.cpp
+++ b/oi/type_graph/DrgnExporter.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "DrgnExporter.h"
+
+#include "AddPadding.h"
+#include "TypeGraph.h"
+#include "TypeIdentifier.h"
+#include "oi/TypeHierarchy.h"
+
+namespace oi::detail::type_graph {
+
+Pass DrgnExporter::createPass(TypeHierarchy& th,
+                              std::list<drgn_type>& drgnTypes) {
+  auto fn = [&th, &drgnTypes](TypeGraph& typeGraph, NodeTracker&) {
+    DrgnExporter pass{th, drgnTypes};
+    for (auto& type : typeGraph.rootTypes()) {
+      pass.accept(type);
+    }
+  };
+
+  return Pass("DrgnExporter", fn);
+}
+
+drgn_type* DrgnExporter::accept(Type& type) {
+  if (auto* t = tracker_.get(type))
+    return t;
+
+  auto* t = type.accept(*this);
+  tracker_.set(type, t);
+  return t;
+}
+
+drgn_type* DrgnExporter::visit(Incomplete& c) {
+  return makeDrgnType(DRGN_TYPE_VOID, false, DRGN_C_TYPE_VOID, c);
+}
+
+drgn_type* DrgnExporter::visit(Class& c) {
+  enum drgn_type_kind kind;
+  switch (c.kind()) {
+    case Class::Kind::Class:
+      kind = DRGN_TYPE_CLASS;
+      break;
+    case Class::Kind::Struct:
+      kind = DRGN_TYPE_STRUCT;
+      break;
+    case Class::Kind::Union:
+      kind = DRGN_TYPE_UNION;
+      break;
+  }
+
+  auto* drgnType = makeDrgnType(kind, true, DRGN_NOT_PRIMITIVE_TYPE, c);
+  th_.classMembersMap.insert({drgnType, {}});
+
+  for (const auto& mem : c.members) {
+    if (mem.name.starts_with(AddPadding::MemberPrefix)) {
+      continue;
+    }
+
+    drgn_type* memType = accept(mem.type());
+
+    th_.classMembersMap[drgnType].push_back(DrgnClassMemberInfo{
+        memType, mem.inputName, mem.bitOffset, mem.bitsize, false});
+
+    if (const auto* container = dynamic_cast<const Container*>(&mem.type());
+        container && container->containerInfo_.ctype == THRIFT_ISSET_TYPE) {
+      th_.thriftIssetStructTypes.insert(drgnType);
+    }
+
+    if (dynamic_cast<const Incomplete*>(&mem.type())) {
+      th_.knownDummyTypeList.insert(drgnType);
+    }
+  }
+
+  return drgnType;
+}
+
+drgn_type* DrgnExporter::visit(Container& c) {
+  auto* drgnType =
+      makeDrgnType(DRGN_TYPE_CLASS, false, DRGN_NOT_PRIMITIVE_TYPE, c);
+
+  // Do not add `shared_ptr<void>`, `unique_ptr<void>`, or `weak_ptr<void>` to
+  // `containerTypeMap`
+  if (c.containerInfo_.ctype == SHRD_PTR_TYPE ||
+      c.containerInfo_.ctype == UNIQ_PTR_TYPE ||
+      c.containerInfo_.ctype == WEAK_PTR_TYPE) {
+    const auto& paramType = c.templateParams[0].type();
+    if (auto* p = dynamic_cast<const Primitive*>(&paramType);
+        p && p->kind() == Primitive::Kind::Void) {
+      return drgnType;
+    }
+  }
+
+  std::vector<size_t> paramIdxs;
+  if (c.containerInfo_.underlyingContainerIndex.has_value()) {
+    paramIdxs.push_back(*c.containerInfo_.underlyingContainerIndex);
+  } else {
+    auto numTemplateParams = c.containerInfo_.numTemplateParams;
+    if (!numTemplateParams.has_value())
+      numTemplateParams = c.templateParams.size();
+    for (size_t i = 0;
+         i < std::min(*numTemplateParams, c.templateParams.size());
+         i++) {
+      paramIdxs.push_back(i);
+    }
+  }
+
+  auto& templateTypes =
+      th_.containerTypeMap
+          .emplace(drgnType,
+                   std::pair{c.containerInfo_.ctype,
+                             std::vector<drgn_qualified_type>{}})
+          .first->second.second;
+  for (auto i : paramIdxs) {
+    if (i >= c.templateParams.size()) {
+      continue;
+    }
+
+    auto& param = c.templateParams[i];
+    drgn_type* paramType = accept(param.type());
+    templateTypes.push_back({paramType, drgn_qualifiers{}});
+
+    if (dynamic_cast<const Incomplete*>(&param.type())) {
+      th_.knownDummyTypeList.insert(drgnType);
+    }
+  }
+
+  return drgnType;
+}
+
+drgn_type* DrgnExporter::visit(Primitive& p) {
+  enum drgn_type_kind kind;
+  switch (p.kind()) {
+    case Primitive::Kind::Int8:
+    case Primitive::Kind::Int16:
+    case Primitive::Kind::Int32:
+    case Primitive::Kind::Int64:
+    case Primitive::Kind::UInt8:
+    case Primitive::Kind::UInt16:
+    case Primitive::Kind::UInt32:
+    case Primitive::Kind::UInt64:
+      kind = DRGN_TYPE_INT;
+      break;
+    case Primitive::Kind::Float32:
+    case Primitive::Kind::Float64:
+    case Primitive::Kind::Float80:
+    case Primitive::Kind::Float128:
+      kind = DRGN_TYPE_FLOAT;
+      break;
+    case Primitive::Kind::Bool:
+      kind = DRGN_TYPE_BOOL;
+      break;
+    case Primitive::Kind::StubbedPointer:
+    case Primitive::Kind::Void:
+      kind = DRGN_TYPE_VOID;
+      break;
+  }
+  // The exact drgn_primitive_type used doesn't matter for TreeBuilder. Just
+  // pick DRGN_C_TYPE_INT for simplicity.
+  return makeDrgnType(kind, false, DRGN_C_TYPE_INT, p);
+}
+
+drgn_type* DrgnExporter::visit(Enum& e) {
+  return makeDrgnType(DRGN_TYPE_ENUM, false, DRGN_NOT_PRIMITIVE_TYPE, e);
+}
+
+drgn_type* DrgnExporter::visit(Array& a) {
+  auto* drgnType =
+      makeDrgnType(DRGN_TYPE_ARRAY, false, DRGN_NOT_PRIMITIVE_TYPE, a);
+  drgnType->_private.length = a.len();
+  drgnType->_private.type = accept(a.elementType());
+  return drgnType;
+}
+
+drgn_type* DrgnExporter::visit(Typedef& td) {
+  auto* drgnType =
+      makeDrgnType(DRGN_TYPE_TYPEDEF, false, DRGN_NOT_PRIMITIVE_TYPE, td);
+  auto* underlyingType = accept(td.underlyingType());
+  th_.typedefMap[drgnType] = underlyingType;
+  return drgnType;
+}
+
+drgn_type* DrgnExporter::visit(Pointer& p) {
+  auto* drgnType =
+      makeDrgnType(DRGN_TYPE_POINTER, false, DRGN_NOT_PRIMITIVE_TYPE, p);
+  auto* pointeeType = accept(p.pointeeType());
+  th_.pointerToTypeMap[drgnType] = pointeeType;
+  return drgnType;
+}
+
+drgn_type* DrgnExporter::visit(Dummy& d) {
+  return makeDrgnType(DRGN_TYPE_VOID, false, DRGN_C_TYPE_VOID, d);
+}
+
+drgn_type* DrgnExporter::visit(DummyAllocator& d) {
+  return makeDrgnType(DRGN_TYPE_VOID, false, DRGN_C_TYPE_VOID, d);
+}
+
+drgn_type* DrgnExporter::visit(CaptureKeys&) {
+  throw std::runtime_error("Feature not supported");
+}
+
+drgn_type* DrgnExporter::makeDrgnType(enum drgn_type_kind kind,
+                                      bool is_complete,
+                                      enum drgn_primitive_type primitive,
+                                      const Type& type) {
+  auto& drgnType = drgnTypes_.emplace_back();
+  tracker_.set(type, &drgnType);
+
+  drgnType._private.kind = kind;
+  drgnType._private.is_complete = is_complete;
+  drgnType._private.primitive = primitive;
+
+  // Deliberately leaked to keep it alive for TreeBuilder
+  char* name = strndup(type.inputName().data(), type.inputName().size());
+
+  drgnType._private.name = name;
+  drgnType._private.oi_size = type.size();
+  drgnType._private.little_endian = true;
+  drgnType._private.oi_name = name;
+
+  return &drgnType;
+}
+
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/DrgnExporter.h
+++ b/oi/type_graph/DrgnExporter.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <list>
+#include <string>
+
+#include "NodeTracker.h"
+#include "PassManager.h"
+#include "Types.h"
+#include "Visitor.h"
+
+extern "C" {
+#include <drgn.h>
+}
+
+struct TypeHierarchy;
+
+namespace oi::detail::type_graph {
+
+/*
+ * DrgnExporter
+ *
+ * Converts Type Graph nodes into minimal drgn_type structs and populates a
+ * TypeHierarchy with them, for use by TreeBuilder v1.
+ */
+class DrgnExporter : public Visitor<drgn_type*> {
+ public:
+  static Pass createPass(TypeHierarchy& th, std::list<drgn_type>& drgnTypes);
+
+  DrgnExporter(TypeHierarchy& th, std::list<drgn_type>& drgnTypes)
+      : th_(th), drgnTypes_(drgnTypes) {
+  }
+
+  drgn_type* accept(Type&);
+  drgn_type* visit(Incomplete&) override;
+  drgn_type* visit(Class&) override;
+  drgn_type* visit(Container&) override;
+  drgn_type* visit(Primitive&) override;
+  drgn_type* visit(Enum&) override;
+  drgn_type* visit(Array&) override;
+  drgn_type* visit(Typedef&) override;
+  drgn_type* visit(Pointer&) override;
+  drgn_type* visit(Dummy&) override;
+  drgn_type* visit(DummyAllocator&) override;
+  drgn_type* visit(CaptureKeys&) override;
+
+ private:
+  drgn_type* makeDrgnType(enum drgn_type_kind kind,
+                          bool is_complete,
+                          enum drgn_primitive_type primitive,
+                          const Type& type);
+
+  ResultTracker<drgn_type*> tracker_;
+  TypeHierarchy& th_;
+  std::list<drgn_type>& drgnTypes_;
+};
+
+}  // namespace oi::detail::type_graph

--- a/oi/type_graph/EnforceCompatibility.cpp
+++ b/oi/type_graph/EnforceCompatibility.cpp
@@ -76,15 +76,6 @@ void EnforceCompatibility::visit(Class& c) {
     // CodeGen v1 replaces parent containers with padding
     if (member.name.starts_with(Flattener::ParentPrefix))
       return true;
-
-    if (auto* ptr = dynamic_cast<Pointer*>(&member.type())) {
-      if (auto* incomplete = dynamic_cast<Incomplete*>(&ptr->pointeeType())) {
-        // This is a pointer to an incomplete type. CodeGen v1 does not record
-        // the pointer's address in this case.
-        return true;
-      }
-    }
-
     return false;
   });
 }

--- a/oi/type_graph/Types.cpp
+++ b/oi/type_graph/Types.cpp
@@ -19,15 +19,18 @@
 
 namespace oi::detail::type_graph {
 
-#define X(OI_TYPE_NAME)                              \
-  void OI_TYPE_NAME::accept(Visitor<void>& v) {      \
-    v.visit(*this);                                  \
-  }                                                  \
-  Type& OI_TYPE_NAME::accept(Visitor<Type&>& m) {    \
-    return m.visit(*this);                           \
-  }                                                  \
-  void OI_TYPE_NAME::accept(ConstVisitor& v) const { \
-    v.visit(*this);                                  \
+#define X(OI_TYPE_NAME)                                     \
+  void OI_TYPE_NAME::accept(Visitor<void>& v) {             \
+    v.visit(*this);                                         \
+  }                                                         \
+  drgn_type* OI_TYPE_NAME::accept(Visitor<drgn_type*>& v) { \
+    return v.visit(*this);                                  \
+  }                                                         \
+  Type& OI_TYPE_NAME::accept(Visitor<Type&>& m) {           \
+    return m.visit(*this);                                  \
+  }                                                         \
+  void OI_TYPE_NAME::accept(ConstVisitor& v) const {        \
+    v.visit(*this);                                         \
   }
 OI_TYPE_LIST
 #undef X

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -54,6 +54,7 @@
   X(CaptureKeys)
 
 struct ContainerInfo;
+struct drgn_type;
 
 namespace oi::detail::type_graph {
 
@@ -69,9 +70,10 @@ using QualifierSet = EnumBitset<Qualifier, static_cast<size_t>(Qualifier::Max)>;
 template <typename T>
 class Visitor;
 class ConstVisitor;
-#define DECLARE_ACCEPT                      \
-  void accept(Visitor<void>& v) override;   \
-  Type& accept(Visitor<Type&>& m) override; \
+#define DECLARE_ACCEPT                                \
+  void accept(Visitor<void>& v) override;             \
+  drgn_type* accept(Visitor<drgn_type*>& v) override; \
+  Type& accept(Visitor<Type&>& m) override;           \
   void accept(ConstVisitor& v) const override;
 
 // TODO delete copy and move ctors
@@ -85,6 +87,7 @@ class Type {
  public:
   virtual ~Type() = default;
   virtual void accept(Visitor<void>& v) = 0;
+  virtual drgn_type* accept(Visitor<drgn_type*>& v) = 0;
   virtual Type& accept(Visitor<Type&>& m) = 0;
   virtual void accept(ConstVisitor& v) const = 0;
 

--- a/test/integration/alignment.toml
+++ b/test/integration/alignment.toml
@@ -47,8 +47,8 @@ definitions = '''
     expect_json = '''[
       {"staticSize": 32, "exclusiveSize": 15, "members": [
         {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
-        {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+        {"typeName": "ns_alignment::Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''
     expect_json_v2 = '''[
       {"staticSize": 32, "exclusiveSize": 15, "members": [
@@ -62,8 +62,8 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[
       {"staticSize": 32, "exclusiveSize": 16, "members": [
-        {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+        {"typeName": "ns_alignment::Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''
   [cases.wrapper_two_members]
     param_types = ["const Wrapper<TwoStruct>&"]
@@ -71,12 +71,12 @@ definitions = '''
     expect_json = '''[
       {"staticSize": 64, "exclusiveSize": 15, "members": [
         {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
-        {"typeName": "TwoStruct", "staticSize": 48, "exclusiveSize": 15, "members": [
-          {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
-            {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}]},
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
-          {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
-            {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}]}
+        {"typeName": "ns_alignment::TwoStruct", "staticSize": 48, "exclusiveSize": 15, "members": [
+          {"typeName": "ns_alignment::Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}]},
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
+          {"typeName": "ns_alignment::Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}]}
     ]}]}]'''
     expect_json_v2 = '''[
       {"staticSize": 64, "exclusiveSize": 15, "members": [
@@ -94,12 +94,12 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[
       {"staticSize": 64, "exclusiveSize": 16, "members": [
-        {"typeName": "TwoStruct", "staticSize": 48, "exclusiveSize": 15, "members": [
-          {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
-            {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}]},
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
-          {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
-            {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}]}
+        {"typeName": "ns_alignment::TwoStruct", "staticSize": 48, "exclusiveSize": 15, "members": [
+          {"typeName": "ns_alignment::Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}]},
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
+          {"typeName": "ns_alignment::Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}]}
     ]}]}]'''
   [cases.wrapper_member_alignment]
     param_types = ["const Wrapper<MemberAlignment>&"]
@@ -107,9 +107,9 @@ definitions = '''
     expect_json = '''[
       {"staticSize": 96, "exclusiveSize": 31, "members": [
         {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
-        {"typeName": "MemberAlignment", "staticSize": 64, "exclusiveSize": 62, "members": [
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+        {"typeName": "ns_alignment::MemberAlignment", "staticSize": 64, "exclusiveSize": 62, "members": [
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''
     expect_json_v2 = '''[
       {"staticSize": 96, "exclusiveSize": 31, "members": [
@@ -124,9 +124,9 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[
       {"staticSize": 96, "exclusiveSize": 32, "members": [
-        {"typeName": "MemberAlignment", "staticSize": 64, "exclusiveSize": 62, "members": [
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+        {"typeName": "ns_alignment::MemberAlignment", "staticSize": 64, "exclusiveSize": 62, "members": [
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''
   [cases.wrapper_union_member]
     param_types = ["const Wrapper<UnionMember>&"]
@@ -134,7 +134,7 @@ definitions = '''
     expect_json = '''[
       {"staticSize": 64, "exclusiveSize": 31, "members": [
         {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
-        {"typeName": "UnionMember", "staticSize": 32, "exclusiveSize": 32, "NOT":"members"}
+        {"typeName": "ns_alignment::UnionMember", "staticSize": 32, "exclusiveSize": 32, "NOT":"members"}
     ]}]'''
     expect_json_v2 = '''[
       {"staticSize": 64, "exclusiveSize": 31, "members": [
@@ -147,7 +147,7 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[
       {"staticSize": 64, "exclusiveSize": 32, "members": [
-        {"typeName": "UnionMember", "staticSize": 32, "exclusiveSize": 32, "NOT":"members"}
+        {"typeName": "ns_alignment::UnionMember", "staticSize": 32, "exclusiveSize": 32, "NOT":"members"}
     ]}]'''
   [cases.wrapper_member_override]
     param_types = ["const Wrapper<MemberAlignmentOverriden>&"]
@@ -155,10 +155,10 @@ definitions = '''
     expect_json = '''[
       {"staticSize": 96, "exclusiveSize": 31, "members": [
         {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
-        {"typeName": "MemberAlignmentOverriden", "staticSize": 64, "exclusiveSize": 47, "members": [
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
-          {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
-            {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+        {"typeName": "ns_alignment::MemberAlignmentOverriden", "staticSize": 64, "exclusiveSize": 47, "members": [
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
+          {"typeName": "ns_alignment::Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]}]'''
     expect_json_v2 = '''[
       {"staticSize": 96, "exclusiveSize": 31, "members": [
@@ -174,10 +174,10 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[
       {"staticSize": 96, "exclusiveSize": 32, "members": [
-        {"typeName": "MemberAlignmentOverriden", "staticSize": 64, "exclusiveSize": 47, "members": [
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
-          {"typeName": "Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
-            {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+        {"typeName": "ns_alignment::MemberAlignmentOverriden", "staticSize": 64, "exclusiveSize": 47, "members": [
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
+          {"typeName": "ns_alignment::Align16", "staticSize": 16, "exclusiveSize": 15, "members": [
+            {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]}]'''
   [cases.wrapper_member_lower]
     param_types = ["const Wrapper<AlignedStructMemberAlignLower>&"]
@@ -185,9 +185,9 @@ definitions = '''
     expect_json = '''[
       {"staticSize": 256, "exclusiveSize": 127, "members": [
         {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
-        {"typeName": "AlignedStructMemberAlignLower", "staticSize": 128, "exclusiveSize": 126, "members": [
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+        {"typeName": "ns_alignment::AlignedStructMemberAlignLower", "staticSize": 128, "exclusiveSize": 126, "members": [
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''
     expect_json_v2 = '''[
       {"staticSize": 256, "exclusiveSize": 127, "members": [
@@ -202,7 +202,7 @@ definitions = '''
     setup = "return {};"
     expect_json = '''[
       {"staticSize": 256, "exclusiveSize": 128, "members": [
-        {"typeName": "AlignedStructMemberAlignLower", "staticSize": 128, "exclusiveSize": 126, "members": [
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1},
-          {"typeName": "char", "staticSize": 1, "exclusiveSize": 1}
+        {"typeName": "ns_alignment::AlignedStructMemberAlignLower", "staticSize": 128, "exclusiveSize": 126, "members": [
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1},
+          {"typeName": "int8_t", "staticSize": 1, "exclusiveSize": 1}
     ]}]}]'''

--- a/test/integration/anonymous.toml
+++ b/test/integration/anonymous.toml
@@ -110,16 +110,16 @@ definitions = '''
       "dynamicSize": 12,
       "members": [{
         "name": "anon",
-        "typeName": "__anon_struct_0",
+        "typeName": "__oi_anon_1",
         "staticSize": 8,
         "dynamicSize": 12,
         "members": [{
           "name": "node",
-          "typeName": "ns_anonymous::Node *",
+          "typeName": "ns_anonymous::Node*",
           "staticSize": 8,
           "dynamicSize": 12,
           "members": [{
-            "typeName": "Node",
+            "typeName": "ns_anonymous::Node",
             "staticSize": 12,
             "dynamicSize": 0,
             "members": [
@@ -165,19 +165,19 @@ definitions = '''
         "exclusiveSize": 0,
         "members": [{
           "name": "",
-          "typeName": "__anon_struct_0",
+          "typeName": "__oi_anon_2",
           "isTypedef": false,
           "staticSize": 8,
           "dynamicSize": 12,
           "exclusiveSize": 0,
           "members": [{
             "name": "node",
-            "typeName": "ns_anonymous::Node *",
+            "typeName": "ns_anonymous::Node*",
             "staticSize": 8,
             "dynamicSize": 12,
             "exclusiveSize": 8,
             "members": [{
-              "typeName": "Node",
+              "typeName": "ns_anonymous::Node",
               "staticSize": 12,
               "exclusiveSize": 0,
               "members": [
@@ -199,9 +199,9 @@ definitions = '''
       "staticSize": 24,
       "dynamicSize": 0,
       "members": [
-        {"name":"__anon_member_0", "staticSize":2, "dynamicSize":0},
-        {"name":"__anon_member_1", "staticSize":8, "dynamicSize":0},
-        {"name":"e", "staticSize":4, "dynamicSize":0, "typeName":"int"}
+        {"name":"__oi_anon_0", "staticSize":2, "dynamicSize":0},
+        {"name":"__oi_anon_2", "staticSize":8, "dynamicSize":0},
+        {"name":"e", "staticSize":4, "dynamicSize":0}
       ]
     }]'''
     expect_json_v2 = '''[{
@@ -231,7 +231,6 @@ definitions = '''
         { "name": "v",
           "staticSize": 32,
           "dynamicSize": 12,
-          "paddingSavingsSize": 4,
           "members": [
             { "name": "a", "staticSize": 4, "dynamicSize": 0 },
             { "name": "b", "staticSize": 4, "dynamicSize": 0 },

--- a/test/integration/cycles.toml
+++ b/test/integration/cycles.toml
@@ -38,47 +38,47 @@ definitions = '''
     expect_json = '''
     [
       {
-        "typeName": "RawNode",
+        "typeName": "ns_cycles::RawNode",
         "staticSize": 16,
         "dynamicSize": 32,
         "members": [
           {
-            "typeName": "int",
+            "typeName": "int32_t",
             "staticSize": 4,
             "dynamicSize": 0
           },
           {
-            "typeName": "ns_cycles::RawNode *",
+            "typeName": "ns_cycles::RawNode*",
             "staticSize": 8,
             "dynamicSize": 32,
             "members": [
               {
-                "typeName": "RawNode",
+                "typeName": "ns_cycles::RawNode",
                 "staticSize": 16,
                 "dynamicSize": 16,
                 "members": [
                   {
-                    "typeName": "int",
+                    "typeName": "int32_t",
                     "staticSize": 4,
                     "dynamicSize": 0
                   },
                   {
-                    "typeName": "ns_cycles::RawNode *",
+                    "typeName": "ns_cycles::RawNode*",
                     "staticSize": 8,
                     "dynamicSize": 16,
                     "members": [
                       {
-                        "typeName": "RawNode",
+                        "typeName": "ns_cycles::RawNode",
                         "staticSize": 16,
                         "dynamicSize": 0,
                         "members": [
                           {
-                            "typeName": "int",
+                            "typeName": "int32_t",
                             "staticSize": 4,
                             "dynamicSize": 0
                           },
                           {
-                            "typeName": "ns_cycles::RawNode *",
+                            "typeName": "ns_cycles::RawNode*",
                             "staticSize": 8,
                             "dynamicSize": 0
                           }
@@ -113,40 +113,40 @@ definitions = '''
       "dynamicSize": 48,
       "members": [{
         "name": "t",
-        "typeName": "ns_cycles::RawNode *",
+        "typeName": "ns_cycles::RawNode*",
         "staticSize": 8,
         "dynamicSize": 48,
         "members": [{
-          "typeName": "RawNode",
+          "typeName": "ns_cycles::RawNode",
           "staticSize": 16,
           "dynamicSize": 32,
           "members": [
-            { "name": "value", "typeName": "int", "staticSize": 4, "dynamicSize": 0 },
+            { "name": "value", "typeName": "int32_t", "staticSize": 4, "dynamicSize": 0 },
             {
               "name": "next",
-              "typeName": "ns_cycles::RawNode *",
+              "typeName": "ns_cycles::RawNode*",
               "staticSize": 8,
               "dynamicSize": 32,
               "members": [{
-                "typeName": "RawNode",
+                "typeName": "ns_cycles::RawNode",
                 "staticSize": 16,
                 "dynamicSize": 16,
                 "members": [
-                  { "name": "value", "typeName": "int", "staticSize": 4, "dynamicSize": 0 },
+                  { "name": "value", "typeName": "int32_t", "staticSize": 4, "dynamicSize": 0 },
                   {
                     "name": "next",
-                    "typeName": "ns_cycles::RawNode *",
+                    "typeName": "ns_cycles::RawNode*",
                     "staticSize": 8,
                     "dynamicSize": 16,
                     "members": [{
-                      "typeName": "RawNode",
+                      "typeName": "ns_cycles::RawNode",
                       "staticSize": 16,
                       "dynamicSize": 0,
                       "members": [
-                        { "name": "value", "typeName": "int", "staticSize": 4, "dynamicSize": 0 },
+                        { "name": "value", "typeName": "int32_t", "staticSize": 4, "dynamicSize": 0 },
                         {
                           "name": "next",
-                          "typeName": "ns_cycles::RawNode *",
+                          "typeName": "ns_cycles::RawNode*",
                           "staticSize": 8,
                           "dynamicSize": 0
                         }
@@ -167,52 +167,52 @@ definitions = '''
     expect_json = '''
     [
       {
-        "typeName": "reference_wrapper<ns_cycles::UniqueNode>",
+        "typeName": "std::reference_wrapper<ns_cycles::UniqueNode>",
         "staticSize": 8,
         "dynamicSize": 48,
         "members": [
           {
-            "typeName": "UniqueNode",
+            "typeName": "ns_cycles::UniqueNode",
             "staticSize": 16,
             "dynamicSize": 32,
             "members": [
               {
-                "typeName": "int",
+                "typeName": "int32_t",
                 "staticSize": 4,
                 "dynamicSize": 0
               },
               {
-                "typeName": "unique_ptr<ns_cycles::UniqueNode, std::default_delete<ns_cycles::UniqueNode> >",
+                "typeName": "std::unique_ptr<ns_cycles::UniqueNode, default_delete<ns_cycles::UniqueNode>>",
                 "staticSize": 8,
                 "dynamicSize": 32,
                 "members": [
                   {
-                    "typeName": "UniqueNode",
+                    "typeName": "ns_cycles::UniqueNode",
                     "staticSize": 16,
                     "dynamicSize": 16,
                     "members": [
                       {
-                        "typeName": "int",
+                        "typeName": "int32_t",
                         "staticSize": 4,
                         "dynamicSize": 0
                       },
                       {
-                        "typeName": "unique_ptr<ns_cycles::UniqueNode, std::default_delete<ns_cycles::UniqueNode> >",
+                        "typeName": "std::unique_ptr<ns_cycles::UniqueNode, default_delete<ns_cycles::UniqueNode>>",
                         "staticSize": 8,
                         "dynamicSize": 16,
                         "members": [
                           {
-                            "typeName": "UniqueNode",
+                            "typeName": "ns_cycles::UniqueNode",
                             "staticSize": 16,
                             "dynamicSize": 0,
                             "members": [
                               {
-                                "typeName": "int",
+                                "typeName": "int32_t",
                                 "staticSize": 4,
                                 "dynamicSize": 0
                               },
                               {
-                                "typeName": "unique_ptr<ns_cycles::UniqueNode, std::default_delete<ns_cycles::UniqueNode> >",
+                                "typeName": "std::unique_ptr<ns_cycles::UniqueNode, default_delete<ns_cycles::UniqueNode>>",
                                 "staticSize": 8,
                                 "dynamicSize": 0
                               }
@@ -245,52 +245,52 @@ definitions = '''
     expect_json = '''
     [
       {
-        "typeName": "reference_wrapper<ns_cycles::SharedNode>",
+        "typeName": "std::reference_wrapper<ns_cycles::SharedNode>",
         "staticSize": 8,
         "dynamicSize": 72,
         "members": [
           {
-            "typeName": "SharedNode",
+            "typeName": "ns_cycles::SharedNode",
             "staticSize": 24,
             "dynamicSize": 48,
             "members": [
               {
-                "typeName": "int",
+                "typeName": "int32_t",
                 "staticSize": 4,
                 "dynamicSize": 0
               },
               {
-                "typeName": "shared_ptr<ns_cycles::SharedNode>",
+                "typeName": "std::shared_ptr<ns_cycles::SharedNode>",
                 "staticSize": 16,
                 "dynamicSize": 48,
                 "members": [
                   {
-                    "typeName": "SharedNode",
+                    "typeName": "ns_cycles::SharedNode",
                     "staticSize": 24,
                     "dynamicSize": 24,
                     "members": [
                       {
-                        "typeName": "int",
+                        "typeName": "int32_t",
                         "staticSize": 4,
                         "dynamicSize": 0
                       },
                       {
-                        "typeName": "shared_ptr<ns_cycles::SharedNode>",
+                        "typeName": "std::shared_ptr<ns_cycles::SharedNode>",
                         "staticSize": 16,
                         "dynamicSize": 24,
                         "members": [
                           {
-                            "typeName": "SharedNode",
+                            "typeName": "ns_cycles::SharedNode",
                             "staticSize": 24,
                             "dynamicSize": 0,
                             "members": [
                               {
-                                "typeName": "int",
+                                "typeName": "int32_t",
                                 "staticSize": 4,
                                 "dynamicSize": 0
                               },
                               {
-                                "typeName": "shared_ptr<ns_cycles::SharedNode>",
+                                "typeName": "std::shared_ptr<ns_cycles::SharedNode>",
                                 "staticSize": 16,
                                 "dynamicSize": 0
                               }

--- a/test/integration/ignored.toml
+++ b/test/integration/ignored.toml
@@ -10,7 +10,7 @@ definitions = '''
 
 [cases]
   [cases.a]
-    oil_skip = 'v2 hides the member entirely when it should show it with static size' # todo: github issue
+    skip = 'v2 hides the member entirely when it should show it with static size' # todo: github issue
     param_types = ["const Bar&"]
     setup = """
       return Bar{

--- a/test/integration/inheritance_multiple.toml
+++ b/test/integration/inheritance_multiple.toml
@@ -27,21 +27,21 @@ definitions = '''
       "staticSize":24,
       "dynamicSize":0,
       "members":[
-        {"name":"a", "staticSize":4, "dynamicSize":0, "typeName": "int"},
-        {"name":"b", "staticSize":4, "dynamicSize":0, "typeName": "int"},
-        {"name":"c", "staticSize":4, "dynamicSize":0, "typeName": "int"},
-        {"name":"d", "staticSize":4, "dynamicSize":0, "typeName": "int"},
-        {"name":"e", "staticSize":4, "dynamicSize":0, "typeName": "int"},
-        {"name":"f", "staticSize":4, "dynamicSize":0, "typeName": "int"}
+        {"name":"a", "staticSize":4, "dynamicSize":0},
+        {"name":"b", "staticSize":4, "dynamicSize":0},
+        {"name":"c", "staticSize":4, "dynamicSize":0},
+        {"name":"d", "staticSize":4, "dynamicSize":0},
+        {"name":"e", "staticSize":4, "dynamicSize":0},
+        {"name":"f", "staticSize":4, "dynamicSize":0}
       ]}]'''
     expect_json_v2 = '''[{
       "staticSize":24,
       "exclusiveSize":0,
       "members":[
-        {"name":"a", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
-        {"name":"b", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
-        {"name":"c", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
-        {"name":"d", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
-        {"name":"e", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]},
-        {"name":"f", "staticSize":4, "exclusiveSize":4, "typeNames": ["int32_t"]}
+        {"name":"a", "staticSize":4, "exclusiveSize":4},
+        {"name":"b", "staticSize":4, "exclusiveSize":4},
+        {"name":"c", "staticSize":4, "exclusiveSize":4},
+        {"name":"d", "staticSize":4, "exclusiveSize":4},
+        {"name":"e", "staticSize":4, "exclusiveSize":4},
+        {"name":"f", "staticSize":4, "exclusiveSize":4}
       ]}]'''

--- a/test/integration/namespaces.toml
+++ b/test/integration/namespaces.toml
@@ -20,7 +20,7 @@ definitions = '''
     param_types = ["const std::queue<std::pair<nsA::Foo, nsB::Foo>>&"]
     setup = "return std::queue<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>>({{ns_namespaces::nsA::Foo(), ns_namespaces::nsB::Foo()}});"
     expect_json = '''[{
-      "typeName": "queue<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>, std::deque<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>, std::allocator<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo> > > >",
+      "typeName": "std::queue<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>, std::deque<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>, std::allocator<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>>>>",
       "staticSize": 80, "dynamicSize": 12, "length": 1, "capacity": 1, "elementStaticSize": 12
     }]'''
   [cases.stack]
@@ -28,6 +28,6 @@ definitions = '''
     param_types = ["const std::stack<std::pair<nsA::Foo, nsB::Foo>>&"]
     setup = "return std::stack<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>>({{ns_namespaces::nsA::Foo(), ns_namespaces::nsB::Foo()}});"
     expect_json = '''[{
-      "typeName": "stack<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>, std::deque<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>, std::allocator<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo> > > >",
+      "typeName": "std::stack<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>, std::deque<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>, std::allocator<std::pair<ns_namespaces::nsA::Foo, ns_namespaces::nsB::Foo>>>>",
       "staticSize": 80, "dynamicSize": 12, "length": 1, "capacity": 1, "elementStaticSize": 12
     }]'''

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -94,7 +94,6 @@ definitions = '''
     expect_json = '''[{
       "staticSize": 88,
       "dynamicSize": 0,
-      "paddingSavingsSize": 21,
       "members": [
         { "name": "ptrundef", "staticSize": 8, "dynamicSize": 0 },
         { "name": "__makePad1", "staticSize": 1, "dynamicSize": 0 },

--- a/test/integration/std_conditional.toml
+++ b/test/integration/std_conditional.toml
@@ -25,7 +25,7 @@ public:
     expect_json = '''
 [
   {
-    "typeName": "C",
+    "typeName": "ns_std_conditional::C",
     "isTypedef": false,
     "staticSize": 8,
     "dynamicSize": 0,
@@ -48,7 +48,7 @@ public:
               {
                 "name": "",
                 "typePath": "",
-                "typeName": "A",
+                "typeName": "ns_std_conditional::A",
                 "isTypedef": false,
                 "staticSize": 8,
                 "dynamicSize": 0,
@@ -56,7 +56,6 @@ public:
                   {
                     "name": "f",
                     "typePath": "f",
-                    "typeName": "int",
                     "isTypedef": false,
                     "staticSize": 4,
                     "dynamicSize": 0
@@ -64,7 +63,6 @@ public:
                   {
                     "name": "g",
                     "typePath": "g",
-                    "typeName": "int",
                     "isTypedef": false,
                     "staticSize": 4,
                     "dynamicSize": 0

--- a/test/integration/std_deque_del_allocator.toml
+++ b/test/integration/std_deque_del_allocator.toml
@@ -38,20 +38,20 @@ includes = ["deque"]
       "members":[
         {"name":"v1", "staticSize":80, "dynamicSize":4, "length":1, "capacity":1, "elementStaticSize":4,
           "members":[
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"a", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"a", "staticSize":4, "dynamicSize":0}
               ]}
           ]},
         {"name":"v2", "staticSize":80, "dynamicSize":8, "length":2, "capacity":2, "elementStaticSize":4,
           "members":[
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"b", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"b", "staticSize":4, "dynamicSize":0}
               ]},
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"b", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"b", "staticSize":4, "dynamicSize":0}
               ]}
           ]}
       ]}]'''

--- a/test/integration/std_list_del_allocator.toml
+++ b/test/integration/std_list_del_allocator.toml
@@ -40,20 +40,20 @@ includes = ["list"]
       "members":[
         {"name":"v1", "staticSize":24, "dynamicSize":4, "length":1, "capacity":1, "elementStaticSize":4,
           "members":[
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"a", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"a", "staticSize":4, "dynamicSize":0}
               ]}
           ]},
         {"name":"v2", "staticSize":24, "dynamicSize":8, "length":2, "capacity":2, "elementStaticSize":4,
           "members":[
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"b", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"b", "staticSize":4, "dynamicSize":0}
               ]},
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"b", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"b", "staticSize":4, "dynamicSize":0}
               ]}
           ]}
       ]}]'''

--- a/test/integration/std_priority_queue.toml
+++ b/test/integration/std_priority_queue.toml
@@ -5,11 +5,11 @@ includes = ["queue"]
     param_types = ["const std::priority_queue<int>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName": "priority_queue<int, std::vector<int, std::allocator<int> >, std::less<int> >",
+      "typeName": "std::priority_queue<int32_t, std::vector<int32_t, std::allocator<int32_t>>, less<int>>",
       "staticSize": 32, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "vector<int, std::allocator<int> >",
+          "typeName": "std::vector<int32_t, std::allocator<int32_t>>",
           "staticSize": 24, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4
         }
       ]}]'''
@@ -18,11 +18,11 @@ includes = ["queue"]
     param_types = ["const std::priority_queue<int>&"]
     setup = "return std::priority_queue<int>({}, {3,2,1});"
     expect_json = '''[{
-      "typeName": "priority_queue<int, std::vector<int, std::allocator<int> >, std::less<int> >",
+      "typeName": "std::priority_queue<int32_t, std::vector<int32_t, std::allocator<int32_t>>, less<int>>",
       "staticSize": 32, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "vector<int, std::allocator<int> >",
+          "typeName": "std::vector<int32_t, std::allocator<int32_t>>",
           "staticSize": 24, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4
         }
       ]}]'''
@@ -31,11 +31,11 @@ includes = ["queue"]
     param_types = ["const std::priority_queue<int, std::deque<int>>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName": "priority_queue<int, std::deque<int, std::allocator<int> >, std::less<int> >",
+      "typeName": "std::priority_queue<int32_t, std::deque<int32_t, std::allocator<int32_t>>, less<int>>",
       "staticSize": 88, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "deque<int, std::allocator<int> >",
+          "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
           "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4
         }
       ]}]'''
@@ -44,11 +44,11 @@ includes = ["queue"]
     param_types = ["const std::priority_queue<int, std::deque<int>>&"]
     setup = "return std::priority_queue<int, std::deque<int>>({}, {3,2,1});"
     expect_json = '''[{
-      "typeName": "priority_queue<int, std::deque<int, std::allocator<int> >, std::less<int> >",
+      "typeName": "std::priority_queue<int32_t, std::deque<int32_t, std::allocator<int32_t>>, less<int>>",
       "staticSize": 88, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "deque<int, std::allocator<int> >",
+          "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
           "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4
         }
       ]}]'''

--- a/test/integration/std_queue.toml
+++ b/test/integration/std_queue.toml
@@ -5,11 +5,11 @@ includes = ["queue"]
     param_types = ["const std::queue<int>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName": "queue<int, std::deque<int, std::allocator<int> > >",
+      "typeName": "std::queue<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
       "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "deque<int, std::allocator<int> >",
+          "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
           "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4
         }
       ]}]'''
@@ -18,11 +18,11 @@ includes = ["queue"]
     param_types = ["const std::queue<int>&"]
     setup = "return std::queue<int>({1,2,3});"
     expect_json = '''[{
-      "typeName": "queue<int, std::deque<int, std::allocator<int> > >",
+      "typeName": "std::queue<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
       "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "deque<int, std::allocator<int> >",
+          "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
           "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4
         }
       ]}]'''
@@ -54,31 +54,31 @@ includes = ["queue"]
           "staticSize": 80, "dynamicSize": 260, "length": 3, "capacity": 3, "elementStaticSize": 80,
           "members": [
             {
-              "typeName": "queue<int, std::deque<int, std::allocator<int> > >",
+              "typeName": "std::queue<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
               "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4,
               "members": [
                 {
-                  "typeName": "deque<int, std::allocator<int> >",
+                  "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
                   "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4
                 }
               ]
             },
             {
-              "typeName": "queue<int, std::deque<int, std::allocator<int> > >",
+              "typeName": "std::queue<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
               "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4,
               "members": [
                 {
-                  "typeName": "deque<int, std::allocator<int> >",
+                  "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
                   "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4
                 }
               ]
             },
             {
-              "typeName": "queue<int, std::deque<int, std::allocator<int> > >",
+              "typeName": "std::queue<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
               "staticSize": 80, "dynamicSize": 8, "length": 2, "capacity": 2, "elementStaticSize": 4,
               "members": [
                 {
-                  "typeName": "deque<int, std::allocator<int> >",
+                  "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
                   "staticSize": 80, "dynamicSize": 8, "length": 2, "capacity": 2, "elementStaticSize": 4
                 }
               ]
@@ -91,11 +91,11 @@ includes = ["queue"]
     param_types = ["const std::queue<int, std::vector<int>>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName": "queue<int, std::vector<int, std::allocator<int> > >",
+      "typeName": "std::queue<int32_t, std::vector<int32_t, std::allocator<int32_t>>>",
       "staticSize": 24, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "vector<int, std::allocator<int> >",
+          "typeName": "std::vector<int32_t, std::allocator<int32_t>>",
           "staticSize": 24, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4
         }
       ]}]'''
@@ -104,11 +104,11 @@ includes = ["queue"]
     param_types = ["const std::queue<int, std::vector<int>>&"]
     setup = "return std::queue<int, std::vector<int>>({1,2,3});"
     expect_json = '''[{
-      "typeName": "queue<int, std::vector<int, std::allocator<int> > >",
+      "typeName": "std::queue<int32_t, std::vector<int32_t, std::allocator<int32_t>>>",
       "staticSize": 24, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "vector<int, std::allocator<int> >",
+          "typeName": "std::vector<int32_t, std::allocator<int32_t>>",
           "staticSize": 24, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4
         }
       ]}]'''

--- a/test/integration/std_stack.toml
+++ b/test/integration/std_stack.toml
@@ -5,11 +5,11 @@ includes = ["stack", "vector"]
     param_types = ["const std::stack<int>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName": "stack<int, std::deque<int, std::allocator<int> > >",
+      "typeName": "std::stack<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
       "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "deque<int, std::allocator<int> >",
+          "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
           "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4
         }
       ]}]'''
@@ -18,11 +18,11 @@ includes = ["stack", "vector"]
     param_types = ["const std::stack<int>&"]
     setup = "return std::stack<int>({1,2,3});"
     expect_json = '''[{
-      "typeName": "stack<int, std::deque<int, std::allocator<int> > >",
+      "typeName": "std::stack<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
       "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "deque<int, std::allocator<int> >",
+          "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
           "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4
         }
       ]}]'''
@@ -54,31 +54,31 @@ includes = ["stack", "vector"]
           "staticSize": 80, "dynamicSize": 260, "length": 3, "capacity": 3, "elementStaticSize": 80,
           "members": [
             {
-              "typeName": "stack<int, std::deque<int, std::allocator<int> > >",
+              "typeName": "std::stack<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
               "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4,
               "members": [
                 {
-                  "typeName": "deque<int, std::allocator<int> >",
+                  "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
                   "staticSize": 80, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4
                 }
               ]
             },
             {
-              "typeName": "stack<int, std::deque<int, std::allocator<int> > >",
+              "typeName": "std::stack<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
               "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4,
               "members": [
                 {
-                  "typeName": "deque<int, std::allocator<int> >",
+                  "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
                   "staticSize": 80, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4
                 }
               ]
             },
             {
-              "typeName": "stack<int, std::deque<int, std::allocator<int> > >",
+              "typeName": "std::stack<int32_t, std::deque<int32_t, std::allocator<int32_t>>>",
               "staticSize": 80, "dynamicSize": 8, "length": 2, "capacity": 2, "elementStaticSize": 4,
               "members": [
                 {
-                  "typeName": "deque<int, std::allocator<int> >",
+                  "typeName": "std::deque<int32_t, std::allocator<int32_t>>",
                   "staticSize": 80, "dynamicSize": 8, "length": 2, "capacity": 2, "elementStaticSize": 4
                 }
               ]
@@ -91,11 +91,11 @@ includes = ["stack", "vector"]
     param_types = ["const std::stack<int, std::vector<int>>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName": "stack<int, std::vector<int, std::allocator<int> > >",
+      "typeName": "std::stack<int32_t, std::vector<int32_t, std::allocator<int32_t>>>",
       "staticSize": 24, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "vector<int, std::allocator<int> >",
+          "typeName": "std::vector<int32_t, std::allocator<int32_t>>",
           "staticSize": 24, "dynamicSize": 0, "length": 0, "capacity": 0, "elementStaticSize": 4
         }
       ]}]'''
@@ -104,11 +104,11 @@ includes = ["stack", "vector"]
     param_types = ["const std::stack<int, std::vector<int>>&"]
     setup = "return std::stack<int, std::vector<int>>({1,2,3});"
     expect_json = '''[{
-      "typeName": "stack<int, std::vector<int, std::allocator<int> > >",
+      "typeName": "std::stack<int32_t, std::vector<int32_t, std::allocator<int32_t>>>",
       "staticSize": 24, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4,
       "members": [
         {
-          "typeName": "vector<int, std::allocator<int> >",
+          "typeName": "std::vector<int32_t, std::allocator<int32_t>>",
           "staticSize": 24, "dynamicSize": 12, "length": 3, "capacity": 3, "elementStaticSize": 4
         }
       ]}]'''

--- a/test/integration/std_variant.toml
+++ b/test/integration/std_variant.toml
@@ -20,7 +20,7 @@ definitions = '''
       "capacity":1,
       "elementStaticSize":8,
       "members":[
-        {"typeName":"char", "staticSize":1, "exclusiveSize":1, "dynamicSize":0}
+        {"typeName":"int8_t", "staticSize":1, "exclusiveSize":1, "dynamicSize":0}
       ]}]'''
   [cases.char_int64_2]
     oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298
@@ -34,7 +34,7 @@ definitions = '''
       "capacity":1,
       "elementStaticSize":8,
       "members":[
-        {"typeName":"long", "staticSize":8, "exclusiveSize":8, "dynamicSize":0}
+        {"typeName":"int64_t", "staticSize":8, "exclusiveSize":8, "dynamicSize":0}
       ]}]'''
 
   [cases.vector_int_1]
@@ -50,7 +50,7 @@ definitions = '''
       "elementStaticSize":24,
       "members":[
         {
-          "typeName":"vector<int, std::allocator<int> >",
+          "typeName":"std::vector<int32_t, std::allocator<int32_t>>",
           "staticSize":24,
           "dynamicSize":12,
           "exclusiveSize":36,
@@ -71,7 +71,7 @@ definitions = '''
       "elementStaticSize":24,
       "members":[
         {
-          "typeName":"int",
+          "typeName":"int32_t",
           "staticSize":4,
           "dynamicSize":0
         }
@@ -99,7 +99,7 @@ definitions = '''
           "capacity":1,
           "elementStaticSize":8,
           "members":[
-            {"typeName":"long", "staticSize":8, "exclusiveSize":8, "dynamicSize":0}
+            {"typeName":"int64_t", "staticSize":8, "exclusiveSize":8, "dynamicSize":0}
           ]
         }
       ]}]'''
@@ -144,7 +144,7 @@ definitions = '''
       "capacity":1,
       "elementStaticSize":4,
       "members":[
-        {"typeName":"char", "staticSize":1, "exclusiveSize":1, "dynamicSize":0}
+        {"typeName":"int8_t", "staticSize":1, "exclusiveSize":1, "dynamicSize":0}
       ]}]'''
   [cases.256_params_empty]
     oil_skip = "std::variant is not implemented for treebuilder v2" # https://github.com/facebookexperimental/object-introspection/issues/298

--- a/test/integration/std_vector_del_allocator.toml
+++ b/test/integration/std_vector_del_allocator.toml
@@ -40,20 +40,20 @@ includes = ["vector"]
       "members":[
         {"name":"v1", "staticSize":24, "dynamicSize":4, "length":1, "capacity":1, "elementStaticSize":4,
           "members":[
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"a", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"a", "staticSize":4, "dynamicSize":0}
               ]}
           ]},
         {"name":"v2", "staticSize":24, "dynamicSize":8, "length":2, "capacity":2, "elementStaticSize":4,
           "members":[
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"b", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"b", "staticSize":4, "dynamicSize":0}
               ]},
-            {"name":"", "typeName": "C", "staticSize":4, "dynamicSize":0,
+            {"name":"", "staticSize":4, "dynamicSize":0,
               "members":[
-                {"name":"b", "typeName": "int", "staticSize":4, "dynamicSize":0}
+                {"name":"b", "staticSize":4, "dynamicSize":0}
               ]}
           ]}
       ]}]'''

--- a/test/integration/templates.toml
+++ b/test/integration/templates.toml
@@ -28,21 +28,21 @@ definitions = '''
     param_types = ["const TemplatedClass1<int>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName":"TemplatedClass1<int>",
+      "typeName":"ns_templates::TemplatedClass1<int>",
       "staticSize":4,
       "dynamicSize":0,
       "members":[{
-        "typeName":"int"
+        "typeName":"int32_t"
     }]}]'''
   [cases.vector]
     param_types = ["const TemplatedClass1<std::vector<int>>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName":"TemplatedClass1<std::vector<int, std::allocator<int> > >",
+      "typeName":"ns_templates::TemplatedClass1<std::vector<int, std::allocator<int> > >",
       "staticSize":24,
       "dynamicSize":0,
       "members":[{
-        "typeName":"vector<int, std::allocator<int> >",
+        "typeName":"std::vector<int32_t, std::allocator<int32_t>>",
         "staticSize":24,
         "dynamicSize":0,
         "length":0,
@@ -65,18 +65,18 @@ definitions = '''
     param_types = ["const TemplatedClass2<Foo, int>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName":"TemplatedClass2<ns_templates::Foo, int>",
+      "typeName":"ns_templates::TemplatedClass2<ns_templates::Foo, int>",
       "staticSize":12,
       "dynamicSize":0,
       "members":[
-        {"typeName":"TemplatedClass1<ns_templates::Foo>", "staticSize":8, "dynamicSize":0},
-        {"typeName":"int", "staticSize":4, "dynamicSize":0}
+        {"typeName":"ns_templates::TemplatedClass1<ns_templates::Foo>", "staticSize":8, "dynamicSize":0},
+        {"typeName":"int32_t", "staticSize":4, "dynamicSize":0}
       ]}]'''
   [cases.value]
     param_types = ["const TemplatedClassVal<3>&"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName":"TemplatedClassVal<3>",
+      "typeName":"ns_templates::TemplatedClassVal<3>",
       "staticSize":12,
       "dynamicSize":0,
       "members":[{

--- a/test/integration/typedefs.toml
+++ b/test/integration/typedefs.toml
@@ -64,7 +64,7 @@ definitions = '''
           "capacity":0,
           "elementStaticSize":4,
           "isTypedef":false,
-          "typeName":"vector<int, std::allocator<int> >",
+          "typeName":"std::vector<int32_t, std::allocator<int32_t>>",
           "NOT":"members"
         }
       ]}]'''

--- a/test/test_enforce_compatibility.cpp
+++ b/test/test_enforce_compatibility.cpp
@@ -32,17 +32,3 @@ TEST(EnforceCompatibilityTest, TypesToStub) {
 [0] Class: EnumMap (size: 8)
 )");
 }
-
-TEST(EnforceCompatibilityTest, VoidPointer) {
-  test(EnforceCompatibility::createPass(),
-       R"(
-[0] Class: MyClass (size: 8)
-      Member: p (offset: 0)
-[1]     Pointer
-          Incomplete
-            Primitive: void
-)",
-       R"(
-[0] Class: MyClass (size: 8)
-)");
-}


### PR DESCRIPTION
Create DrgnExporter to translate Type Graph "Type" nodes into drgn_type structs, suitable for use in OICache and TreeBuilder.