### PR TITLE
clangparser: mark incomplete arrays as incomplete without failing

### DIFF
--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -410,8 +410,17 @@ ContainerInfo* ClangTypeParser::getContainerInfo(
 namespace {
 
 bool requireCompleteType(clang::Sema& sema, const clang::Type& ty) {
-  if (ty.isSpecificBuiltinType(clang::BuiltinType::Void))
-    return true;  // treat as complete
+  switch (ty.getTypeClass()) {
+    case clang::Type::Builtin: {
+      if (ty.isSpecificBuiltinType(clang::BuiltinType::Void))
+        return true;  // treat as complete
+      break;
+    }
+    case clang::Type::IncompleteArray:
+      return false;  // would fail completion
+    default:
+      break;
+  }
 
   // TODO: This is a terrible warning.
   return !sema.RequireCompleteType(


### PR DESCRIPTION
clangparser: mark incomplete arrays as incomplete without failing

Attempting to complete a type which can't be completed currently fails oilgen.
For incomplete arrays, which we know are not possible to complete, return false
deliberately.

`requireCompleteType` likely needs to not fail in all cases in the future. For
now this works.

Test plan:
- `std::unique_ptr<long[]>` used to fail the generation. Now it can
  successfully codegen.
