### PR TITLE
tbv2: add support for std::reference_wrapper

### DIFF
--- a/test/integration/std_reference_wrapper.toml
+++ b/test/integration/std_reference_wrapper.toml
@@ -1,12 +1,14 @@
 includes = ["functional"]
 [cases]
   [cases.int]
-    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/307
     param_types = ["const std::reference_wrapper<int>&"]
     setup = "return std::ref(*new int(1));"
     expect_json = '[{"staticSize":8, "dynamicSize":4, "length":1, "capacity":1, "elementStaticSize":4}]'
+    expect_json_v2 = '''[{
+      "size":12, "staticSize":8, "exclusiveSize":8, "length":1, "capacity":1, "members":[
+        {"size":4, "staticSize":4, "exclusiveSize":4, "members":[]}
+    ]}]'''
   [cases.vector]
-    oil_skip = 'not implemented for treebuilder v2' # https://github.com/facebookexperimental/object-introspection/issues/307
     param_types = ["const std::vector<std::reference_wrapper<int>>&"]
     setup = "return {{std::ref(*new int(1)), std::ref(*new int(2)), std::ref(*new int(3))}};"
     expect_json = '''[{
@@ -20,3 +22,21 @@ includes = ["functional"]
         {"staticSize":8, "dynamicSize":4, "length":1, "capacity":1, "elementStaticSize":4},
         {"staticSize":8, "dynamicSize":4, "length":1, "capacity":1, "elementStaticSize":4}
       ]}]'''
+    expect_json_v2 = '''[{
+      "size":60,
+      "staticSize":24,
+      "exclusiveSize":24,
+      "length":3,
+      "capacity":3,
+      "members":[
+        {"size":12, "staticSize":8, "exclusiveSize":8, "length":1, "capacity":1, "members":[
+          {"size":4, "staticSize":4, "exclusiveSize":4, "members":[]}
+        ]},
+        {"size":12, "staticSize":8, "exclusiveSize":8, "length":1, "capacity":1, "members":[
+          {"size":4, "staticSize":4, "exclusiveSize":4, "members":[]}
+        ]},
+        {"size":12, "staticSize":8, "exclusiveSize":8, "length":1, "capacity":1, "members":[
+          {"size":4, "staticSize":4, "exclusiveSize":4, "members":[]}
+        ]}
+      ]
+    }]'''

--- a/types/ref_wrapper_type.toml
+++ b/types/ref_wrapper_type.toml
@@ -29,3 +29,42 @@ void getSizeType(const %1%<T> &ref, size_t& returnArg)
     }
 }
 """
+
+traversal_func = """
+auto tail = returnArg.write((uintptr_t)&(container.get()));
+
+if (ctx.pointers.add((uintptr_t)&container.get())) {
+  return tail.template delegate<1>([&ctx, &container](auto ret) {
+    return OIInternal::getSizeType<Ctx>(ctx, container.get(), ret);
+  });
+} else {
+  return tail.template delegate<0>(std::identity());
+}
+"""
+
+[[codegen.processor]]
+type = "types::st::VarInt<DB>"
+func = """
+el.pointer = std::get<ParsedData::VarInt>(d.val).value;
+"""
+
+[[codegen.processor]]
+type = """
+types::st::Sum<DB,
+  types::st::Unit<DB>,
+  typename TypeHandler<Ctx, T0>::type>
+"""
+func = """
+auto sum = std::get<ParsedData::Sum>(d.val);
+el.container_stats.emplace(result::Element::ContainerStats {
+  .capacity = 1,
+  .length = sum.index, // 0 if in a cycle, 1 otherwise
+});
+
+if constexpr (oi_is_complete<T0>) {
+  if (sum.index == 1) {
+    static constexpr auto element = make_field<Ctx, T0>("ref_val");
+    stack_ins(element);
+  }
+}
+"""


### PR DESCRIPTION
tbv2: add support for std::reference_wrapper

Closes #307

Test plan:
- CI
- Updated and enabled tests.
