### PR TITLE
tbv2: fix pointer codegen

### DIFF
--- a/oi/FuncGen.h
+++ b/oi/FuncGen.h
@@ -76,7 +76,7 @@ class FuncGen {
 
   static void DefineDataSegmentDataBuffer(std::string& testCode);
   static void DefineBackInserterDataBuffer(std::string& code);
-  static void DefineBasicTypeHandlers(std::string& code, FeatureSet features);
+  static void DefineBasicTypeHandlers(std::string& code);
 
   static ContainerInfo GetOiArrayContainerInfo();
 };

--- a/oi/type_graph/TopoSorter.cpp
+++ b/oi/type_graph/TopoSorter.cpp
@@ -126,12 +126,27 @@ void TopoSorter::visit(Pointer& p) {
     // Typedefs can not be forward declared, so we must sort them before
     // pointers which reference them
     accept(p.pointeeType());
-    return;
+  } else {
+    // Pointers do not create a dependency, but we do still care about the types
+    // they point to, so delay them until the end.
+    acceptAfter(p.pointeeType());
   }
 
-  // Pointers do not create a dependency, but we do still care about the types
-  // they point to, so delay them until the end.
-  acceptAfter(p.pointeeType());
+  sortedTypes_.push_back(p);
+}
+
+void TopoSorter::visit(Reference& r) {
+  if (dynamic_cast<Typedef*>(&r.pointeeType())) {
+    // Typedefs can not be forward declared, so we must sort them before
+    // pointers which reference them
+    accept(r.pointeeType());
+  } else {
+    // Pointers do not create a dependency, but we do still care about the types
+    // they point to, so delay them until the end.
+    acceptAfter(r.pointeeType());
+  }
+
+  sortedTypes_.push_back(r);
 }
 
 void TopoSorter::visit(CaptureKeys& c) {

--- a/oi/type_graph/TopoSorter.h
+++ b/oi/type_graph/TopoSorter.h
@@ -46,6 +46,7 @@ class TopoSorter : public RecursiveVisitor {
   void visit(Enum& e) override;
   void visit(Typedef& td) override;
   void visit(Pointer& p) override;
+  void visit(Reference& r) override;
   void visit(Primitive& p) override;
   void visit(CaptureKeys& p) override;
   void visit(Incomplete& i) override;

--- a/test/integration/anonymous.toml
+++ b/test/integration/anonymous.toml
@@ -97,7 +97,6 @@ definitions = '''
       ]}]'''
 
   [cases.anon_struct]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const AnonStructContainer&"]
     setup = '''
       return AnonStructContainer{
@@ -133,6 +132,40 @@ definitions = '''
         }]
       }]
     }]'''
+    expect_json_v2 = '''[{
+      "name":"a0",
+      "typeNames":["ns_anonymous::AnonStructContainer"],
+      "staticSize":8,
+      "exclusiveSize":0,
+      "size":20,
+      "members":[{
+        "name":"anon",
+        "typeNames":["__oi_anon_1"],
+        "staticSize":8,
+        "exclusiveSize":0,
+        "size":20,
+        "members":[{
+          "name":"node",
+          "typeNames":["ns_anonymous::Node*"],
+          "staticSize":8,
+          "exclusiveSize":8,
+          "size":20,
+          "length":1,
+          "capacity":1,
+          "members":[{
+            "name":"*",
+            "typeNames":["ns_anonymous::Node"],
+            "staticSize":12,
+            "exclusiveSize":0,
+            "size":12,
+            "members":[
+              { "name": "a", "staticSize": 4, "exclusiveSize": 4, "size": 4 },
+              { "name": "b", "staticSize": 4, "exclusiveSize": 4, "size": 4 },
+              { "name": "c", "staticSize": 4, "exclusiveSize": 4, "size": 4 }
+            ]
+        }]
+      }]}
+    ]}]'''
 
   [cases.anon_struct_ptr]
     skip = "We don't support pointer to anon-structs yet" # https://github.com/facebookexperimental/object-introspection/issues/20
@@ -146,7 +179,6 @@ definitions = '''
     features = ["chase-raw-pointers"]
 
   [cases.anon_typedef]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const AnonTypedefContainer&"]
     setup = '''
       return AnonTypedefContainer{
@@ -192,6 +224,34 @@ definitions = '''
         }]
       }]
     }]'''
+    expect_json_v2 = '''[{
+      "staticSize": 8,
+      "exclusiveSize": 0,
+      "size": 20,
+      "members": [{
+        "typeNames":["AnonStruct", "__oi_anon_2"],
+        "staticSize": 8,
+        "exclusiveSize": 0,
+        "size": 20,
+        "members": [{
+          "typeNames": ["ns_anonymous::Node*"],
+          "staticSize": 8,
+          "exclusiveSize": 8,
+          "size": 20,
+          "members": [{
+            "typeNames": ["ns_anonymous::Node"],
+            "staticSize": 12,
+            "exclusiveSize": 0,
+            "size": 12,
+            "members": [
+              { "name": "a", "staticSize": 4, "exclusiveSize": 4, "size": 4 },
+              { "name": "b", "staticSize": 4, "exclusiveSize": 4, "size": 4 },
+              { "name": "c", "staticSize": 4, "exclusiveSize": 4, "size": 4 }
+            ]
+          }]
+        }]
+      }]
+    }]'''
 
   [cases.anon_union]
     param_types = ["const AnonUnionContainer&"]
@@ -217,7 +277,6 @@ definitions = '''
     }]'''
 
   [cases.nested_anon_struct]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const NestedAnonContainer&"]
     features = ["chase-raw-pointers"]
     setup = 'return NestedAnonContainer{.m = { .v = {.as = {new Node{1, 2, 3}}}}};'
@@ -271,6 +330,64 @@ definitions = '''
         "staticSize": 8,
         "dynamicSize": 0
       }]
