### PR TITLE
remove internal build config and update for CentOS 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/drgn")
 endif()
 
 ### Select Python version
-find_program(PYTHON NAMES python3.8 python3)
+find_program(PYTHON NAMES python3.9 python3)
 
 add_library(folly_headers INTERFACE)
 target_include_directories(folly_headers SYSTEM INTERFACE ${folly_SOURCE_DIR})
@@ -218,7 +218,7 @@ find_package(zstd REQUIRED)
 # clang-12 does NOT work. clang fails with the following error :-
 # configure: error: gcc with GNU99 support required
 
-set(DRGN_CONFIGURE_FLAGS "--with-libkdumpfile=no")
+set(DRGN_CONFIGURE_FLAGS "--with-libkdumpfile=no" "--disable-libdebuginfod")
 if (ASAN)
   list(APPEND DRGN_CONFIGURE_FLAGS "--enable-asan=yes")
 endif()
@@ -252,7 +252,28 @@ set(CMAKE_BUILD_RPATH
 )
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-include_directories(SYSTEM "${DRGN_PATH}")
+# This header from elfutils is not in the right place. Fake the path manually.
+add_custom_command(TARGET libdrgn POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
+${CMAKE_CURRENT_SOURCE_DIR}/extern/drgn/libdrgn/velfutils/libdw/known-dwarf.h
+${CMAKE_CURRENT_BINARY_DIR}/elfutils/known-dwarf.h)
+
+add_library(drgn INTERFACE)
+add_dependencies(drgn libdrgn)
+target_include_directories(drgn SYSTEM INTERFACE
+  "${DRGN_PATH}"
+  "${DRGN_PATH}/include"
+  "${PROJECT_SOURCE_DIR}/extern/drgn/libdrgn/velfutils"
+)
+target_link_options(drgn INTERFACE
+  "-L${DRGN_PATH}/.libs"
+  "-L${DRGN_PATH}/velfutils/libdw"
+)
+target_link_libraries(drgn INTERFACE
+  "-ldrgn"
+  "-ldw"
+)
+
+
 
 if (STATIC_LINK)
   # glog links against the `gflags` target, which is an alias for `gflags_shared`
@@ -288,7 +309,6 @@ add_library(oicore
   oi/PaddingHunter.cpp
   oi/Serialize.cpp
 )
-add_dependencies(oicore libdrgn)
 target_include_directories(oicore SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
 target_compile_definitions(oicore PRIVATE ${LLVM_DEFINITIONS})
 target_include_directories(oicore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -299,6 +319,7 @@ target_link_libraries(oicore
 
   ${Boost_LIBRARIES}
   Boost::headers
+  drgn
   glog::glog
   range-v3
   resources
@@ -322,9 +343,6 @@ else()
 endif()
 
 target_link_libraries(oicore
-  "-L${DRGN_PATH}/.libs"
-  drgn
-  dw
   pthread
 )
 
@@ -365,8 +383,12 @@ add_executable(oilgen
 target_link_libraries(oilgen
   drgn_utils
   oicore
-  clangTooling
 )
+if (FORCE_LLVM_STATIC)
+  target_link_libraries(oilgen
+    clangTooling
+  )
+endif()
 
 ### Object Introspection cache Printer (OIP)
 add_executable(oip tools/OIP.cpp)

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -16,6 +16,7 @@ endif()
 
 # Generate compile_commands.json to make it easier to work with clang based tools
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 
 option(ENABLE_IPO "Enable Interprocedural Optimization, aka Link Time Optimization (LTO)" OFF)
 

--- a/oi/CMakeLists.txt
+++ b/oi/CMakeLists.txt
@@ -6,11 +6,8 @@ target_link_libraries(toml PUBLIC tomlplusplus::tomlplusplus)
 add_library(drgn_utils DrgnUtils.cpp)
 target_link_libraries(drgn_utils
   glog::glog
-
-  "-L${DRGN_PATH}/.libs"
   drgn
 )
-add_dependencies(drgn_utils libdrgn)
 
 add_library(symbol_service
   Descs.cpp
@@ -22,8 +19,6 @@ target_link_libraries(symbol_service
   Boost::headers
   ${Boost_LIBRARIES}
   glog::glog
-
-  dw
 )
 
 add_library(features Features.cpp)

--- a/oi/SymbolService.cpp
+++ b/oi/SymbolService.cpp
@@ -31,7 +31,7 @@ extern "C" {
 #include <elfutils/libdwfl.h>
 
 #include "drgn.h"
-#include "dwarf.h"
+#include "libdw/dwarf.h"
 }
 
 namespace fs = std::filesystem;

--- a/oi/type_graph/CMakeLists.txt
+++ b/oi/type_graph/CMakeLists.txt
@@ -20,12 +20,10 @@ add_library(type_graph
   TypeIdentifier.cpp
   Types.cpp
 )
-add_dependencies(type_graph libdrgn)
 target_link_libraries(type_graph
   container_info
   symbol_service
 
-  "-L${DRGN_PATH}/.libs"
   drgn
 )
 target_include_directories(type_graph SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -28,7 +28,7 @@ add_link_options(-no-pie)
 set(INTEGRATION_TEST_TARGET_SRC integration_test_target.cpp)
 set(INTEGRATION_TEST_RUNNER_SRC integration_test_runner.cpp)
 
-find_program(PYTHON_CMD NAMES python3.6 python3)
+find_program(PYTHON_CMD NAMES python3.9 python3)
 
 set(INTEGRATION_TEST_THRIFT_SRCS ${THRIFT_TESTS})
 list(TRANSFORM INTEGRATION_TEST_THRIFT_SRCS APPEND ".thrift")


### PR DESCRIPTION
remove internal build config and update for CentOS 9

Previously we maintained three types of builds: a fully internal BUCK build, a
CMake build with modifications to use things from an internal toolchain, and an
open source CMake build.

As far as I'm concerned the intermediate build is not useful because our source
is readily available in both an internal and external form. Use cases as
follows:
1. BUCK build for distributing widely.
2. BUCK build for getting a static binary that can be run on any machine.
3. CMake build for primary development.
4. CMake build for external CI.

With the internal update to CentOS Stream 9 an unmodified CMake build now works
readily. This change patches up some things that were relying on system headers
that should have been vendored and cleans up drgn dependencies.

Test plan:
- It builds.
- TODO: Document CentOS 9 installation.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookexperimental/object-introspection/pull/482).
* #483
* __->__ #482