### PR TITLE
test: add features field to integration tests

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -201,13 +201,23 @@ definitions = '''
 
     Implies `oil_disable`.
 
+  - `features`
+
+    Append this list of features to the configuration. This works for all types
+    of test.
+
+    Example:
+    ```
+    features = ["chase-raw-pointers"]
+    ```
+
   - `cli_options`
 
     Additional command line arguments passed to oid.
 
     Example:
     ```
-    cli_options = ["-fchase-raw-pointers"]
+    cli_options = ["-Ftype-graph"]
     ```
 
   - `skip`, `oid_skip`, `oil_skip`

--- a/test/integration/anonymous.toml
+++ b/test/integration/anonymous.toml
@@ -84,7 +84,7 @@ definitions = '''
   [cases.regular_struct]
     param_types = ["const Node&"]
     setup = "return Node{1, 2, 3};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize":12,
       "dynamicSize":0,
@@ -97,7 +97,7 @@ definitions = '''
       ]}]'''
 
   [cases.anon_struct]
-    oil_disable = "oil can't chase raw pointers safely"
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const AnonStructContainer&"]
     setup = '''
       return AnonStructContainer{
@@ -106,7 +106,7 @@ definitions = '''
         }
       };
     '''
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 8,
       "dynamicSize": 12,
@@ -143,10 +143,10 @@ definitions = '''
           new Node{1, 2, 3}
         }
       };'''
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
 
   [cases.anon_typedef]
-    oil_disable = "oil can't chase raw pointers safely"
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const AnonTypedefContainer&"]
     setup = '''
       return AnonTypedefContainer{
@@ -154,7 +154,7 @@ definitions = '''
           .node = new Node{1, 2, 3}
         }
       };'''
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 8,
       "dynamicSize": 12,
@@ -196,7 +196,6 @@ definitions = '''
   [cases.anon_union]
     param_types = ["const AnonUnionContainer&"]
     setup = 'return AnonUnionContainer{ .a = 3 };'
-    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 24,
       "dynamicSize": 0,
@@ -218,10 +217,10 @@ definitions = '''
     }]'''
 
   [cases.nested_anon_struct]
-    oil_disable = "oil can't chase raw pointers safely"
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const NestedAnonContainer&"]
+    features = ["chase-raw-pointers"]
     setup = 'return NestedAnonContainer{.m = { .v = {.as = {new Node{1, 2, 3}}}}};'
-    cli_options = ["-fchase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 80,
       "dynamicSize": 12,
@@ -290,7 +289,7 @@ definitions = '''
   #     result.ns[3].nodes.resize(22);
   #     return result;
   #   '''
-  #   cli_options = ["-fchase-raw-pointers"]
+  #   features = ["chase-raw-pointers"]
   #   expect_json = '''[{
   #     "staticSize": 104,
   #     "dynamicSize": 556,

--- a/test/integration/arrays.toml
+++ b/test/integration/arrays.toml
@@ -76,7 +76,7 @@ definitions = '''
         "elementStaticSize":4
       }]}]'''
   [cases.multidim]
-    cli_options = ["-ftype-graph"]
+    
     param_types = ["const MultiDim&"]
     setup = "return {};"
     expect_json = '''[

--- a/test/integration/bitfields.toml
+++ b/test/integration/bitfields.toml
@@ -53,7 +53,7 @@ definitions = '''
 # if they were regular primitives.
 [cases]
   [cases.single]
-    cli_options = ["-ftype-graph"]
+    
     oil_skip = "not implemented"
     param_types = ["Single&"]
     setup = "return {};"
@@ -62,7 +62,7 @@ definitions = '''
         {"staticSize":4, "dynamicSize":0, "exclusiveSize":4}
     ]}]'''
   [cases.within_bytes]
-    cli_options = ["-ftype-graph"]
+    
     oil_skip = "not implemented"
     param_types = ["WithinBytes&"]
     setup = "return {};"
@@ -73,7 +73,7 @@ definitions = '''
         {"staticSize":1, "dynamicSize":0, "exclusiveSize":1}
     ]}]'''
   [cases.straddle_bytes]
-    cli_options = ["-ftype-graph"]
+    
     oil_skip = "not implemented"
     param_types = ["StraddleBytes&"]
     setup = "return {};"
@@ -84,7 +84,7 @@ definitions = '''
         {"staticSize":1, "dynamicSize":0, "exclusiveSize":1}
     ]}]'''
   [cases.mixed]
