### PR TITLE
oilgen: add to integration test framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
           name: test-gcc
           requires:
             - build-gcc
-          exclude_regex: ".*inheritance_polymorphic.*|.*arrays_member_int0"
+          exclude_regex: "OilgenIntegration\\..*|.*inheritance_polymorphic.*|.*arrays_member_int0"
       - coverage:
           name: coverage
           requires:

--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -350,6 +350,7 @@ Primitive& ClangTypeParser::enumeratePrimitive(const clang::BuiltinType& ty) {
     case clang::BuiltinType::WChar_U:
       return makeType<Primitive>(ty, Primitive::Kind::UInt32);
 
+    case clang::BuiltinType::Char8:
     case clang::BuiltinType::Char_S:
     case clang::BuiltinType::SChar:
       return makeType<Primitive>(ty, Primitive::Kind::Int8);
@@ -380,8 +381,9 @@ Primitive& ClangTypeParser::enumeratePrimitive(const clang::BuiltinType& ty) {
     case clang::BuiltinType::Float:
       return makeType<Primitive>(ty, Primitive::Kind::Float32);
     case clang::BuiltinType::Double:
-    case clang::BuiltinType::LongDouble:
       return makeType<Primitive>(ty, Primitive::Kind::Float64);
+    case clang::BuiltinType::LongDouble:
+      return makeType<Primitive>(ty, Primitive::Kind::Float128);
 
     case clang::BuiltinType::UInt128:
     case clang::BuiltinType::Int128:

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -592,7 +592,7 @@ class Primitive : public Type {
     Float32,
     Float64,
     Float80,   // TODO worth including?
-    Float128,  // TODO can we generate this?
+    Float128,
     Bool,
 
     StubbedPointer,

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -58,12 +58,18 @@ target_link_libraries(integration_test_runner PRIVATE
   GTest::gmock_main
   Boost::headers
   ${Boost_LIBRARIES}
+  range-v3
   toml
 )
 target_compile_definitions(integration_test_runner PRIVATE
-  TARGET_EXE_PATH="${CMAKE_CURRENT_BINARY_DIR}/integration_test_target"
+  TARGET_EXE_PATH="$<TARGET_FILE:integration_test_target>"
   OID_EXE_PATH="$<TARGET_FILE:oid>"
-  CONFIG_FILE_PATH="${CMAKE_BINARY_DIR}/testing.oid.toml")
+  OILGEN_EXE_PATH="$<TARGET_FILE:oilgen>"
+  CONFIG_FILE_PATH="${CMAKE_BINARY_DIR}/testing.oid.toml"
+
+  CXX="${CMAKE_CXX_COMPILER}"
+  TARGET_INCLUDE_DIRECTORIES="$<JOIN:$<TARGET_PROPERTY:integration_test_target,INCLUDE_DIRECTORIES>,:>"
+)
 
 if (${THRIFT_FOUND})
   foreach(THRIFT_TEST IN LISTS THRIFT_TESTS)
@@ -85,6 +91,7 @@ if (${THRIFT_FOUND})
 
     add_custom_target(integration_test_thrift_sources_${THRIFT_TEST} DEPENDS ${THRIFT_TYPES_H})
     add_dependencies(integration_test_target integration_test_thrift_sources_${THRIFT_TEST})
+    add_dependencies(integration_test_runner integration_test_thrift_sources_${THRIFT_TEST})
     target_sources(integration_test_target PRIVATE ${THRIFT_DATA_CPP})
   endforeach()
 

--- a/test/integration/runner_common.h
+++ b/test/integration/runner_common.h
@@ -22,6 +22,11 @@ struct OilOpts {
   std::string targetArgs;
 };
 
+struct OilgenOpts {
+  boost::asio::io_context& ctx;
+  std::string_view targetSrc;
+};
+
 struct Proc {
   boost::asio::io_context& ctx;
   boost::process::child proc;
@@ -80,4 +85,13 @@ class OilIntegration : public IntegrationBase {
   Proc runOilTarget(OilOpts opts,
                     std::string configPrefix,
                     std::string configSuffix);
+};
+
+class OilgenIntegration : public IntegrationBase {
+ protected:
+  std::string TmpDirStr() override;
+
+  Proc runOilgenTarget(OilgenOpts opts,
+                       std::string configPrefix,
+                       std::string configSuffix);
 };


### PR DESCRIPTION
oilgen: add to integration test framework

TODO: Replace the references to local paths.

oilgen (the basis of Ahead Of Time compilation for OIL) has never been passed
through our large test suite and has instead had more focused testing and large
examples. When consuming DWARF information in a similar fashion to JIT OIL this
was okay, but with the new Clang AST based mechanism it means we have very
little coverage.

This change adds an oilgen test for every test case that has an oil test.
Relying on the build system to create the test target as before would make it
difficult to have failing tests, so we move the build into the integration test
runner. This involves:
1. Writing the input source to a file.
2. Consuming it with oilgen to get the implementation object file.
3. Compiling the input source and linking it with this file.
4. Running the newly created target.

This approach can give the full error message at any stage that fails and will
fail the test appropriately. The downside is the build system integration is
more difficult, as we need the correct compiler flags for the target and to use
the correct compiler. It would be very tricky to replicate this in a build
system that's not CMake, so we will likely only run these tests in open source.

Test plan:
- CI
