### PR TITLE
clangparser: provide alignment info for members

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -213,8 +213,12 @@ template <typename T>
 struct NameProvider {};
 )";
 
+  // TODO: stop types being duplicated at this point and remove this check
+  std::unordered_set<std::string_view> emittedTypes;
   for (const Type& t : typeGraph.finalTypes) {
     if (dynamic_cast<const Typedef*>(&t))
+      continue;
+    if (!emittedTypes.emplace(t.name()).second)
       continue;
 
     code += "template <> struct NameProvider<";

--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -183,7 +183,12 @@ Type& ClangTypeParser::enumerateClass(const clang::RecordType& ty) {
 
   std::string name = decl->getNameAsString();
 
-  auto kind = Class::Kind::Struct;  // TODO: kind
+  auto kind = Class::Kind::Struct;
+  if (ty.isUnionType()) {
+    kind = Class::Kind::Union;
+  } else if (ty.isClassType()) {
+    kind = Class::Kind::Class;
+  }
 
   int virtuality = 0;
 

--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -294,6 +294,7 @@ void ClangTypeParser::enumerateClassMembers(const clang::RecordType& ty,
 
     auto& mtype = enumerateType(*qualType);
     Member m{mtype, std::move(member_name), offset_in_bits, size_in_bits};
+    m.align = decl->getASTContext().getTypeAlign(qualType) / 8;
     members.push_back(m);
   }
 

--- a/types/folly_iobuf_type.toml
+++ b/types/folly_iobuf_type.toml
@@ -39,3 +39,34 @@ void getSizeType(const %1% &container, size_t& returnArg)
     SAVE_SIZE(fullCapacity);
 }
 """
+
+traversal_func = """
+// We calculate the length of all IOBufs in the chain manually.
+// IOBuf has built-in computeChainCapacity()/computeChainLength()
+// functions which do this for us. But dead code optimization in TAO
+// caused these functions to be removed which causes relocation
+// errors.
+
+std::size_t fullLength = container.length();
+std::size_t fullCapacity = container.capacity();
+for (const folly::IOBuf* current = container.next(); current != &container;
+    current = current->next()) {
+  fullLength += current->length();
+  fullCapacity += current->capacity();
+}
+
+return returnArg.write(fullCapacity).write(fullLength);
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.container_stats.emplace(result::Element::ContainerStats{ .capacity = std::get<ParsedData::VarInt>(d.val).value });
+el.exclusive_size += el.container_stats->capacity;
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.container_stats->length = std::get<ParsedData::VarInt>(d.val).value;
+"""


### PR DESCRIPTION
clangparser: provide alignment info for members

Unlike DWARF, the Clang AST is capable of correctly calculating the alignment
for each member. If we do this then AlignmentCalc doesn't traverse into the
member to attempt to calculate the alignment.

This check might be wrong if the field has explicit alignment. That case can be
covered when we have proper integration testing and a repro.

Test plan:
- Without this lots of static asserts occur. With this it's okay.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/440).
* #441
* __->__ #440
* #439
* #438
* #437