### PR TITLE
CodeGen: Remove Incomplete members from Classes

### DIFF
--- a/oi/type_graph/RemoveMembers.cpp
+++ b/oi/type_graph/RemoveMembers.cpp
@@ -61,7 +61,11 @@ void RemoveMembers::visit(Class& c) {
   }
 
   std::erase_if(c.members, [this, &c](Member member) {
-    return ignoreMember(c.name(), member.name);
+    if (ignoreMember(c.name(), member.name))
+      return true;
+    if (dynamic_cast<Incomplete*>(&member.type()))
+      return true;
+    return false;
   });
 }
 

--- a/test/test_remove_members.cpp
+++ b/test/test_remove_members.cpp
@@ -183,3 +183,23 @@ TEST(RemoveMembersTest, Union) {
 [0] Union: MyUnion (size: 4)
 )");
 }
+
+TEST(RemoveMembersTest, Incomplete) {
+  test(RemoveMembers::createPass({}),
+       R"(
+[0] Class: ClassA (size: 12)
+      Member: a (offset: 0)
+        Primitive: int32_t
+      Member: b (offset: 4)
+        Incomplete: [MyIncompleteType]
+      Member: c (offset: 8)
+        Primitive: int32_t
+)",
+       R"(
+[0] Class: ClassA (size: 12)
+      Member: a (offset: 0)
+        Primitive: int32_t
+      Member: c (offset: 8)
+        Primitive: int32_t
+)");
+}


### PR DESCRIPTION
They must not appear in the final generated code as we'd end up with invalid types with void members, e.g.:
```
  struct Foo {
    int a;
    void myIncompleteMember;
    int c;
  };
```

Removing them from the type graph early also ensures that padding is calculated correctly.