### PR TITLE
Increase template backtrace limit in clang driver

### DIFF
--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -577,6 +577,7 @@ bool OICompiler::compile(const std::string& code,
   if (config.features[Feature::GenJitDebug]) {
     compInv->getCodeGenOpts().setDebugInfo(codegenoptions::FullDebugInfo);
   }
+  compInv->getDiagnosticOpts().TemplateBacktraceLimit = 0;
 
   CompilerInstance compInstance;
   compInstance.setInvocation(compInv);


### PR DESCRIPTION
## Summary
Currently when clang is dumping out a stacktrace of badness with template instantiations it will truncate the stack at 10 "frames". This diff means we disable any limiting so that we get all the template instantiation frames. It's bad enough trying to decipher the template madness but having incomplete information just adds to the problem.

## Test plan
Internally tested on a cycle.