### PR TITLE
tbv2: add is_primitive to output

### DIFF
--- a/include/oi/exporters/Json.h
+++ b/include/oi/exporters/Json.h
@@ -98,8 +98,8 @@ inline void Json::printStringField(std::string_view name,
 inline void Json::printBoolField(std::string_view name,
                                  bool value,
                                  std::string_view indent) {
-  out_ << tab() << '"' << name << "\":" << space() << value << ',' << endl()
-       << indent;
+  out_ << tab() << '"' << name << "\":" << space() << (value ? "true" : "false")
+       << ',' << endl() << indent;
 }
 inline void Json::printUnsignedField(std::string_view name,
                                      uint64_t value,
@@ -159,6 +159,7 @@ inline void Json::printFields(const result::Element& el,
   }
   if (el.is_set_stats.has_value())
     printUnsignedField("is_set", el.is_set_stats->is_set, indent);
+  printBoolField("is_primitive", el.is_primitive, indent);
 }
 
 template <typename It>

--- a/include/oi/exporters/inst.h
+++ b/include/oi/exporters/inst.h
@@ -58,19 +58,22 @@ struct Field {
                   std::string_view name_,
                   const std::array<std::string_view, N0>& type_names_,
                   const std::array<Field, N1>& fields_,
-                  const std::array<ProcessorInst, N2>& processors_);
+                  const std::array<ProcessorInst, N2>& processors_,
+                  bool is_primitive_);
   template <size_t N0, size_t N1, size_t N2>
   constexpr Field(size_t static_size_,
                   std::string_view name_,
                   const std::array<std::string_view, N0>& type_names_,
                   const std::array<Field, N1>& fields_,
-                  const std::array<ProcessorInst, N2>& processors_)
+                  const std::array<ProcessorInst, N2>& processors_,
+                  bool is_primitive_)
       : Field(static_size_,
               static_size_,
               name_,
               type_names_,
               fields_,
-              processors_) {
+              processors_,
+              is_primitive_) {
   }
   constexpr Field(const Field&) = default;  // no idea why this is needed
 
@@ -80,6 +83,7 @@ struct Field {
   std::span<const std::string_view> type_names;
   std::span<const Field> fields;
   std::span<const ProcessorInst> processors;
+  bool is_primitive;
 };
 
 template <size_t N0, size_t N1, size_t N2>
@@ -88,13 +92,15 @@ constexpr Field::Field(size_t static_size_,
                        std::string_view name_,
                        const std::array<std::string_view, N0>& type_names_,
                        const std::array<Field, N1>& fields_,
-                       const std::array<ProcessorInst, N2>& processors_)
+                       const std::array<ProcessorInst, N2>& processors_,
+                       bool is_primitive_)
     : static_size(static_size_),
       exclusive_size(exclusive_size_),
       name(name_),
       type_names(type_names_),
       fields(fields_),
-      processors(processors_) {
+      processors(processors_),
+      is_primitive(is_primitive_) {
 }
 
 }  // namespace oi::exporters::inst

--- a/include/oi/result/Element.h
+++ b/include/oi/result/Element.h
@@ -52,6 +52,7 @@ struct Element {
       std::nullopt};
   std::optional<ContainerStats> container_stats;
   std::optional<IsSetStats> is_set_stats;
+  bool is_primitive;
 };
 
 }  // namespace oi::result

--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -798,12 +798,15 @@ void CodeGen::genClassTreeBuilderInstructions(const Class& c,
     if (m.name.starts_with(AddPadding::MemberPrefix))
       continue;
     std::string fullName = c.name() + "::" + m.name;
+    bool isPrimitive = dynamic_cast<const Primitive*>(&m.type());
     code += "      inst::Field{sizeof(" + fullName + "), " +
             std::to_string(calculateExclusiveSize(m.type())) + ",\"" +
             m.inputName + "\", member_" + std::to_string(index) +
             "_type_names, TypeHandler<Ctx, decltype(" + fullName +
             ")>::fields, TypeHandler<Ctx, decltype(" + fullName +
-            ")>::processors},\n";
+            ")>::processors, ";
+    code += isPrimitive ? "true" : "false";
+    code += "},\n";
   }
   code += "  };\n";
   code +=
@@ -1074,6 +1077,7 @@ constexpr inst::Field make_field(std::string_view name) {
     NameProvider<T>::names,
     TypeHandler<Ctx, T>::fields,
     TypeHandler<Ctx, T>::processors,
+    std::is_fundamental_v<T>
   };
 }
 )";

