### PR TITLE
add cppcon presentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # object-introspection
 
 [![Matrix Chat](https://img.shields.io/matrix/object-introspection:matrix.org.svg)](https://matrix.to/#/#object-introspection:matrix.org)
+[![CppCon 2023 Presentation](https://img.shields.io/youtube/views/6IlTs8YRne0?label=CppCon%202023)](https://youtu.be/6IlTs8YRne0)
 
 ![OI Logo](/website/static/img/OIBrandmark.svg)
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -85,6 +85,10 @@ const config = {
                 label: 'Getting Started',
                 to: 'docs/intro',
               },
+              {
+                label: 'CppCon 2023 Presentation',
+                to: 'https://youtu.be/6IlTs8YRne0',
+              },
             ],
           },
           {


### PR DESCRIPTION
## Summary

Adds CppCon 2023 presentation links to the README and the website.

## Test plan
- `cd website && yarn start` - it works
