### PR TITLE
tbv2: fix type names for std::optional

### DIFF
--- a/test/integration/std_optional.toml
+++ b/test/integration/std_optional.toml
@@ -18,6 +18,7 @@ includes = ["optional", "cstdint", "vector"]
     expect_json_v2 = '''
     [
       {
+        "typeNames": ["std::optional<uint64_t>"],
         "staticSize": 16,
         "exclusiveSize": 16,
         "size": 16,
@@ -45,6 +46,7 @@ includes = ["optional", "cstdint", "vector"]
     expect_json_v2 = '''
     [
       {
+        "typeNames": ["std::optional<uint64_t>"],
         "staticSize": 16,
         "exclusiveSize": 8,
         "size": 16,
@@ -52,6 +54,7 @@ includes = ["optional", "cstdint", "vector"]
         "capacity": 1,
         "members": [
           {
+            "typeNames": ["uint64_t"],
             "staticSize": 8,
             "exclusiveSize": 8
           }
@@ -77,6 +80,7 @@ includes = ["optional", "cstdint", "vector"]
     expect_json_v2 = '''
     [
       {
+        "typeNames": ["std::optional<std::vector<uint64_t, std::allocator<uint64_t>>>"],
         "staticSize": 32,
         "exclusiveSize": 32,
         "size": 32,
@@ -112,6 +116,7 @@ includes = ["optional", "cstdint", "vector"]
     expect_json_v2 = '''
     [
       {
+        "typeNames": ["std::optional<std::vector<uint64_t, std::allocator<uint64_t>>>"],
         "staticSize": 32,
         "exclusiveSize": 8,
         "size": 72,
@@ -119,6 +124,7 @@ includes = ["optional", "cstdint", "vector"]
         "capacity": 1,
         "members": [
           {
+            "typeNames": ["std::vector<uint64_t, std::allocator<uint64_t>>"],
             "staticSize": 24,
             "exclusiveSize": 24,
             "size": 64,

--- a/types/optional_type.toml
+++ b/types/optional_type.toml
@@ -41,14 +41,7 @@ if (container.has_value()) {
 [[codegen.processor]]
 type = "types::st::Sum<DB, types::st::Unit<DB>, typename TypeHandler<Ctx, T0>::type>"
 func = """
-static constexpr std::array<std::string_view, 1> names{"TODO"};
-static constexpr auto elementField = inst::Field{
-  sizeof(T0),
-  "el",
-  names,
-  TypeHandler<Ctx, T0>::fields,
-  TypeHandler<Ctx, T0>::processors,
-};
+static constexpr auto elementField = make_field<Ctx, T0>("el");
 
 auto sum = std::get<ParsedData::Sum>(d.val);
 


### PR DESCRIPTION
tbv2: fix type names for std::optional

Type names of optional elements were accidentally left as todo. Update
`std::optional` to use `make_field` and correctly name its elements.

Test Plan:
- CI
- Updated the integration tests to test the names.
