### PR TITLE
Really, really make sure arrays when used as a template parameter have a name

### DIFF
--- a/oi/OICodeGen.cpp
+++ b/oi/OICodeGen.cpp
@@ -528,6 +528,8 @@ bool OICodeGen::buildNameInt(drgn_type* type,
 
       if (drgn_type_has_name(arrayElementType)) {
         templateParamName = drgn_type_name(arrayElementType);
+      } else if (drgn_type_has_tag(arrayElementType)) {
+        templateParamName = drgn_type_tag(arrayElementType);
       } else {
         LOG(ERROR) << "Failed4 to get typename ";
         return false;


### PR DESCRIPTION
## Summary
During AdIndexerUnit tests when  processing a template parameter that is an array we sometimes have no 'name' stored but do have a 'tag'. Use the tag in this case.

## Test plan

Verified on an AdIndexerUnit that failed to codegen with CGV1.
