### PR TITLE
tbv2: support capture-thrift-isset

### DIFF
--- a/include/oi/exporters/Json.h
+++ b/include/oi/exporters/Json.h
@@ -158,7 +158,7 @@ inline void Json::printFields(const result::Element& el,
     printUnsignedField("capacity", el.container_stats->capacity, indent);
   }
   if (el.is_set_stats.has_value())
-    printUnsignedField("is_set", el.is_set_stats->is_set, indent);
+    printBoolField("is_set", el.is_set_stats->is_set, indent);
   printBoolField("is_primitive", el.is_primitive, indent);
 }
 

--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -40,6 +40,13 @@ constexpr int oidMagicId = 0x01DE8;
 
 namespace {
 
+template <typename T, size_t N>
+constexpr std::array<T, N + 1> arrayPrepend(std::array<T, N> a, T t);
+template <typename T, size_t N, size_t... I>
+constexpr std::array<T, N + 1> arrayPrependHelper(std::array<T, N> a,
+                                                  T t,
+                                                  std::index_sequence<I...>);
+
 template <size_t Size = (1 << 20) / sizeof(uintptr_t)>
 class PointerHashSet {
  private:
@@ -181,6 +188,22 @@ bool isStorageInline(const auto& c) {
   return (uintptr_t)std::data(c) < (uintptr_t)(&c + sizeof(c)) &&
          (uintptr_t)std::data(c) >= (uintptr_t)&c;
 }
+
+namespace {
+
+template <typename T, size_t N, size_t... I>
+constexpr std::array<T, N + 1> arrayPrependHelper(std::array<T, N> a,
+                                                  T t,
+                                                  std::index_sequence<I...>) {
+  return {t, a[I]...};
+}
+
+template <typename T, size_t N>
+constexpr std::array<T, N + 1> arrayPrepend(std::array<T, N> a, T t) {
+  return arrayPrependHelper(a, t, std::make_index_sequence<N>());
+}
+
+}  // namespace
 
 namespace OIInternal {
 namespace {

--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -137,6 +137,8 @@ Typedef& ClangTypeParser::enumerateTypedef(const clang::TypedefType& ty) {
 }
 
 Enum& ClangTypeParser::enumerateEnum(const clang::EnumType& ty) {
+  std::string fqName = clang::TypeName::getFullyQualifiedName(
+      clang::QualType(&ty, 0), *ast, {ast->getLangOpts()});
   std::string name = ty.getDecl()->getNameAsString();
   auto size = ast->getTypeSize(clang::QualType(&ty, 0)) / 8;
 
@@ -148,7 +150,8 @@ Enum& ClangTypeParser::enumerateEnum(const clang::EnumType& ty) {
     }
   }
 
-  return makeType<Enum>(ty, std::move(name), size, std::move(enumeratorMap));
+  return makeType<Enum>(
+      ty, std::move(name), std::move(fqName), size, std::move(enumeratorMap));
 }
 
 Array& ClangTypeParser::enumerateArray(const clang::ConstantArrayType& ty) {

--- a/oi/type_graph/Types.h
+++ b/oi/type_graph/Types.h
@@ -477,13 +477,19 @@ class Container : public Type {
 class Enum : public Type {
  public:
   explicit Enum(std::string name,
+                std::string inputName,
                 size_t size,
                 std::map<int64_t, std::string> enumerators = {})
-      : name_(name),
-        inputName_(std::move(name)),
+      : name_(std::move(name)),
+        inputName_(std::move(inputName)),
         size_(size),
         enumerators_(std::move(enumerators)) {
   }
+
+  explicit Enum(std::string name,
+                size_t size,
+                std::map<int64_t, std::string> enumerators = {})
+      : Enum{name, std::move(name), size, std::move(enumerators)} {};
 
   static inline constexpr bool has_node_id = false;
 

--- a/test/integration/enums.toml
+++ b/test/integration/enums.toml
@@ -36,12 +36,12 @@ definitions = '''
     param_types = ["ScopedEnum"]
     setup = "return {};"
     expect_json = '[{"staticSize":4, "dynamicSize":0}]'
-    expect_json_v2 = '[{"typeNames": ["ScopedEnum"], "staticSize":4, "exclusiveSize":4, "size":4}]'
+    expect_json_v2 = '[{"typeNames": ["ns_enums::ScopedEnum"], "staticSize":4, "exclusiveSize":4, "size":4}]'
   [cases.scoped_uint8]
     param_types = ["ScopedEnumUint8"]
     setup = "return {};"
     expect_json = '[{"staticSize":1, "dynamicSize":0}]'
-    expect_json_v2 = '[{"typeNames": ["ScopedEnumUint8"], "staticSize":1, "exclusiveSize":1, "size":1}]'
+    expect_json_v2 = '[{"typeNames": ["ns_enums::ScopedEnumUint8"], "staticSize":1, "exclusiveSize":1, "size":1}]'
   [cases.unscoped]
     param_types = ["UNSCOPED_ENUM"]
     setup = "return {};"
@@ -60,7 +60,7 @@ definitions = '''
     expect_json = '[{"staticSize":2, "dynamicSize":0}]'
     expect_json_v2 = '''[
       {"staticSize": 2, "exclusiveSize": 0, "size":2, "members": [
-        {"typeNames": ["ScopedEnumUint8"], "staticSize":1, "exclusiveSize":1, "size":1},
+        {"typeNames": ["ns_enums::ScopedEnumUint8"], "staticSize":1, "exclusiveSize":1, "size":1},
         {"typeNames": ["uint8_t"], "staticSize":1, "exclusiveSize":1, "size":1}
       ]}
     ]'''

--- a/test/integration/thrift_isset.toml
+++ b/test/integration/thrift_isset.toml
@@ -77,7 +77,6 @@ namespace cpp2 {
 
 [cases]
   [cases.unpacked]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructUnpacked&"]
     setup = '''
       cpp2::MyThriftStructUnpacked ret;
@@ -95,9 +94,19 @@ namespace cpp2 {
         {"name":"__fbthrift_field_c", "staticSize":4, "isset":true},
         {"name":"__isset", "staticSize":3}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":16,
+      "exclusiveSize":1,
+      "size":16,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_b", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_c", "staticSize":4, "is_set":true},
+        {"name":"__isset", "staticSize":3, "NOT":"is_set"}
+      ]
+    }]'''
 
   [cases.packed]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructPacked&"]
     setup = '''
       cpp2::MyThriftStructPacked ret;
@@ -126,9 +135,25 @@ namespace cpp2 {
         {"name":"__fbthrift_field_j", "staticSize":4, "isset":true},
         {"name":"__isset", "staticSize":2}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":44,
+      "exclusiveSize":2,
+      "size":44,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_b", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_c", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_d", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_e", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_f", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_g", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_h", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_i", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_j", "staticSize":4, "is_set":true},
+        {"name":"__isset", "staticSize":2, "NOT":"is_set"}
+      ]}]'''
 
   [cases.packed_non_atomic]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructPackedNonAtomic&"]
     setup = '''
       cpp2::MyThriftStructPackedNonAtomic ret;
@@ -147,9 +172,19 @@ namespace cpp2 {
         {"name":"__fbthrift_field_d", "staticSize":4, "isset":false},
         {"name":"__isset", "staticSize":1}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":20,
+      "exclusiveSize":3,
+      "size":20,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_b", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_c", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_d", "staticSize":4, "is_set":false},
+        {"name":"__isset", "staticSize":1, "NOT":"is_set"}
+      ]}]'''
 
   [cases.out_of_order]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructOutOfOrder&"]
     setup = '''
       cpp2::MyThriftStructOutOfOrder ret;
@@ -166,9 +201,18 @@ namespace cpp2 {
         {"name":"__fbthrift_field_c", "staticSize":4, "isset":false},
         {"name":"__isset", "staticSize":3}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":16,
+      "exclusiveSize":1,
+      "size":16,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_b", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_c", "staticSize":4, "is_set":false},
+        {"name":"__isset", "staticSize":3, "NOT":"is_set"}
+      ]}]'''
 
   [cases.required]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructRequired&"]
     setup = '''
       cpp2::MyThriftStructRequired ret;
@@ -189,9 +233,21 @@ namespace cpp2 {
         {"name":"__fbthrift_field_f", "staticSize":4, "isset":true},
         {"name":"__isset", "staticSize":3}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":28,
+      "exclusiveSize":1,
+      "size":28,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":4, "NOT":"is_set"},
+        {"name":"__fbthrift_field_b", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_c", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_d", "staticSize":4, "NOT":"is_set"},
+        {"name":"__fbthrift_field_e", "staticSize":4, "NOT":"is_set"},
+        {"name":"__fbthrift_field_f", "staticSize":4, "is_set":true},
+        {"name":"__isset", "staticSize":3, "NOT":"is_set"}
+      ]}]'''
 
   [cases.box]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const cpp2::MyThriftStructBoxed&"]
     setup = '''
       cpp2::MyThriftStructBoxed ret;
@@ -210,6 +266,18 @@ namespace cpp2 {
         {"name":"__fbthrift_field_d", "staticSize":4, "isset":true},
         {"name":"__fbthrift_field_e", "staticSize":4, "isset":true},
         {"name":"__isset", "staticSize":3}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":32,
+      "exclusiveSize":1,
+      "size":32,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":8, "NOT":"is_set"},
+        {"name":"__fbthrift_field_b", "staticSize":8, "NOT":"is_set"},
+        {"name":"__fbthrift_field_c", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_d", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_e", "staticSize":4, "is_set":true},
+        {"name":"__isset", "staticSize":3, "NOT":"is_set"}
       ]}]'''
 
   [cases.no_capture]
@@ -230,4 +298,16 @@ namespace cpp2 {
         {"name":"__fbthrift_field_d", "staticSize":4, "NOT":"isset"},
         {"name":"__fbthrift_field_e", "staticSize":4, "NOT":"isset"},
         {"name":"__isset", "staticSize":3}
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":32,
+      "exclusiveSize":1,
+      "size":32,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":8, "NOT":"is_set"},
+        {"name":"__fbthrift_field_b", "staticSize":8, "NOT":"is_set"},
+        {"name":"__fbthrift_field_c", "staticSize":4, "NOT":"is_set"},
+        {"name":"__fbthrift_field_d", "staticSize":4, "NOT":"is_set"},
+        {"name":"__fbthrift_field_e", "staticSize":4, "NOT":"is_set"},
+        {"name":"__isset", "staticSize":3, "NOT":"is_set"}
       ]}]'''

--- a/test/integration/thrift_isset_missing.toml
+++ b/test/integration/thrift_isset_missing.toml
@@ -58,7 +58,6 @@ raw_definitions = '''
 '''
 [cases]
   [cases.present]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const FakeThriftWithData&"]
     setup = '''
       FakeThriftWithData ret;
@@ -78,8 +77,17 @@ raw_definitions = '''
         {"name":"__fbthrift_field_c", "staticSize":4, "isset":true},
         {"name":"__isset", "staticSize":3}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":16,
+      "exclusiveSize":1,
+      "size":16,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":4, "is_set":true},
+        {"name":"__fbthrift_field_b", "staticSize":4, "is_set":false},
+        {"name":"__fbthrift_field_c", "staticSize":4, "is_set":true},
+        {"name":"__isset", "staticSize":3, "NOT":"is_set"}
+      ]}]'''
   [cases.missing]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const FakeThriftWithoutData&"]
     setup = '''
       FakeThriftWithoutData ret;
@@ -99,8 +107,17 @@ raw_definitions = '''
         {"name":"__fbthrift_field_c", "staticSize":4, "NOT":"isset"},
         {"name":"__isset", "staticSize":3}
       ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":16,
+      "exclusiveSize":1,
+      "size":16,
+      "members":[
+        {"name":"__fbthrift_field_a", "staticSize":4, "NOT":"is_set"},
+        {"name":"__fbthrift_field_b", "staticSize":4, "NOT":"is_set"},
+        {"name":"__fbthrift_field_c", "staticSize":4, "NOT":"is_set"},
+        {"name":"__isset", "staticSize":3, "NOT":"is_set"}
+      ]}]'''
   [cases.mixed]
-    oil_skip = 'oil does not support thrift isset yet' # https://github.com/facebookexperimental/object-introspection/issues/296
     param_types = ["const Mixed&"]
     setup = '''
       Mixed ret;
@@ -140,6 +157,34 @@ raw_definitions = '''
             {"name":"__fbthrift_field_b", "staticSize":4, "NOT":"isset"},
             {"name":"__fbthrift_field_c", "staticSize":4, "NOT":"isset"},
             {"name":"__isset", "staticSize":3}
+          ]
+        }
+      ]}]'''
+    expect_json_v2 = '''[{
+      "staticSize":32,
+      "exclusiveSize":0,
+      "size":32,
+      "members":[
+        {
+          "staticSize":16,
+          "exclusiveSize":1,
+          "size":16,
+          "members":[
+            {"name":"__fbthrift_field_a", "staticSize":4, "is_set":true},
+            {"name":"__fbthrift_field_b", "staticSize":4, "is_set":false},
+            {"name":"__fbthrift_field_c", "staticSize":4, "is_set":true},
+            {"name":"__isset", "staticSize":3, "NOT":"is_set"}
+          ]
+        },
+        {
+          "staticSize":16,
+          "exclusiveSize":1,
+          "size":16,
+          "members":[
+            {"name":"__fbthrift_field_a", "staticSize":4, "NOT":"is_set"},
+            {"name":"__fbthrift_field_b", "staticSize":4, "NOT":"is_set"},
+            {"name":"__fbthrift_field_c", "staticSize":4, "NOT":"is_set"},
+            {"name":"__isset", "staticSize":3, "NOT":"is_set"}
           ]
         }
       ]}]'''


### PR DESCRIPTION
tbv2: support capture-thrift-isset

Support the capture-thrift-isset feature with TreeBuilder-v2. Fairly minor
changes here except the type of the Enum in a template parameter now matters.

We follow the previous behaviour of capturing a value for each field in a
struct that has an `isset_bitset`. This value is a VarInt captured before the
C++ contents of the member. It has 3 values: 0 (not set), 1 (set), and 2
(unavailable). These are handled by the processor and represented in the output
as `false`, `true`, and `std::nullopt_t` respectively.

Changes:
- Add a simple Thrift isset processor before any fields that have Thrift isset.
- Store the fully qualified names of enum types in DrgnParser - it already
  worked out this information anyway for naming the values and this is
  consistent with classes.
- Forward all enum template parameters under their input name under the
  assumption that they will all be policy type things like `IssetBitsetOption`.
  This could turn out to be wrong.

Test plan:
- CI (doesn't test thrift changes but covers other regressions)
- Updated Thrift enum tests for new format.
- `FILTER='OilIntegration.*' make test` - Thrift tests failed before, succeed
  after.