-    cli_options = ["-ftype-graph"]
+    
     oil_skip = "not implemented"
     param_types = ["Mixed&"]
     setup = "return {};"
@@ -98,13 +98,13 @@ definitions = '''
     ]}]'''
   [cases.more_bits_than_type] # TODO member sizes are wrong
     skip = "drgn errors out"
-    cli_options = ["-ftype-graph"]
+    
     oil_skip = "not implemented"
     param_types = ["MoreBitsThanType&"]
     setup = "return {};"
     expect_json = '"TODO"'
   [cases.zero_bits]
-    cli_options = ["-ftype-graph"]
+    
     oil_skip = "not implemented"
     param_types = ["ZeroBits&"]
     setup = "return {};"
@@ -114,7 +114,7 @@ definitions = '''
         {"staticSize":1, "dynamicSize":0, "exclusiveSize":1}
     ]}]'''
   [cases.enum]
-    cli_options = ["-ftype-graph"]
+    
     oil_skip = "not implemented"
     param_types = ["Enum&"]
     setup = "return {};"

--- a/test/integration/cycles.toml
+++ b/test/integration/cycles.toml
@@ -23,7 +23,7 @@ definitions = '''
 '''
 [cases]
   [cases.raw_ptr]
-    oil_disable = "oil can't chase pointers safely"
+    oil_skip = "cycles are broken" # https://github.com/facebookexperimental/object-introspection/issues/293
     param_types = ["RawNode*"]
     setup = '''
       RawNode *first  = new RawNode{1, nullptr};
@@ -34,7 +34,7 @@ definitions = '''
       third->next = first;
       return first;
     '''
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''
     [
       {
@@ -96,7 +96,7 @@ definitions = '''
     '''
 
   [cases.raw_ptr_wrapped]
-    oil_disable = "oil can't chase pointers safely"
+    oil_skip = "cycles are broken" # https://github.com/facebookexperimental/object-introspection/issues/293
     param_types = ["Wrapper<RawNode*>&"]
     setup = '''
       RawNode *first  = new RawNode{1, nullptr};
@@ -107,7 +107,7 @@ definitions = '''
       third->next = first;
       return Wrapper<RawNode*>(first);
     '''
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 8,
       "dynamicSize": 48,

--- a/test/integration/gen_tests.py
+++ b/test/integration/gen_tests.py
@@ -268,6 +268,19 @@ def add_tests(f, config):
         add_oil_integration_test(f, config, case_name, case)
 
 
+def get_config_strings(case):
+    config_prefix = case.get("config_prefix", "")
+    if "features" in case:
+        feature_config = "features = ["
+        for f in case.get("features", []):
+            feature_config += '"' + f + '"'
+        feature_config += "]\n"
+        config_prefix = feature_config + config_prefix
+    config_suffix = case.get("config_suffix", "")
+
+    return (config_prefix, config_suffix)
+
+
 def add_oid_integration_test(f, config, case_name, case):
     probe_type = case.get("type", "entry")
     args = case.get("args", "arg0")
@@ -283,8 +296,7 @@ def add_oid_integration_test(f, config, case_name, case):
         "{" + ", ".join(f'"{option}"' for option in case.get("cli_options", ())) + "}"
     )
 
-    config_prefix = case.get("config_prefix", "")
-    config_suffix = case.get("config_suffix", "")
+    config_prefix, config_suffix = get_config_strings(case)
 
     f.write(
         f"\n"
@@ -356,8 +368,7 @@ def add_oil_integration_test(f, config, case_name, case):
     if "oil_disable" in case or "target_function" in case:
         return
 
-    config_prefix = case.get("config_prefix", "")
-    config_suffix = case.get("config_suffix", "")
+    config_prefix, config_suffix = get_config_strings(case)
 
     f.write(
         f"\n"

--- a/test/integration/inheritance_polymorphic.toml
+++ b/test/integration/inheritance_polymorphic.toml
@@ -24,7 +24,7 @@ definitions = '''
 [cases]
   [cases.a_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["A"]
     setup = "return {};"
@@ -39,7 +39,7 @@ definitions = '''
 
   [cases.b_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["B"]
     setup = '''
@@ -58,7 +58,7 @@ definitions = '''
       ]}]'''
   [cases.b_as_b]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const B&"]
     arg_types = ["B"]
     setup = '''
