### PR TITLE
stub clang::BuiltinType::NullPtr primitive type

### DIFF
--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -405,10 +405,15 @@ Primitive& ClangTypeParser::enumeratePrimitive(const clang::BuiltinType& ty) {
     case clang::BuiltinType::LongDouble:
       return makeType<Primitive>(ty, Primitive::Kind::Float64);
 
+    case clang::BuiltinType::NullPtr:
+      return makeType<Primitive>(ty, Primitive::Kind::StubbedPointer);
+
     case clang::BuiltinType::UInt128:
     case clang::BuiltinType::Int128:
     default:
-      throw std::logic_error(std::string("unsupported BuiltinType::Kind"));
+      throw std::logic_error(std::string("unsupported BuiltinType::Kind") +
+                             " " +
+                             ty.getNameAsCString(ast->getPrintingPolicy()));
   }
 }
 


### PR DESCRIPTION
Summary: Adding support for the nullptr clang type (clang::BuiltinType::NullPtr). While there I augmented the exception message to include the type name that is missing.

Differential Revision: D53272742


