### PR TITLE
tbv2: use std::decay_t with smart pointers

### DIFF
--- a/oi/FuncGen.cpp
+++ b/oi/FuncGen.cpp
@@ -625,11 +625,11 @@ template <typename Ctx, typename T>
 constexpr inst::Field make_field(std::string_view name) {
   return inst::Field{
       sizeof(T),
-      ExclusiveSizeProvider<T>::size,
+      ExclusiveSizeProvider<std::decay_t<T>>::size,
       name,
-      NameProvider<T>::names,
-      TypeHandler<Ctx, T>::fields,
-      TypeHandler<Ctx, T>::processors,
+      NameProvider<std::decay_t<T>>::names,
+      TypeHandler<Ctx, std::decay_t<T>>::fields,
+      TypeHandler<Ctx, std::decay_t<T>>::processors,
       std::is_fundamental_v<T>,
   };
 }

--- a/test/integration/std_smart_ptr.toml
+++ b/test/integration/std_smart_ptr.toml
@@ -32,6 +32,31 @@ definitions = '''
       }
     ]
     '''
+  [cases.unique_ptr_const_uint64_empty]
+    param_types = ["std::unique_ptr<const std::uint64_t>&"]
+    setup = "return {nullptr};"
+    expect_json = '''
+    [
+      {
+        "staticSize": 8,
+        "dynamicSize": 0,
+        "exclusiveSize": 8,
+        "length": 0,
+        "capacity": 1,
+        "elementStaticSize": 8
+      }
+    ]
+    '''
+    expect_json_v2 = '''
+    [
+      {
+        "staticSize": 8,
+        "exclusiveSize": 8,
+        "length": 0,
+        "capacity": 1
+      }
+    ]
+    '''
   [cases.unique_ptr_uint64_present]
     param_types = ["std::unique_ptr<std::uint64_t>&"]
     setup = "return {std::make_unique<std::uint64_t>(64)};"
@@ -77,6 +102,30 @@ definitions = '''
         "staticSize": 8,
         "exclusiveSize": 8,
         "size": 8,
+        "length": 0,
+        "capacity": 1
+      }
+    ]
+    '''
+  [cases.unique_ptr_const_vector_empty]
+    param_types = ["std::unique_ptr<const std::vector<std::uint64_t>>&"]
+    setup = "return {nullptr};"
+    expect_json = '''
+    [
+      {
+        "staticSize": 8,
+        "dynamicSize": 0,
+        "length": 0,
+        "capacity": 1,
+        "elementStaticSize": 24
+      }
+    ]
+    '''
+    expect_json_v2 = '''
+    [
+      {
+        "staticSize": 8,
+        "exclusiveSize": 8,
         "length": 0,
         "capacity": 1
       }
@@ -188,6 +237,30 @@ definitions = '''
       }
     ]
     '''
+  [cases.shared_ptr_const_uint64_empty]
+    param_types = ["std::shared_ptr<const std::uint64_t>&"]
+    setup = "return {nullptr};"
+    expect_json = '''
+    [
+      {
+        "staticSize": 16,
+        "dynamicSize": 0,
+        "length": 0,
+        "capacity": 1,
+        "elementStaticSize": 8
+      }
+    ]
+    '''
+    expect_json_v2 = '''
+    [
+      {
+        "staticSize": 16,
+        "exclusiveSize": 16,
+        "length": 0,
+        "capacity": 1
+      }
+    ]
+    '''
   [cases.shared_ptr_uint64_present]
     param_types = ["std::shared_ptr<std::uint64_t>&"]
     setup = "return std::make_shared<std::uint64_t>(64);"
@@ -236,6 +309,30 @@ definitions = '''
         "staticSize": 16,
         "exclusiveSize": 16,
         "size": 16,
+        "length": 0,
+        "capacity": 1
+      }
+    ]
+    '''
+  [cases.shared_ptr_const_vector_empty]
+    param_types = ["std::shared_ptr<const std::vector<std::uint64_t>>&"]
+    setup = "return {nullptr};"
+    expect_json = '''
+    [
+      {
+        "staticSize": 16,
+        "dynamicSize": 0,
+        "length": 0,
+        "capacity": 1,
+        "elementStaticSize": 24
+      }
+    ]
+    '''
+    expect_json_v2 = '''
+    [
+      {
+        "staticSize": 16,
+        "exclusiveSize": 16,
         "length": 0,
         "capacity": 1
       }

--- a/types/shrd_ptr_type.toml
+++ b/types/shrd_ptr_type.toml
@@ -60,7 +60,7 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 type = """
 types::st::Sum<DB,
   types::st::Unit<DB>,
-  typename TypeHandler<Ctx, T0>::type>
+  typename TypeHandler<Ctx, std::decay_t<T0>>::type>
 """
 func = """
 #ifdef __GLIBCXX__

--- a/types/uniq_ptr_type.toml
+++ b/types/uniq_ptr_type.toml
@@ -61,7 +61,7 @@ el.pointer = std::get<ParsedData::VarInt>(d.val).value;
 type = """
 types::st::Sum<DB,
   types::st::Unit<DB>,
-  typename TypeHandler<Ctx, T0>::type>
+  typename TypeHandler<Ctx, std::decay_t<T0>>::type>
 """
 func = """
 auto sum = std::get<ParsedData::Sum>(d.val);


### PR DESCRIPTION
tbv2: use std::decay_t with smart pointers

CodeGen v2 permits template parameters to be qualified. This means that if we
call `make_field` with a template parameter it will be qualified. However, we
don't qualify the types when generating meta functions such as `NameProvider`
and `TypeHandler`. This means these qualified types don't match up with the
expected type.

Use `std::decay_t` when forwarding the type to `NameProvider` and `TypeHandler`
so they're always the base type that they were generated with. Most of this is
covered by `make_field`, but there are direct references to `TypeHandler<Ctx,
T>` in a lot of `TypeHandler::type` fields. Fix the problematic types manually
for now, there may need to be a better solution with meta functions for this in
the future.

Test Plan:
- CI
- Added a test for `std::unique_ptr<const uint64_t>` to exercise this. Failed
  before, passes after.
- Added a test for `std::unique_ptr<const std::vector<uint64_t>>` to test a
  non-primitive type. Failed before, passes after.
