### PR TITLE
Add namespaces to integration tests' "typeName"

### DIFF
--- a/test/integration/inheritance_polymorphic.toml
+++ b/test/integration/inheritance_polymorphic.toml
@@ -29,7 +29,7 @@ definitions = '''
     arg_types = ["A"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName":"A",
+      "typeName":"ns_inheritance_polymorphic::A",
       "staticSize":16,
       "dynamicSize":0,
       "members":[
@@ -48,7 +48,7 @@ definitions = '''
       return b;
     '''
     expect_json = '''[{
-      "typeName":"B",
+      "typeName":"ns_inheritance_polymorphic::B",
       "staticSize":40,
       "dynamicSize":12,
       "members":[
@@ -67,7 +67,7 @@ definitions = '''
       return b;
     '''
     expect_json = '''[{
-      "typeName":"B",
+      "typeName":"ns_inheritance_polymorphic::B",
       "staticSize":40,
       "dynamicSize":12,
       "members":[
@@ -87,7 +87,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"C",
+      "typeName":"ns_inheritance_polymorphic::C",
       "staticSize":48,
       "dynamicSize":12,
       "members":[
@@ -107,7 +107,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"C",
+      "typeName":"ns_inheritance_polymorphic::C",
       "staticSize":48,
       "dynamicSize":12,
       "members":[
@@ -127,7 +127,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"C",
+      "typeName":"ns_inheritance_polymorphic::C",
       "staticSize":48,
       "dynamicSize":12,
       "members":[

--- a/test/integration/inheritance_polymorphic_diamond.toml
+++ b/test/integration/inheritance_polymorphic_diamond.toml
@@ -36,7 +36,7 @@ definitions = '''
     arg_types = ["Root"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName":"Root",
+      "typeName":"ns_inheritance_polymorphic_diamond::Root",
       "staticSize":16,
       "dynamicSize":0,
       "members":[
@@ -55,7 +55,7 @@ definitions = '''
       return m;
     '''
     expect_json = '''[{
-      "typeName":"Middle1",
+      "typeName":"ns_inheritance_polymorphic_diamond::Middle1",
       "staticSize":40,
       "dynamicSize":12,
       "members":[
@@ -67,14 +67,14 @@ definitions = '''
     oil_skip = "Polymorphic inheritance disabled in OIL"
     cli_options = ["-fpolymorphic-inheritance"]
     param_types = ["const Middle1&"]
-    arg_types = ["Middle1"]
+    arg_types = ["ns_inheritance_polymorphic_diamond::Middle1"]
     setup = '''
       Middle1 m;
       m.vec_middle1 = {1,2,3};
       return m;
     '''
     expect_json = '''[{
-      "typeName":"Middle1",
+      "typeName":"ns_inheritance_polymorphic_diamond::Middle1",
       "staticSize":40,
       "dynamicSize":12,
       "members":[
@@ -94,7 +94,7 @@ definitions = '''
       return m;
     '''
     expect_json = '''[{
-      "typeName":"Middle2",
+      "typeName":"ns_inheritance_polymorphic_diamond::Middle2",
       "staticSize":40,
       "dynamicSize":8,
       "members":[
@@ -113,7 +113,7 @@ definitions = '''
       return m;
     '''
     expect_json = '''[{
-      "typeName":"Middle2",
+      "typeName":"ns_inheritance_polymorphic_diamond::Middle2",
       "staticSize":40,
       "dynamicSize":8,
       "members":[
@@ -136,7 +136,7 @@ definitions = '''
       return static_cast<Middle1&>(*c);
     '''
     expect_json = '''[{
-      "typeName":"Child",
+      "typeName":"ns_inheritance_polymorphic_diamond::Child",
       "staticSize":88,
       "dynamicSize":20,
       "members":[
@@ -162,7 +162,7 @@ definitions = '''
       return static_cast<Middle2&>(*c);
     '''
     expect_json = '''[{
-      "typeName":"Child",
+      "typeName":"ns_inheritance_polymorphic_diamond::Child",
       "staticSize":88,
       "dynamicSize":20,
       "members":[
@@ -186,7 +186,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"Child",
+      "typeName":"ns_inheritance_polymorphic_diamond::Child",
       "staticSize":88,
       "dynamicSize":20,
       "members":[
@@ -210,7 +210,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"Child",
+      "typeName":"ns_inheritance_polymorphic_diamond::Child",
       "staticSize":88,
       "dynamicSize":20,
       "members":[
@@ -234,7 +234,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"Child",
+      "typeName":"ns_inheritance_polymorphic_diamond::Child",
       "staticSize":88,
       "dynamicSize":20,
       "members":[

--- a/test/integration/inheritance_polymorphic_non_dynamic_base.toml
+++ b/test/integration/inheritance_polymorphic_non_dynamic_base.toml
@@ -27,7 +27,7 @@ definitions = '''
     arg_types = ["A"]
     setup = "return {};"
     expect_json = '''[{
-      "typeName":"A",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::A",
       "staticSize":4,
       "dynamicSize":0,
       "members":[
@@ -38,7 +38,7 @@ definitions = '''
     arg_types = ["A"]
     setup = 'return {};'
     expect_json = '''[{
-      "typeName":"A",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::A",
       "staticSize":4,
       "dynamicSize":0,
       "members":[
@@ -63,7 +63,7 @@ definitions = '''
       return b;
     '''
     expect_json = '''[{
-      "typeName":"A",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::A",
       "staticSize":4,
       "dynamicSize":0,
       "members":[
@@ -80,7 +80,7 @@ definitions = '''
       return b;
     '''
     expect_json = '''[{
-      "typeName":"B",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::B",
       "staticSize":40,
       "dynamicSize":12,
       "members":[
@@ -98,7 +98,7 @@ definitions = '''
       return b;
     '''
     expect_json = '''[{
-      "typeName":"B",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::B",
       "staticSize":40,
       "dynamicSize":12,
       "members":[
@@ -118,7 +118,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"A",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::A",
       "staticSize":4,
       "dynamicSize":0,
       "members":[
@@ -135,7 +135,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"C",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::C",
       "staticSize":48,
       "dynamicSize":12,
       "members":[
@@ -155,7 +155,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"C",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::C",
       "staticSize":48,
       "dynamicSize":12,
       "members":[
@@ -174,7 +174,7 @@ definitions = '''
       return c;
     '''
     expect_json = '''[{
-      "typeName":"C",
+      "typeName":"ns_inheritance_polymorphic_non_dynamic_base::C",
       "staticSize":48,
       "dynamicSize":12,
       "members":[
@@ -184,7 +184,7 @@ definitions = '''
         {"name":"int_c", "staticSize":4, "dynamicSize":0}
       ]}]'''
     expect_json_v2 = '''[{
-      "typeNames": ["C"],
+      "typeNames": ["ns_inheritance_polymorphic_non_dynamic_base::C"],
       "staticSize": 48,
       "exclusiveSize": 8,
       "members": [

--- a/test/integration/thrift_unions.toml
+++ b/test/integration/thrift_unions.toml
@@ -31,7 +31,7 @@ namespace cpp2 {
       "staticSize":8,
       "dynamicSize":0,
       "members":[
-        {"typeName":"storage_type", "name":"value_", "staticSize":4},
+        {"typeName":"cpp2::StaticUnion::storage_type", "name":"value_", "staticSize":4},
         {"typeName":"underlying_type_t<cpp2::StaticUnion::Type>", "name":"type_", "staticSize":4}
       ]}]'''
     expect_json_v2 = '''[{
@@ -39,7 +39,7 @@ namespace cpp2 {
       "exclusiveSize":0,
       "size":8,
       "members":[
-        {"typeNames":["storage_type"], "name":"value_", "staticSize":4, "exclusiveSize":4, "size":4},
+        {"typeNames":["cpp2::StaticUnion::storage_type"], "name":"value_", "staticSize":4, "exclusiveSize":4, "size":4},
         {"typeNames":["underlying_type_t<cpp2::StaticUnion::Type>", "type", "int32_t"], "name":"type_", "staticSize":4, "exclusiveSize":4, "size":4}
       ]}]'''
   [cases.dynamic_int]
@@ -53,7 +53,7 @@ namespace cpp2 {
       "staticSize":32,
       "dynamicSize":0,
       "members":[
-        {"typeName":"storage_type", "name":"value_", "staticSize":24},
+        {"typeName":"cpp2::DynamicUnion::storage_type", "name":"value_", "staticSize":24},
         {"typeName":"underlying_type_t<cpp2::DynamicUnion::Type>", "name":"type_", "staticSize":4}
       ]}]'''
     expect_json_v2 = '''[{
@@ -61,7 +61,7 @@ namespace cpp2 {
       "exclusiveSize":4,
       "size":32,
       "members":[
-        {"typeNames":["storage_type"], "name":"value_", "staticSize":24, "exclusiveSize":24, "size":24},
+        {"typeNames":["cpp2::DynamicUnion::storage_type"], "name":"value_", "staticSize":24, "exclusiveSize":24, "size":24},
         {"typeNames":["underlying_type_t<cpp2::DynamicUnion::Type>", "type", "int32_t"], "name":"type_", "staticSize":4, "exclusiveSize":4, "size":4}
       ]}]'''
   [cases.dynamic_vec]
@@ -75,7 +75,7 @@ namespace cpp2 {
       "staticSize":32,
       "dynamicSize":0,
       "members":[
-        {"typeName":"storage_type", "name":"value_", "staticSize":24},
+        {"typeName":"cpp2::DynamicUnion::storage_type", "name":"value_", "staticSize":24},
         {"typeName":"underlying_type_t<cpp2::DynamicUnion::Type>", "name":"type_", "staticSize":4}
       ]}]'''
     expect_json_v2 = '''[{
@@ -83,6 +83,6 @@ namespace cpp2 {
       "exclusiveSize":4,
       "size":32,
       "members":[
-        {"typeNames":["storage_type"], "name":"value_", "staticSize":24, "exclusiveSize":24, "size":24},
+        {"typeNames":["cpp2::DynamicUnion::storage_type"], "name":"value_", "staticSize":24, "exclusiveSize":24, "size":24},
         {"typeNames":["underlying_type_t<cpp2::DynamicUnion::Type>", "type", "int32_t"], "name":"type_", "staticSize":4, "exclusiveSize":4, "size":4}
       ]}]'''


### PR DESCRIPTION
## Summary
Some integration tests have not been updated since drgn started reporting type names with all their namespaces, and were failing.

## Test plan
Running the tests now report 15 failure, instead of 32 previously. The polymorphic tests are still failing due to TypeGraph not supporting them yet.