@@ -78,7 +78,7 @@ definitions = '''
 
   [cases.c_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["C"]
     setup = '''
@@ -98,7 +98,7 @@ definitions = '''
       ]}]'''
   [cases.c_as_b]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const B&"]
     arg_types = ["C"]
     setup = '''
@@ -118,7 +118,7 @@ definitions = '''
       ]}]'''
   [cases.c_as_c]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const C&"]
     arg_types = ["C"]
     setup = '''

--- a/test/integration/inheritance_polymorphic_diamond.toml
+++ b/test/integration/inheritance_polymorphic_diamond.toml
@@ -31,7 +31,7 @@ definitions = '''
 [cases]
   [cases.root_as_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const Root&"]
     arg_types = ["Root"]
     setup = "return {};"
@@ -46,7 +46,7 @@ definitions = '''
 
   [cases.middle1_as_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const Root&"]
     arg_types = ["Middle1"]
     setup = '''
@@ -65,7 +65,7 @@ definitions = '''
       ]}]'''
   [cases.middle1_as_middle1]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const Middle1&"]
     arg_types = ["ns_inheritance_polymorphic_diamond::Middle1"]
     setup = '''
@@ -85,7 +85,7 @@ definitions = '''
 
   [cases.middle2_as_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const Root&"]
     arg_types = ["Middle2"]
     setup = '''
@@ -104,7 +104,7 @@ definitions = '''
       ]}]'''
   [cases.middle2_as_middle2]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const Middle2&"]
     arg_types = ["Middle2"]
     setup = '''
@@ -124,7 +124,7 @@ definitions = '''
 
   [cases.child_as_middle1_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     # We need to explicitly cast from Child to Middle1 before going to root to
     # resolve the diamond problem
     param_types = ["const Root&"]
@@ -150,7 +150,7 @@ definitions = '''
       ]}]'''
   [cases.child_as_middle2_root]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     # We need to explicitly cast from Child to Middle2 before going to root to
     # resolve the diamond problem
     param_types = ["const Root&"]
@@ -176,7 +176,7 @@ definitions = '''
       ]}]'''
   [cases.child_as_middle1]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const Middle1&"]
     arg_types = ["Child"]
     setup = '''
@@ -200,7 +200,7 @@ definitions = '''
       ]}]'''
   [cases.child_as_middle2]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const Middle2&"]
     arg_types = ["Child"]
     setup = '''
@@ -224,7 +224,7 @@ definitions = '''
       ]}]'''
   [cases.child_as_child]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const Child&"]
     arg_types = ["Child"]
     setup = '''

--- a/test/integration/inheritance_polymorphic_non_dynamic_base.toml
+++ b/test/integration/inheritance_polymorphic_non_dynamic_base.toml
@@ -22,7 +22,7 @@ definitions = '''
 [cases]
   [cases.a_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["A"]
     setup = "return {};"
@@ -54,7 +54,7 @@ definitions = '''
 
   [cases.b_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["B"]
     setup = '''
@@ -71,7 +71,7 @@ definitions = '''
       ]}]'''
   [cases.b_as_b]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const B&"]
     arg_types = ["B"]
     setup = '''
@@ -109,7 +109,7 @@ definitions = '''
 
   [cases.c_as_a]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const A&"]
     arg_types = ["C"]
     setup = '''
@@ -126,7 +126,7 @@ definitions = '''
       ]}]'''
   [cases.c_as_b]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const B&"]
     arg_types = ["C"]
     setup = '''
@@ -146,7 +146,7 @@ definitions = '''
       ]}]'''
   [cases.c_as_c]
     oil_skip = "Polymorphic inheritance disabled in OIL"
-    cli_options = ["-fpolymorphic-inheritance"]
+    features = ["polymorphic-inheritance"]
     param_types = ["const C&"]
     arg_types = ["C"]
     setup = '''

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -17,7 +17,7 @@ definitions = '''
     skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["int*"]
     setup = "return new int(1);"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "typeName": "int *",
       "staticSize": 8,
@@ -59,7 +59,7 @@ definitions = '''
     skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["void*"]
     setup = "return new int(1);"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "typeName": "void *",
       "staticSize": 8,
@@ -95,7 +95,7 @@ definitions = '''
     skip = "top-level pointers are skipped over" # https://github.com/facebookexperimental/object-introspection/issues/19
     param_types = ["std::vector<int>*"]
     setup = "return new std::vector<int>{1,2,3};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "typeName": "std::vector<int> *",
       "staticSize": 8,
