### PR TITLE
clangparser: provide correct kind for classes/unions

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -213,8 +213,12 @@ template <typename T>
 struct NameProvider {};
 )";
 
+  // TODO: stop types being duplicated at this point and remove this check
+  std::unordered_set<std::string_view> emittedTypes;
   for (const Type& t : typeGraph.finalTypes) {
     if (dynamic_cast<const Typedef*>(&t))
+      continue;
+    if (!emittedTypes.emplace(t.name()).second)
       continue;
 
     code += "template <> struct NameProvider<";

--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -183,7 +183,12 @@ Type& ClangTypeParser::enumerateClass(const clang::RecordType& ty) {
 
   std::string name = decl->getNameAsString();
 
-  auto kind = Class::Kind::Struct;  // TODO: kind
+  auto kind = Class::Kind::Struct;
+  if (ty.isUnionType()) {
+    kind = Class::Kind::Union;
+  } else if (ty.isClassType()) {
+    kind = Class::Kind::Class;
+  }
 
   int virtuality = 0;
 

--- a/types/folly_iobuf_type.toml
+++ b/types/folly_iobuf_type.toml
@@ -39,3 +39,34 @@ void getSizeType(const %1% &container, size_t& returnArg)
     SAVE_SIZE(fullCapacity);
 }
 """
+
+traversal_func = """
+// We calculate the length of all IOBufs in the chain manually.
+// IOBuf has built-in computeChainCapacity()/computeChainLength()
+// functions which do this for us. But dead code optimization in TAO
+// caused these functions to be removed which causes relocation
+// errors.
+
+std::size_t fullLength = container.length();
+std::size_t fullCapacity = container.capacity();
+for (const folly::IOBuf* current = container.next(); current != &container;
+    current = current->next()) {
+  fullLength += current->length();
+  fullCapacity += current->capacity();
+}
+
+return returnArg.write(fullCapacity).write(fullLength);
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get<ParsedData::VarInt>(d.val).value });
+el.exclusive_size += el.container_stats->capacity;
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.container_stats->length = std::get<ParsedData::VarInt>(d.val).value;
+"""


### PR DESCRIPTION
clangparser: provide correct kind for classes/unions

Previously ClangTypeParser assumed all RecordTypes were structs. This is fine
for structs and classes but completely incorrect for unions. Check which type
it is and give type graph the correct one.

Test plan:
- Unions static assert without this change because their size/alignment is
  wrong.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/439).
* #441
* #440
* __->__ #439
* #438
* #437