+    }]'''
+    expect_json_v2 = '''[{
+      "staticSize":80,
+      "exclusiveSize":0,
+      "size":92,
+      "members":[
+        {
+          "name":"m",
+          "typeNames": ["__oi_anon_1"],
+          "staticSize": 48,
+          "exclusiveSize":0,
+          "size": 60,
+          "members":[
+            {"name":"__oi_anon_0", "typeNames":["__oi_anon_2"], "staticSize":16, "exclusiveSize":16, "size":16},
+            {
+              "name":"v",
+              "typeNames":["__oi_anon_3"],
+              "staticSize":32,
+              "exclusiveSize":4,
+              "size":44,
+              "members":[
+                {"name":"a", "typeNames":["int32_t"], "staticSize":4, "exclusiveSize":4, "size":4},
+                {"name":"b", "typeNames":["int32_t"], "staticSize":4, "exclusiveSize":4, "size":4},
+                {"name":"c", "typeNames":["int32_t"], "staticSize":4, "exclusiveSize":4, "size":4},
+                {"name":"__oi_anon_4", "typeNames":["__oi_anon_4"], "staticSize":8, "exclusiveSize":8, "size":8},
+                {
+                  "name":"as",
+                  "typeNames":["AnonStruct", "__oi_anon_6"],
+                  "staticSize":8,
+                  "exclusiveSize":0,
+                  "size":20,
+                  "members":[{
+                    "name":"node",
+                    "typeNames":["ns_anonymous::Node*"],
+                    "staticSize":8,
+                    "exclusiveSize":8,
+                    "size":20,
+                    "members":[{
+                      "name":"*",
+                      "typeNames":["ns_anonymous::Node"],
+                      "staticSize":12,
+                      "exclusiveSize":0,
+                      "size":12,
+                      "members":[
+                        { "name": "a", "staticSize": 4, "exclusiveSize": 4, "size": 4 },
+                        { "name": "b", "staticSize": 4, "exclusiveSize": 4, "size": 4 },
+                        { "name": "c", "staticSize": 4, "exclusiveSize": 4, "size": 4 }
+                      ]
+                    }]
+                  }]
+                }
+              ]
+            }
+          ]
+        },
+        {"name":"__oi_anon_1", "typeNames": ["__oi_anon_8"], "staticSize":24, "exclusiveSize":24, "size":24},
+        {"name":"__oi_anon_2", "typeNames": ["__oi_anon_9"], "staticSize":8, "exclusiveSize":8, "size":8}
+      ]
     }]'''
 
   # This test is disabled due to GCC not supporting it

--- a/test/integration/pointers.toml
+++ b/test/integration/pointers.toml
@@ -134,7 +134,6 @@ definitions = '''
 
 
   [cases.struct_primitive_ptrs]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const PrimitivePtrs&"]
     setup = "return PrimitivePtrs{0, new int(0), new int(0)};"
     features = ["chase-raw-pointers"]
@@ -147,6 +146,16 @@ definitions = '''
         {"name":"b", "staticSize":8, "exclusiveSize":8, "dynamicSize":4},
         {"name":"c", "staticSize":8, "exclusiveSize":8, "dynamicSize":0}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":24,
+      "exclusiveSize":4,
+      "size":28,
+      "members":[
+        {"name":"a", "typeNames":["int32_t"], "staticSize":4, "exclusiveSize":4, "size":4},
+        {"name":"b", "typeNames":["int32_t*"], "staticSize":8, "exclusiveSize":8, "size":12, "capacity":1, "length":1},
+        {"name":"c", "typeNames":["void*"], "staticSize":8, "exclusiveSize":8, "size":8, "capacity":1, "length":1}
+      ]
+    }]'''
   [cases.struct_primitive_ptrs_no_follow]
     param_types = ["const PrimitivePtrs&"]
     setup = "return PrimitivePtrs{0, new int(0), new int(0)};"