@@ -134,10 +134,10 @@ definitions = '''
 
 
   [cases.struct_primitive_ptrs]
-    oil_disable = "oil can't chase raw pointers safely"
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const PrimitivePtrs&"]
     setup = "return PrimitivePtrs{0, new int(0), new int(0)};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":4,
@@ -161,9 +161,10 @@ definitions = '''
         {"name":"c", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8}
       ]}]'''
   [cases.struct_primitive_ptrs_null]
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const PrimitivePtrs&"]
     setup = "return PrimitivePtrs{0, nullptr, nullptr};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":0,
@@ -177,10 +178,10 @@ definitions = '''
 
 
   [cases.struct_vector_ptr]
-    oil_disable = "oil can't chase raw pointers safely"
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const VectorPtr&"]
     setup = "return VectorPtr{new std::vector<int>{1,2,3}};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize":8,
       "dynamicSize":36,
@@ -199,9 +200,10 @@ definitions = '''
         {"name":"vec", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8}
       ]}]'''
   [cases.struct_vector_ptr_null]
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const VectorPtr&"]
     setup = "return VectorPtr{nullptr};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize":8,
       "dynamicSize":0,
@@ -213,10 +215,10 @@ definitions = '''
 
 
   [cases.vector_of_pointers]
-    oil_disable = "oil can't chase raw pointers safely"
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const std::vector<int*>&"]
     setup = "return {{new int(1), nullptr, new int(3)}};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize":24,
       "dynamicSize":32,
@@ -258,7 +260,7 @@ definitions = '''
         {"name":"c", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8}
       ]}]'''
   [cases.feature_config]
-    oil_disable = "oil can't chase raw pointers safely"
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const std::vector<int*>&"]
     setup = "return {{new int(1), nullptr, new int(3)}};"
     config_prefix = 'features = ["chase-raw-pointers"]'

--- a/test/integration/pointers_function.toml
+++ b/test/integration/pointers_function.toml
@@ -29,11 +29,10 @@ definitions = '''
       }]
     }]'''
   [cases.raw_chase] # We should never chase function pointers
-    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
-    oil_disable = "oil can't chase raw pointers safely"
+    skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["const FuncPtrStruct&"]
     setup = "return {{myFunction}};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 8,
       "dynamicSize": 0,
@@ -73,11 +72,10 @@ definitions = '''
       "NOT": "members"
     }]'''
   [cases.std_function_chase] # We should never chase function pointers
-    oid_skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
-    oil_disable = "oil can't chase raw pointers safely"
+    skip = "function pointers are not handled correctly" # https://github.com/facebookexperimental/object-introspection/issues/22
     param_types = ["std::function<void(int)> &"]
     setup = "return myFunction;"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "typeName": "function<void (int)>",
       "staticSize": 32,

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -19,38 +19,37 @@ definitions = '''
 '''
 [cases]
   [cases.raw]
-    oil_disable = "oil can't chase raw pointers safely"
     oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    oil_skip = "oil codegen fails on top level incomplete objects" # https://github.com/facebookexperimental/object-introspection/issues/459
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
-      "typeName": "IncompleteType *",
-      "staticSize": 8,
+      "typeName": "IncompleteType",
+      "staticSize": 0,
       "dynamicSize": 0,
-      "NOT": {"pointer": 0},
       "NOT": "members"
     }]'''
   [cases.raw_no_follow]
-    skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    oil_skip = "oil codegen fails on top level incomplete objects" # https://github.com/facebookexperimental/object-introspection/issues/459
     param_types = ["IncompleteType*"]
     setup = "return static_cast<IncompleteType*>(::operator new(5));"
     expect_json = '''[{
-      "typeName": "IncompleteType *",
-      "staticSize": 8,
+      "typeName": "IncompleteType",
+      "staticSize": 0,
       "dynamicSize": 0,
-      "NOT": {"pointer": 0},
       "NOT": "members"
     }]'''
   [cases.raw_null]
