### PR TITLE
clangparser: add support for parents

### DIFF
--- a/oi/type_graph/ClangTypeParser.h
+++ b/oi/type_graph/ClangTypeParser.h
@@ -50,6 +50,7 @@ class Array;
 class Class;
 class Enum;
 class Member;
+struct Parent;
 class Primitive;
 class Reference;
 class Type;
@@ -114,6 +115,7 @@ class ClangTypeParser {
   std::optional<TemplateParam> enumerateTemplateTemplateParam(
       const clang::TemplateName&);
 
+  void enumerateClassParents(const clang::RecordType&, std::vector<Parent>&);
   void enumerateClassMembers(const clang::RecordType&, std::vector<Member>&);
 
   ContainerInfo* getContainerInfo(const std::string& fqName) const;


### PR DESCRIPTION
clangparser: add support for parents

TODO: Check the assumption that a "base" always has a Type that can be cast to
RecordType.
TODO: Check the assumption that a "base" always has a Decl that can be cast to
CXXRecordDecl.

Add basic support for class parents. Focus purely on bases for now and ignore
vbases.

Test Plan:
- Tested with a simple example. Base containing a long and a class containing a
  float. Both fields appear in the final flattened code.
