### PR TITLE
std::align_t fix

### DIFF
--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -499,6 +499,7 @@ bool OICompiler::compile(const std::string& code,
   compInv->getLangOpts()->Exceptions = true;
   compInv->getLangOpts()->CXXExceptions = true;
   compInv->getLangOpts()->Coroutines = true;
+  compInv->getLangOpts()->AlignedAllocation = true;
 
   compInv->getPreprocessorOpts();
   compInv->getPreprocessorOpts().addRemappedFile(


### PR DESCRIPTION
## Summary
C++17 defines the `__cpp_aligned_new` feature test macro and and according to https://en.cppreference.com/w/cpp/feature_test this is included in the `cxx17_core` group of feature test macros. In the 'new' header file this feature test is used to gate the definition of `std::align_t`. However, it appears that clang15 with `-std=c++20` somehow doesn't enable this feature flag and therefore code that we define that uses a `std::align_t` fails to compile.

Looking at the clang source (https://clang.llvm.org/doxygen/InitPreprocessor_8cpp_source.html) the `__cpp_aligned_new` feature macro is enabled separately to the block of cxx17 macros and is under the `AlignedAllocation` langopt. I'm not sure why this is so but we'll justset the language option in the driver and that appears to work fine.

## Test plan
Internally tested.