### PR TITLE
tbv2: correctly account for list overhead

### DIFF
--- a/test/integration/std_list.toml
+++ b/test/integration/std_list.toml
@@ -18,7 +18,7 @@ definitions = '''
     param_types = ["const std::list<int>&"]
     setup = "return {{1,2,3}};"
     expect_json = '[{"staticSize":24, "dynamicSize":12, "length":3, "capacity":3, "elementStaticSize":4}]'
-    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "size":36, "length":3, "capacity":3, "members":[
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":84, "size":96, "length":3, "capacity":3, "members":[
       {"staticSize":4, "exclusiveSize":4, "size":4},
       {"staticSize":4, "exclusiveSize":4, "size":4},
       {"staticSize":4, "exclusiveSize":4, "size":4}
@@ -27,7 +27,7 @@ definitions = '''
     param_types = ["const std::list<SimpleStruct>&"]
     setup = "return {{{}, {}, {}}};"
     expect_json = '[{"staticSize":24, "dynamicSize":48, "length":3, "capacity":3, "elementStaticSize":16}]'
-    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "size":72, "length":3, "capacity":3, "members":[
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":72, "size":120, "length":3, "capacity":3, "members":[
       {"staticSize":16, "exclusiveSize":3, "size":16},
       {"staticSize":16, "exclusiveSize":3, "size":16},
       {"staticSize":16, "exclusiveSize":3, "size":16}
@@ -52,8 +52,8 @@ definitions = '''
         {"staticSize":24, "dynamicSize":4, "exclusiveSize":28, "length":1, "capacity":1, "elementStaticSize":4},
         {"staticSize":24, "dynamicSize":8, "exclusiveSize":32, "length":2, "capacity":2, "elementStaticSize":4}
       ]}]'''
-    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":24, "size":120, "length":3, "capacity": 3, "members":[
-      {"staticSize":24, "exclusiveSize":24, "size":36, "length":3, "capacity": 3},
-      {"staticSize":24, "exclusiveSize":24, "size":28, "length":1, "capacity": 1},
-      {"staticSize":24, "exclusiveSize":24, "size":32, "length":2, "capacity": 2}
+    expect_json_v2 = '''[{"staticSize":24, "exclusiveSize":72, "size":288, "length":3, "capacity": 3, "members":[
+      {"staticSize":24, "exclusiveSize":84, "size":96, "length":3, "capacity": 3},
+      {"staticSize":24, "exclusiveSize":44, "size":48, "length":1, "capacity": 1},
+      {"staticSize":24, "exclusiveSize":64, "size":72, "length":2, "capacity": 2}
     ]}]'''

--- a/test/integration/std_list_del_allocator.toml
+++ b/test/integration/std_list_del_allocator.toml
@@ -60,8 +60,8 @@ includes = ["list"]
     expect_json_v2 = '''[{
       "staticSize": 48,
       "exclusiveSize": 0,
-      "size": 60,
+      "size": 120,
       "members": [
-        {"name": "v1", "staticSize": 24, "exclusiveSize": 24, "size": 28, "length": 1, "capacity": 1},
-        {"name": "v2", "staticSize": 24, "exclusiveSize": 24, "size": 32, "length": 2, "capacity": 2}
+        {"name": "v1", "staticSize": 24, "exclusiveSize": 44, "size": 48, "length": 1, "capacity": 1},
+        {"name": "v2", "staticSize": 24, "exclusiveSize": 64, "size": 72, "length": 2, "capacity": 2}
       ]}]'''

--- a/types/cxx11_list_type.toml
+++ b/types/cxx11_list_type.toml
@@ -61,17 +61,6 @@ static constexpr size_t element_size = sizeof(std::_List_node<T0>);
 static_assert(false && "No known element_size for list. See types/cxx11_list_type.toml");
 #endif
 
-static constexpr std::array<inst::Field, 1> child_field{
-  make_field<Ctx, T0>("*"),
-};
-static constexpr inst::Field element{
-  element_size,
-  element_size - sizeof(T0),
-  "[]",
-  std::array<std::string_view, 0>{},
-  child_field,
-  std::array<inst::ProcessorInst, 0>{},
-};
 static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
@@ -79,7 +68,7 @@ el.container_stats.emplace(result::Element::ContainerStats{
   .capacity = list.length,
   .length = list.length,
 });
-el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(T0);
+el.exclusive_size += el.container_stats->length * (element_size - sizeof(T0));
 
 stack_ins(inst::Repeat{ list.length, childField });
 """

--- a/types/list_type.toml
+++ b/types/list_type.toml
@@ -61,17 +61,6 @@ static constexpr size_t element_size = sizeof(std::_List_node<T0>);
 static_assert(false && "No known element_size for list. See types/cxx11_list_type.toml");
 #endif
 
-static constexpr std::array<inst::Field, 1> child_field{
-  make_field<Ctx, T0>("*"),
-};
-static constexpr inst::Field element{
-  element_size,
-  element_size - sizeof(T0),
-  "[]",
-  std::array<std::string_view, 0>{},
-  child_field,
-  std::array<inst::ProcessorInst, 0>{},
-};
 static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 auto list = std::get<ParsedData::List>(d.val);
@@ -79,7 +68,7 @@ el.container_stats.emplace(result::Element::ContainerStats{
   .capacity = list.length,
   .length = list.length,
 });
-el.exclusive_size += (el.container_stats->capacity - el.container_stats->length) * sizeof(T0);
+el.exclusive_size += el.container_stats->length * (element_size - sizeof(T0));
 
 stack_ins(inst::Repeat{ list.length, childField });
 """


### PR DESCRIPTION
tbv2: correctly account for list overhead

`std::list` has per element overhead for the individual heap allocations. This
was already calculated in the container implementation but not used. Allocate
the overhead of each element in the `std::list` to the `std::list` itself as
with other sequential containers.

Test Plan:
- CI
- Updated test cases

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/455).
* #452
* #456
* __->__ #455