-    skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    oid_skip = "oid codegen fails on this" # https://github.com/facebookexperimental/object-introspection/issues/17
+    oil_skip = "oil codegen fails on top level incomplete objects" # https://github.com/facebookexperimental/object-introspection/issues/459
     param_types = ["IncompleteType*"]
     setup = "return nullptr;"
     expect_json = '''[{
-      "typeName": "IncompleteType *",
-      "staticSize": 8,
+      "typeName": "IncompleteType",
+      "staticSize": 0,
       "dynamicSize": 0,
-      "pointer": 0,
       "NOT": "members"
     }]'''
 
@@ -87,10 +86,10 @@ definitions = '''
     expect_json_v2 = '[{"staticSize":16, "exclusiveSize":16}]'
 
   [cases.containing_struct]
-    oil_disable = "oil can't chase raw pointers safely"
+    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const IncompleteTypeContainer&"]
     setup = "return IncompleteTypeContainer{};"
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     expect_json = '''[{
       "staticSize": 88,
       "dynamicSize": 0,

--- a/test/integration/std_smart_ptr.toml
+++ b/test/integration/std_smart_ptr.toml
@@ -373,7 +373,7 @@ definitions = '''
     expect_json_v2 = '''[{ "staticSize": 16, "exclusiveSize": 16, "size": 16, "members":[]}]'''
   [cases.weak_ptr_int64_present_chase]
     param_types = ["std::weak_ptr<std::uint64_t>&"]
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     setup = '''
     static std::shared_ptr<std::uint64_t> shd = std::make_shared<std::uint64_t>(0xDEADBEEF);
     std::weak_ptr<std::uint64_t> weak = shd;
@@ -392,7 +392,7 @@ definitions = '''
     expect_json_v2 = '''[{ "staticSize": 16, "exclusiveSize": 16, "size": 16, "members":[]}]'''
   [cases.weak_ptr_int64_expired_chase]
     param_types = ["std::weak_ptr<std::uint64_t>&"]
-    cli_options = ["-fchase-raw-pointers"]
+    features = ["chase-raw-pointers"]
     setup = '''
     return std::make_shared<std::uint64_t>(0xDEADBEEF);
     '''

--- a/test/integration/thrift_isset.toml
+++ b/test/integration/thrift_isset.toml
@@ -85,7 +85,7 @@ namespace cpp2 {
       ret.c_ref() = 1;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
@@ -109,7 +109,7 @@ namespace cpp2 {
       ret.j_ref() = 1;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":44,
       "dynamicSize":0,
@@ -136,7 +136,7 @@ namespace cpp2 {
       ret.c_ref() = 1;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":20,
       "dynamicSize":0,
@@ -156,7 +156,7 @@ namespace cpp2 {
       ret.b_ref() = 1;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
@@ -176,7 +176,7 @@ namespace cpp2 {
       ret.f_ref() = 1;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":28,
       "dynamicSize":0,
@@ -199,7 +199,7 @@ namespace cpp2 {
       ret.e_ref() = 1;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":32,
       "dynamicSize":0,

--- a/test/integration/thrift_isset_missing.toml
+++ b/test/integration/thrift_isset_missing.toml
@@ -68,7 +68,7 @@ raw_definitions = '''
       ret.__isset.at(2) = true;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
@@ -89,7 +89,7 @@ raw_definitions = '''
       ret.__isset.at(2) = true;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,
@@ -117,7 +117,7 @@ raw_definitions = '''
 
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":32,
       "dynamicSize":0,

--- a/test/integration/thrift_namespaces.toml
+++ b/test/integration/thrift_namespaces.toml
@@ -16,7 +16,7 @@ thrift_definitions = '''
       namespaceA::namespaceB::TTTTT ret;
       return ret;
     '''
-    cli_options = ["-fcapture-thrift-isset"]
+    features = ["capture-thrift-isset"]
     expect_json = '''[{
       "staticSize":16,
       "dynamicSize":0,


### PR DESCRIPTION
test: add features field to integration tests

Previously we tested different feature flags by using the `cli_options` field
in the test `.toml`. This works for OID but doesn't work for JIT OIL and won't
work for AoT OIL when those tests get added.

This change adds a new higher level `features` field to the test `.toml` which
adds the features to the config file as a prefix. This works with all methods
of generation.

Change the existing `cli_options` features to `features` except for where
they're testing something specific. Enable tests that were previously disabled
for OIL but only didn't work because of not being able to enable features.
Change pointer tests that are currently broken for OIL from `oil_disable` to
`oil_skip` - they can work, but codegen is broken for them at the minute.

Test plan:
- CI
- `make test` is no worse

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/460).
* #462
* __->__ #460