### PR TITLE
Handle stubbed types in NameProvider

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -223,6 +223,13 @@ template <typename T>
 struct NameProvider;
 )";
 
+  code += R"(
+template <unsigned int N, unsigned int align, int32_t Id>
+struct NameProvider<DummySizedOperator<N, align, Id>> {
+  static constexpr std::array<std::string_view, 0> names = { };
+};
+)";
+
   // TODO: stop types being duplicated at this point and remove this check
   std::unordered_set<std::string_view> emittedTypes;
   for (const Type& t : typeGraph.finalTypes) {


### PR DESCRIPTION
## Summary
Stubbing out a type that is used in a template parameter (e.g., the first parameter in a unique_ptr - types that we actually recurse into) means that `make_field` will be called on the stubbed type. This fails as we have no NameProvider instantiation for this newly created stubbed type. This fix simply adds a template specialisation for any stubbed types in the NameProvider implementation.

## Test plan
Tested internally.