@@ -161,7 +170,6 @@ definitions = '''
         {"name":"c", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8}
       ]}]'''
   [cases.struct_primitive_ptrs_null]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const PrimitivePtrs&"]
     setup = "return PrimitivePtrs{0, nullptr, nullptr};"
     features = ["chase-raw-pointers"]
@@ -175,10 +183,19 @@ definitions = '''
         {"name":"b", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8},
         {"name":"c", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":24,
+      "exclusiveSize":4,
+      "size":24,
+      "members":[
+        {"name":"a", "typeNames":["int32_t"], "staticSize":4, "exclusiveSize":4, "size":4},
+        {"name":"b", "typeNames":["int32_t*"], "staticSize":8, "exclusiveSize":8, "size":8, "capacity":1, "length":0},
+        {"name":"c", "typeNames":["void*"], "staticSize":8, "exclusiveSize":8, "size":8, "capacity":1, "length":0}
+      ]
+    }]'''
 
 
   [cases.struct_vector_ptr]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const VectorPtr&"]
     setup = "return VectorPtr{new std::vector<int>{1,2,3}};"
     features = ["chase-raw-pointers"]
@@ -188,6 +205,22 @@ definitions = '''
       "members":[
         {"name":"vec", "staticSize":8, "dynamicSize":36}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":8,
+      "exclusiveSize":0,
+      "size":44,
+      "members": [
+        {
+          "typeNames":["std::vector<int32_t, std::allocator<int32_t>>*"],
+          "staticSize":8,
+          "exclusiveSize":8,
+          "size":44,
+          "length":1,
+          "capacity":1,
+          "members":[{ "staticSize":24, "exclusiveSize":24, "size":36 }]
+        }
+      ]
+    }]'''
   [cases.struct_vector_ptr_no_follow]
     param_types = ["const VectorPtr&"]
     setup = "return VectorPtr{new std::vector<int>{1,2,3}};"
@@ -200,7 +233,6 @@ definitions = '''
         {"name":"vec", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8}
       ]}]'''
   [cases.struct_vector_ptr_null]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const VectorPtr&"]
     setup = "return VectorPtr{nullptr};"
     features = ["chase-raw-pointers"]
@@ -212,10 +244,25 @@ definitions = '''
       "members":[
         {"name":"vec", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":8,
+      "exclusiveSize":0,
+      "size":8,
+      "members": [
+        {
+          "typeNames":["std::vector<int32_t, std::allocator<int32_t>>*"],
+          "staticSize":8,
+          "exclusiveSize":8,
+          "size":8,
+          "length":0,
+          "capacity":1,
+          "members":[]
+        }
+      ]
+    }]'''
 
 
   [cases.vector_of_pointers]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const std::vector<int*>&"]
     setup = "return {{new int(1), nullptr, new int(3)}};"
     features = ["chase-raw-pointers"]
@@ -230,6 +277,18 @@ definitions = '''
         {"staticSize":8, "dynamicSize":0, "pointer":0},
         {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":24,
+      "exclusiveSize":24,
+      "size":56,
+      "length":3,
+      "capacity":3,
+      "members":[
+        {"staticSize":8, "exclusiveSize":8, "size":12, "NOT": {"pointer":0}},
+        {"staticSize":8, "exclusiveSize":8, "size":8, "pointer":0},
+        {"staticSize":8, "exclusiveSize":8, "size":12, "NOT": {"pointer":0}}
+      ]
+    }]'''
   [cases.vector_of_pointers_no_follow]
     skip = "pointer field is missing from results" # https://github.com/facebookexperimental/object-introspection/issues/21
     param_types = ["const std::vector<int*>&"]
@@ -260,7 +319,6 @@ definitions = '''
         {"name":"c", "staticSize":8, "dynamicSize":0, "exclusiveSize":8, "size":8}
       ]}]'''
   [cases.feature_config]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const std::vector<int*>&"]
     setup = "return {{new int(1), nullptr, new int(3)}};"
     config_prefix = 'features = ["chase-raw-pointers"]'
