### PR TITLE
tbv2: name array member types correctly

### DIFF
--- a/oi/FuncGen.cpp
+++ b/oi/FuncGen.cpp
@@ -742,14 +742,7 @@ return tail.finish();
   oiArray.codegen.processors.emplace_back(ContainerInfo::Processor{
       .type = "types::st::List<DB, typename TypeHandler<Ctx, T0>::type>",
       .func = R"(
-static constexpr std::array<std::string_view, 1> names{"TODO"};
-static constexpr auto childField = inst::Field{
-  sizeof(T0),
-  "[]",
-  names,
-  TypeHandler<Ctx, T0>::fields,
-  TypeHandler<Ctx, T0>::processors,
-};
+static constexpr auto childField = make_field<Ctx, T0>("[]");
 
 el.exclusive_size = 0;
 el.container_stats.emplace(result::Element::ContainerStats{ .capacity = N0, .length = N0 });

--- a/oi/type_graph/TopoSorter.cpp
+++ b/oi/type_graph/TopoSorter.cpp
@@ -143,6 +143,11 @@ void TopoSorter::visit(Incomplete& i) {
   sortedTypes_.push_back(i);
 }
 
+void TopoSorter::visit(Array& a) {
+  RecursiveVisitor::visit(a);
+  sortedTypes_.push_back(a);
+}
+
 /*
  * A type graph may contain cycles, so we need to slightly tweak the standard
  * topological sorting algorithm. Cycles can only be introduced by certain

--- a/oi/type_graph/TopoSorter.h
+++ b/oi/type_graph/TopoSorter.h
@@ -49,6 +49,7 @@ class TopoSorter : public RecursiveVisitor {
   void visit(Primitive& p) override;
   void visit(CaptureKeys& p) override;
   void visit(Incomplete& i) override;
+  void visit(Array& i) override;
 
  private:
   std::unordered_set<Type*> visited_;

--- a/test/integration/arrays.toml
+++ b/test/integration/arrays.toml
@@ -88,8 +88,8 @@ definitions = '''
     expect_json_v2 = '''[
       {"staticSize":24, "exclusiveSize":0, "size":24, "members":[
         {"staticSize":24, "exclusiveSize":0, "size":24, "length":2, "capacity":2, "members":[
-          {"staticSize":12, "exclusiveSize":0, "size":12, "length":3, "capacity":3},
-          {"staticSize":12, "exclusiveSize":0, "size":12, "length":3, "capacity":3}]
+          {"typeNames":["int32_t[3]"], "staticSize":12, "exclusiveSize":0, "size":12, "length":3, "capacity":3},
+          {"typeNames":["int32_t[3]"], "staticSize":12, "exclusiveSize":0, "size":12, "length":3, "capacity":3}]
       }]}]'''
   [cases.direct_int10]
     skip = "Direct array arguments don't work"

--- a/test/test_topo_sorter.cpp
+++ b/test/test_topo_sorter.cpp
@@ -211,7 +211,10 @@ TEST(TopoSorterTest, Arrays) {
   auto myclass = Class{0, Class::Kind::Class, "MyClass", 69};
   auto myarray = Array{1, myclass, 10};
 
-  test({myarray}, "MyClass\n");
+  test({myarray}, R"(
+MyClass
+OIArray<MyClass, 10>
+)");
 }
 
 TEST(TopoSorterTest, Typedef) {


### PR DESCRIPTION
tbv2: name array member types correctly

Array members are currently being named "TODO" (whoops). Include arrays in
TopoSorter so each one can have a `NameProvider` generated in CodeGen. Then
pass array elements through `make_field`.

Test plan:
- CI
- Add array member names to an array test.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/456).
* #452
* __->__ #456