### PR TITLE
codegen: remove reliance on drgn type for top level name

### DIFF
--- a/oi/CodeGen.h
+++ b/oi/CodeGen.h
@@ -45,6 +45,14 @@ class CodeGen {
       : config_(config), symbols_(symbols) {
   }
 
+  struct ExactName {
+    std::string name;
+  };
+  struct HashedComponent {
+    std::string name;
+  };
+  using RootFunctionName = std::variant<ExactName, HashedComponent>;
+
   /*
    * Helper function to perform all the steps required for code generation for a
    * single drgn_type.
@@ -64,9 +72,7 @@ class CodeGen {
   void transform(type_graph::TypeGraph& typeGraph);
   void generate(type_graph::TypeGraph& typeGraph,
                 std::string& code,
-                struct drgn_type*
-                    drgnType /* TODO: this argument should not be required */
-  );
+                RootFunctionName rootName);
 
  private:
   type_graph::TypeGraph typeGraph_;
@@ -76,7 +82,10 @@ class CodeGen {
   std::unordered_set<const ContainerInfo*> definedContainers_;
   std::unordered_map<const type_graph::Class*, const type_graph::Member*>
       thriftIssetMembers_;
-  std::string linkageName_;
+
+  bool codegenFromDrgn(struct drgn_type* drgnType,
+                       std::string& code,
+                       RootFunctionName name);
 
   void genDefsThrift(const type_graph::TypeGraph& typeGraph, std::string& code);
   void addGetSizeFuncDefs(const type_graph::TypeGraph& typeGraph,


### PR DESCRIPTION
codegen: remove reliance on drgn type for top level name

Currently we rely on `SymbolService::getTypeName` for getting the hash that's
included in the generated function's name. The value of this must stay the same
to match with the value expected by OIDebugger - changing it causes failure to
relocate when attaching with OID and JIT OIL.

Calculate this name in the `codegenFromDrgn` method and pass it through where
appropriate rather than passing the `drgn_type` itself through.

We don't need to name the type like that when using AoT OIL. Let's
hash the linkage name instead as that is more unique.

Test Plan:
- CI

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/435).
* #421
* __->__ #435