### PR TITLE
fix string type sso computation

### DIFF
--- a/oi/OITraceCode.cpp
+++ b/oi/OITraceCode.cpp
@@ -185,8 +185,10 @@ struct validate_offset {
 enum class StubbedPointer : uintptr_t {};
 
 bool isStorageInline(const auto& c) {
-  return (uintptr_t)std::data(c) < (uintptr_t)(&c + sizeof(c)) &&
-         (uintptr_t)std::data(c) >= (uintptr_t)&c;
+  uintptr_t data_p = (uintptr_t)std::data(c);
+  uintptr_t container_p = (uintptr_t)&c;
+
+  return data_p >= container_p && data_p < container_p + sizeof(c);
 }
 
 namespace {

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -28,7 +28,7 @@ void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
     // Test for small string optimisation - whether the underlying string is
     // contained within the string object.
     SAVE_SIZE(
-      (((uintptr_t)container.data() < (uintptr_t)(&container + sizeof(%1%<T>)))
+      (((uintptr_t)container.data() < (uintptr_t)(&container + 1))
         &&
       ((uintptr_t)container.data() >= (uintptr_t)&container))
         ? 0 : (container.capacity() * sizeof(T))

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -28,10 +28,7 @@ void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
     // Test for small string optimisation - whether the underlying string is
     // contained within the string object.
     SAVE_SIZE(
-      (((uintptr_t)container.data() < (uintptr_t)(&container + 1))
-        &&
-      ((uintptr_t)container.data() >= (uintptr_t)&container))
-        ? 0 : (container.capacity() * sizeof(T))
+      isStorageInline(container) ? 0 : (container.capacity() * sizeof(T))
     );
 }
 """
@@ -55,8 +52,7 @@ class CaptureKeyHandler<Ctx, std::__cxx11::basic_string<CharT, Traits, Allocator
 """
 
 traversal_func = """
-    bool sso = ((uintptr_t)container.data() < (uintptr_t)(&container + 1)) &&
-               ((uintptr_t)container.data() >= (uintptr_t)&container);
+    bool sso = isStorageInline(container);
 
     return returnArg.write(container.capacity())
         .write(sso)

--- a/types/cxx11_string_type.toml
+++ b/types/cxx11_string_type.toml
@@ -55,8 +55,7 @@ class CaptureKeyHandler<Ctx, std::__cxx11::basic_string<CharT, Traits, Allocator
 """
 
 traversal_func = """
-    bool sso = ((uintptr_t)container.data() <
-                (uintptr_t)(&container + sizeof(std::__cxx11::basic_string<T0>))) &&
+    bool sso = ((uintptr_t)container.data() < (uintptr_t)(&container + 1)) &&
                ((uintptr_t)container.data() >= (uintptr_t)&container);
 
     return returnArg.write(container.capacity())

--- a/types/fb_string_type.toml
+++ b/types/fb_string_type.toml
@@ -25,7 +25,7 @@ void getSizeType(const %1%<E, T, A, Storage> &container, size_t& returnArg)
     SAVE_DATA((uintptr_t)container.capacity());
     SAVE_DATA((uintptr_t)container.size());
 
-    bool inlined = ((uintptr_t)container.data() < (uintptr_t)(&container + sizeof(%1%<E, T, A, Storage>)))
+    bool inlined = ((uintptr_t)container.data() < (uintptr_t)(&container + 1))
         &&
       ((uintptr_t)container.data() >= (uintptr_t)&container);
 

--- a/types/fb_string_type.toml
+++ b/types/fb_string_type.toml
@@ -25,9 +25,7 @@ void getSizeType(const %1%<E, T, A, Storage> &container, size_t& returnArg)
     SAVE_DATA((uintptr_t)container.capacity());
     SAVE_DATA((uintptr_t)container.size());
 
-    bool inlined = ((uintptr_t)container.data() < (uintptr_t)(&container + 1))
-        &&
-      ((uintptr_t)container.data() >= (uintptr_t)&container);
+    bool inlined = isStorageInline(container);
 
     if (!inlined && ctx.pointers.add((uintptr_t)container.data())) {
       SAVE_SIZE(container.capacity() * sizeof(T));

--- a/types/small_vec_type.toml
+++ b/types/small_vec_type.toml
@@ -48,7 +48,7 @@ traversal_func = """
 // TODO: Is there an API to get this information?
 bool uses_intern_storage =
   (uintptr_t)&container <= (uintptr_t)container.data() &&
-  (uintptr_t)container.data() < ((uintptr_t)&container + 1);
+  (uintptr_t)container.data() < (uintptr_t)(&container + 1);
 
 auto tail = returnArg
   .write((uintptr_t)uses_intern_storage)

--- a/types/small_vec_type.toml
+++ b/types/small_vec_type.toml
@@ -23,7 +23,7 @@ void getSizeType(const %1%<V, N, P> &container, size_t& returnArg)
     SAVE_SIZE(sizeof(%1%<V, N, P>));
 
     bool dataInlined = ((uintptr_t)container.data() >= (uintptr_t)&container) &&
-                       ((uintptr_t)container.data() < (uintptr_t)(&container + sizeof(%1%<V, N, P>)));
+                       ((uintptr_t)container.data() < (uintptr_t)(&container + 1));
     if (dataInlined) {
       // Don't double count inlined elements
       SAVE_SIZE(-(container.size() * sizeof(V)));
@@ -48,7 +48,7 @@ traversal_func = """
 // TODO: Is there an API to get this information?
 bool uses_intern_storage =
   (uintptr_t)&container <= (uintptr_t)container.data() &&
-  (uintptr_t)container.data() < ((uintptr_t)&container + sizeof(container));
+  (uintptr_t)container.data() < ((uintptr_t)&container + 1);
 
 auto tail = returnArg
   .write((uintptr_t)uses_intern_storage)

--- a/types/small_vec_type.toml
+++ b/types/small_vec_type.toml
@@ -22,8 +22,8 @@ void getSizeType(const %1%<V, N, P> &container, size_t& returnArg)
 {
     SAVE_SIZE(sizeof(%1%<V, N, P>));
 
-    bool dataInlined = ((uintptr_t)container.data() >= (uintptr_t)&container) &&
-                       ((uintptr_t)container.data() < (uintptr_t)(&container + 1));
+    bool dataInlined = isStorageInline(container);
+
     if (dataInlined) {
       // Don't double count inlined elements
       SAVE_SIZE(-(container.size() * sizeof(V)));
@@ -43,12 +43,7 @@ void getSizeType(const %1%<V, N, P> &container, size_t& returnArg)
 """
 
 traversal_func = """
-// If `container.data()` pointer is within the container struct,
-// then the container's storage is inlined and doesn't uses the heap.
-// TODO: Is there an API to get this information?
-bool uses_intern_storage =
-  (uintptr_t)&container <= (uintptr_t)container.data() &&
-  (uintptr_t)container.data() < (uintptr_t)(&container + 1);
+bool uses_intern_storage = isStorageInline(container);
 
 auto tail = returnArg
   .write((uintptr_t)uses_intern_storage)

--- a/types/string_type.toml
+++ b/types/string_type.toml
@@ -37,8 +37,7 @@ void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
 """
 
 traversal_func = """
-    bool sso = ((uintptr_t)container.data() <
-                (uintptr_t)(&container + sizeof(std::__cxx11::basic_string<T0>))) &&
+    bool sso = ((uintptr_t)container.data() < (uintptr_t)(&container + 1)) &&
                ((uintptr_t)container.data() >= (uintptr_t)&container);
 
     return returnArg.write(container.capacity())

--- a/types/string_type.toml
+++ b/types/string_type.toml
@@ -28,7 +28,7 @@ void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
     // Test for small string optimisation - whether the underlying string is
     // contained within the string object.
     SAVE_SIZE(
-      ((uintptr_t)container.data() < (uintptr_t)(&container + sizeof(%1%<T>)))
+      ((uintptr_t)container.data() < (uintptr_t)(&container + 1))
         &&
       ((uintptr_t)container.data() >= (uintptr_t)&container)
         ? 0 : (container.capacity() * sizeof(T))

--- a/types/string_type.toml
+++ b/types/string_type.toml
@@ -28,17 +28,13 @@ void getSizeType(const %1%<T, Traits, Allocator> &container, size_t& returnArg)
     // Test for small string optimisation - whether the underlying string is
     // contained within the string object.
     SAVE_SIZE(
-      ((uintptr_t)container.data() < (uintptr_t)(&container + 1))
-        &&
-      ((uintptr_t)container.data() >= (uintptr_t)&container)
-        ? 0 : (container.capacity() * sizeof(T))
+      isStorageInline(container) ? 0 : (container.capacity() * sizeof(T))
     );
 }
 """
 
 traversal_func = """
-    bool sso = ((uintptr_t)container.data() < (uintptr_t)(&container + 1)) &&
-               ((uintptr_t)container.data() >= (uintptr_t)&container);
+    bool sso = isStorageInline(container);
 
     return returnArg.write(container.capacity())
         .write(sso)


### PR DESCRIPTION
## Summary
The sso flag in string types was calculated wrongly:
```
containter.data() >= &container && containter.data() < (&container + sizeof(container))
```
But because the `&container` is of type `std::basic_string<>*` the + already multiplies by sizeof.

## Note:
Some other types had similar problem, so I have changed them too.