--- a/oi/FuncGen.cpp
+++ b/oi/FuncGen.cpp
@@ -399,7 +399,8 @@ const std::array<std::string_view, )";
       ", OIInternal::TypeHandler<FakeContext, "
       "OIInternal::__ROOT_TYPE__>::fields, "
       "OIInternal::TypeHandler<FakeContext, "
-      "OIInternal::__ROOT_TYPE__>::processors};\n";
+      "OIInternal::__ROOT_TYPE__>::processors, "
+      "std::is_fundamental_v<OIInternal::__ROOT_TYPE__>};\n";
   code += "} // namespace\n";
   code +=
       "extern const exporters::inst::Inst __attribute__((used, retain)) "
@@ -640,13 +641,7 @@ void FuncGen::DefineBasicTypeHandlers(std::string& code, FeatureSet features) {
         }
         static void process_pointer_content(result::Element& el, std::function<void(inst::Inst)> stack_ins, ParsedData d) {
           static constexpr std::array<std::string_view, 1> names{"TODO"};
-          static constexpr auto childField = inst::Field{
-            sizeof(T),
-            "*",
-            names,
-            TypeHandler<Ctx, T>::fields,
-            TypeHandler<Ctx, T>::processors,
-          };
+          static constexpr auto childField = make_field<Ctx, T>("*");
 
           const ParsedData::Sum& sum = std::get<ParsedData::Sum>(d.val);
 

--- a/oi/IntrospectionResult.cpp
+++ b/oi/IntrospectionResult.cpp
@@ -78,6 +78,7 @@ IntrospectionResult::const_iterator::operator++() {
                 .exclusive_size = ty.exclusive_size,
                 .container_stats = std::nullopt,
                 .is_set_stats = std::nullopt,
+                .is_primitive = ty.is_primitive,
             };
 
             for (const auto& [dy, handler] : ty.processors) {

--- a/test/integration/simple.toml
+++ b/test/integration/simple.toml
@@ -24,11 +24,20 @@ definitions = '''
       "staticSize":16,
       "dynamicSize":0,
       "exclusiveSize": 3,
-      "size": 16,
       "members":[
         {"name":"a", "staticSize":4, "dynamicSize":0, "exclusiveSize": 4, "size": 4},
         {"name":"b", "staticSize":1, "dynamicSize":0, "exclusiveSize": 1, "size": 1},
         {"name":"c", "staticSize":8, "dynamicSize":0, "exclusiveSize": 8, "size": 8}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":16,
+      "exclusiveSize": 3,
+      "size": 16,
+      "is_primitive": false,
+      "members":[
+        {"name":"a", "staticSize":4, "exclusiveSize": 4, "size": 4, "is_primitive": true},
+        {"name":"b", "staticSize":1, "exclusiveSize": 1, "size": 1, "is_primitive": true},
+        {"name":"c", "staticSize":8, "exclusiveSize": 8, "size": 8, "is_primitive": true}
       ]}]'''
   [cases.class]
     param_types = ["const SimpleClass&"]
@@ -37,11 +46,20 @@ definitions = '''
       "staticSize":16,
       "dynamicSize":0,
       "exclusiveSize": 3,
-      "size": 16,
       "members":[
         {"name":"a", "staticSize":4, "dynamicSize":0, "exclusiveSize": 4, "size": 4},
         {"name":"b", "staticSize":1, "dynamicSize":0, "exclusiveSize": 1, "size": 1},
         {"name":"c", "staticSize":8, "dynamicSize":0, "exclusiveSize": 8, "size": 8}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":16,
+      "exclusiveSize": 3,
+      "size": 16,
+      "is_primitive": false,
+      "members":[
+        {"name":"a", "staticSize":4, "exclusiveSize": 4, "size": 4, "is_primitive": true},
+        {"name":"b", "staticSize":1, "exclusiveSize": 1, "size": 1, "is_primitive": true},
+        {"name":"c", "staticSize":8, "exclusiveSize": 8, "size": 8, "is_primitive": true}
       ]}]'''
   [cases.union]
     param_types = ["const SimpleUnion&"]
@@ -49,6 +67,11 @@ definitions = '''
     expect_json = '''[{
       "staticSize":8,
       "dynamicSize":0,
+      "exclusiveSize":8
+    }]'''
+    expect_json_v2 = '''[{
+      "staticSize":8,
       "exclusiveSize":8,
-      "size":8
+      "size":8,
+      "is_primitive":false
     }]'''

--- a/types/f14_fast_map.toml
+++ b/types/f14_fast_map.toml
@@ -95,6 +95,7 @@ static constexpr inst::Field element{
   std::array<std::string_view, 0>{},
   element_fields,
   std::array<inst::ProcessorInst, 0>{},
+  element_fields[0].is_primitive && element_fields[1].is_primitive,
 };
 
 for (size_t i = 0; i < list.length; i++)

--- a/types/f14_node_map.toml
+++ b/types/f14_node_map.toml
@@ -95,6 +95,7 @@ static constexpr inst::Field element{
   std::array<std::string_view, 0>{},
   element_fields,
   std::array<inst::ProcessorInst, 0>{},
+  element_fields[0].is_primitive && element_fields[1].is_primitive,
 };
 
 for (size_t i = 0; i < list.length; i++)

--- a/types/f14_value_map.toml
+++ b/types/f14_value_map.toml
@@ -95,6 +95,7 @@ static constexpr inst::Field element{
   std::array<std::string_view, 0>{},
   element_fields,
   std::array<inst::ProcessorInst, 0>{},
+  element_fields[0].is_primitive && element_fields[1].is_primitive,
 };
 
 for (size_t i = 0; i < list.length; i++)

--- a/types/f14_vector_map.toml
+++ b/types/f14_vector_map.toml
@@ -95,6 +95,7 @@ static constexpr inst::Field element{
   std::array<std::string_view, 0>{},
   element_fields,
   std::array<inst::ProcessorInst, 0>{},
+  element_fields[0].is_primitive && element_fields[1].is_primitive,
 };
 
 for (size_t i = 0; i < list.length; i++)

--- a/types/map_seq_type.toml
+++ b/types/map_seq_type.toml
@@ -91,6 +91,7 @@ static constexpr auto entry = inst::Field {
   std::array<std::string_view, 0>{},
   entryFields,
   processors,
+  entryFields[0].is_primitive && entryFields[1].is_primitive,
 };
 
 auto list = std::get<ParsedData::List>(d.val);

--- a/types/multi_map_type.toml
+++ b/types/multi_map_type.toml
@@ -118,6 +118,7 @@ static constexpr auto element = inst::Field {
   std::array<std::string_view, 0>{},
   elementFields,
   std::array<inst::ProcessorInst, 0>{},
+  elementFields[0].is_primitive && elementFields[1].is_primitive,
 };
 
 auto list = std::get<ParsedData::List>(d.val);

--- a/types/std_map_type.toml
+++ b/types/std_map_type.toml
@@ -135,6 +135,7 @@ static constexpr inst::Field element{
   std::array<std::string_view, 0>{},
   element_fields,
   processors,
+  element_fields[0].is_primitive && element_fields[1].is_primitive,
 };
 
 auto list = std::get<ParsedData::List>(d.val);

--- a/types/std_unordered_map_type.toml
+++ b/types/std_unordered_map_type.toml
@@ -135,6 +135,7 @@ static constexpr auto element = inst::Field{
   std::array<std::string_view, 0>{},
   element_fields,
   processors,
+  element_fields[0].is_primitive && element_fields[1].is_primitive,
 };
 
 for (size_t i = 0; i < list.length; i++)

--- a/types/std_unordered_multimap_type.toml
+++ b/types/std_unordered_multimap_type.toml
@@ -121,6 +121,7 @@ static constexpr auto element = inst::Field{
   std::array<std::string_view, 0>{},
   element_fields,
   std::array<inst::ProcessorInst, 0>{},
+  element_fields[0].is_primitive && element_fields[1].is_primitive,
 };
 
 for (size_t i = 0; i < list.length; i++)


### PR DESCRIPTION
tbv2: add is_primitive to output

C++ has a concept of Primitive which holds in the type graph. However we don't
currently expose this information to the end user. Expose this from the OIL
iterator to allow future features like primitive rollups.

This affects containers like maps which have a fake `[]` element with no type.
They use this to group together the key/value in a map and to account for any
per element storage overhead. Currently the decision is to make the fake `[]`
element a primitive if all of its children are primitives. This allows for more
effective primitive rollups if that is implemented. This implementation detail
may be changed in future.

Test Plan:
- CI
- Updated simple tests.
