### PR TITLE
Integration Tests: Fix thrift_unions tests

### DIFF
--- a/test/integration/thrift_unions.toml
+++ b/test/integration/thrift_unions.toml
@@ -16,6 +16,7 @@ raw_definitions = '''
 namespace cpp2 {
   void StaticUnion::__fbthrift_clear() {}
   void DynamicUnion::__fbthrift_clear() {}
+  DynamicUnion::~DynamicUnion() {}
 }
 '''
 


### PR DESCRIPTION
## Summary
Fix internal build which depends on Thrift.

With a recent Thrift update, we now must also define a destructor for this type.

## Test plan
CI