@@ -275,3 +333,15 @@ definitions = '''
         {"staticSize":8, "dynamicSize":0, "pointer":0},
         {"staticSize":8, "dynamicSize":4, "NOT": {"pointer":0}}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":24,
+      "exclusiveSize":24,
+      "size":56,
+      "length":3,
+      "capacity":3,
+      "members":[
+        {"staticSize":8, "exclusiveSize":8, "size":12, "NOT": {"pointer":0}},
+        {"staticSize":8, "exclusiveSize":8, "size":8, "pointer":0},
+        {"staticSize":8, "exclusiveSize":8, "size":12, "NOT": {"pointer":0}}
+      ]
+    }]'''

--- a/test/integration/pointers_incomplete.toml
+++ b/test/integration/pointers_incomplete.toml
@@ -86,7 +86,6 @@ definitions = '''
     expect_json_v2 = '[{"staticSize":16, "exclusiveSize":16}]'
 
   [cases.containing_struct]
-    oil_skip = "pointers are broken in tbv2" # https://github.com/facebookexperimental/object-introspection/issues/458
     param_types = ["const IncompleteTypeContainer&"]
     setup = "return IncompleteTypeContainer{};"
     features = ["chase-raw-pointers"]
@@ -112,6 +111,32 @@ definitions = '''
           "length": 0,
           "capacity": 1,
           "elementStaticSize": 8
+        }
+      ]
+    }]'''
+    expect_json_v2 = '''[{
+      "staticSize": 88,
+      "exclusiveSize": 21,
+      "size": 88,
+      "members": [
+        { "name": "ptrundef", "staticSize": 8, "exclusiveSize": 8, "size": 8 },
+        { "name": "__makePad1", "staticSize": 1, "exclusiveSize": 1, "size": 1 },
+        { "name": "shundef", "staticSize": 16, "exclusiveSize": 16, "size": 16 },
+        { "name": "__makePad2", "staticSize": 1, "exclusiveSize": 1, "size": 1 },
+        { "name": "shoptundef",
+          "staticSize": 24,
+          "exclusiveSize": 24,
+          "size": 24,
+          "length": 0,
+          "capacity": 1
+        },
+        { "name": "__makePad3", "staticSize": 1, "exclusiveSize": 1, "size": 1 },
+        { "name": "optundef",
+          "staticSize": 16,
+          "exclusiveSize": 16,
+          "size": 16,
+          "length": 0,
+          "capacity": 1
         }
       ]
     }]'''

--- a/test/test_topo_sorter.cpp
+++ b/test/test_topo_sorter.cpp
@@ -236,6 +236,22 @@ TEST(TopoSorterTest, Pointers) {
   myclass.members.push_back(Member{mypointer, "ptr", 0});
 
   test({myclass}, R"(
+ClassA*
+MyClass
+ClassA
+)");
+}
+
+TEST(TopoSorterTest, References) {
+  // References do not require pointee types to be defined first
+  auto classA = Class{0, Class::Kind::Class, "ClassA", 69};
+  auto myreference = Reference{1, classA};
+
+  auto myclass = Class{2, Class::Kind::Class, "MyClass", 69};
+  myclass.members.push_back(Member{myreference, "ref", 0});
+
+  test({myclass}, R"(
+ClassA*
 MyClass
 ClassA
 )");
@@ -258,6 +274,7 @@ TEST(TopoSorterTest, PointerCycle) {
   // the same sorted order for ClassA and ClassB.
   for (const auto& input : inputs) {
     test(input, R"(
+ClassA*
 ClassB
 ClassA
 )");
@@ -276,6 +293,7 @@ TEST(TopoSorterTest, PointerToTypedef) {
   test({myclass}, R"(
 ClassA
 aliasA
+aliasA*
 MyClass
 )");
 }


### PR DESCRIPTION
tbv2: fix pointer codegen

A previous change enabled running OIL tests with specific features enabled.
This highlighted that pointer code generation under TreeBuilder-v2 was very
broken. This change updates pointer code generation to work and enables the
skipped tests. All enabled tests need `expected_json_v2` added to them due to
formatting differences.

Reformatted and rewrote the basic type handler that handles primitives and
pointers. Removed the reliance on `features` to decide whether to generate for
TreeBuilder-v2 as the intermediate features have been removed. Pointers are
treated as containers with a capacity of 1 and a length of 0 if null/a cycle
and 1 if followed. This holds for void pointers where, although they aren't
followed, the length is still set.

There were a couple of other changes needed to enable these tests on TBv2 that
aren't worth their own issues and PRs, I sneaked them in here.

Extra changes:
- Added `Pointer` and `Reference` to TopoSorter so they generate
  `NameProvider` instances. It might be worth visiting the graph differently
  for `NameProvider` as it requires so many instances that others generators do
  not. Will consider that in the future.
- Follow typedefs when calculating exclusive size for a type.

Closes #458.

Test plan:
- CI
- Enabled previously disabled tests.
