### PR TITLE
tests: add ClangTypeParserTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/drgn")
 endif()
 
 ### Select Python version
-find_program(PYTHON NAMES python3.8 python3)
+find_program(PYTHON NAMES python3.9 python3)
 
 add_library(folly_headers INTERFACE)
 target_include_directories(folly_headers SYSTEM INTERFACE ${folly_SOURCE_DIR})
@@ -218,7 +218,7 @@ find_package(zstd REQUIRED)
 # clang-12 does NOT work. clang fails with the following error :-
 # configure: error: gcc with GNU99 support required
 
-set(DRGN_CONFIGURE_FLAGS "--with-libkdumpfile=no")
+set(DRGN_CONFIGURE_FLAGS "--with-libkdumpfile=no" "--disable-libdebuginfod")
 if (ASAN)
   list(APPEND DRGN_CONFIGURE_FLAGS "--enable-asan=yes")
 endif()
@@ -252,7 +252,25 @@ set(CMAKE_BUILD_RPATH
 )
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-include_directories(SYSTEM "${DRGN_PATH}")
+# This header from elfutils is not in the right place. Fake the path manually.
+configure_file(extern/drgn/libdrgn/velfutils/libdw/known-dwarf.h
+elfutils/known-dwarf.h COPYONLY)
+
+add_library(drgn INTERFACE)
+add_dependencies(drgn libdrgn)
+target_include_directories(drgn INTERFACE
+  "${DRGN_PATH}"
+  "${DRGN_PATH}/include"
+  "${PROJECT_SOURCE_DIR}/extern/drgn/libdrgn/velfutils"
+)
+target_link_options(drgn INTERFACE
+  "-L${DRGN_PATH}/.libs"
+  "-ldrgn"
+  "-L${DRGN_PATH}/velfutils/libdw"
+  "-ldw"
+)
+
+
 
 if (STATIC_LINK)
   # glog links against the `gflags` target, which is an alias for `gflags_shared`
@@ -288,7 +306,6 @@ add_library(oicore
   oi/PaddingHunter.cpp
   oi/Serialize.cpp
 )
-add_dependencies(oicore libdrgn)
 target_include_directories(oicore SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
 target_compile_definitions(oicore PRIVATE ${LLVM_DEFINITIONS})
 target_include_directories(oicore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -299,6 +316,7 @@ target_link_libraries(oicore
 
   ${Boost_LIBRARIES}
   Boost::headers
+  drgn
   glog::glog
   range-v3
   resources
@@ -322,9 +340,6 @@ else()
 endif()
 
 target_link_libraries(oicore
-  "-L${DRGN_PATH}/.libs"
-  drgn
-  dw
   pthread
 )
 
@@ -365,8 +380,12 @@ add_executable(oilgen
 target_link_libraries(oilgen
   drgn_utils
   oicore
-  clangTooling
 )
+if (FORCE_LLVM_STATIC)
+  target_link_libraries(oilgen
+    clangTooling
+  )
+endif()
 
 ### Object Introspection cache Printer (OIP)
 add_executable(oip tools/OIP.cpp)

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -16,6 +16,7 @@ endif()
 
 # Generate compile_commands.json to make it easier to work with clang based tools
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 
 option(ENABLE_IPO "Enable Interprocedural Optimization, aka Link Time Optimization (LTO)" OFF)
 

--- a/oi/CMakeLists.txt
+++ b/oi/CMakeLists.txt
@@ -6,11 +6,8 @@ target_link_libraries(toml PUBLIC tomlplusplus::tomlplusplus)
 add_library(drgn_utils DrgnUtils.cpp)
 target_link_libraries(drgn_utils
   glog::glog
-
-  "-L${DRGN_PATH}/.libs"
   drgn
 )
-add_dependencies(drgn_utils libdrgn)
 
 add_library(symbol_service
   Descs.cpp
@@ -22,8 +19,6 @@ target_link_libraries(symbol_service
   Boost::headers
   ${Boost_LIBRARIES}
   glog::glog
-
-  dw
 )
 
 add_library(features Features.cpp)

--- a/oi/SymbolService.cpp
+++ b/oi/SymbolService.cpp
@@ -31,7 +31,7 @@ extern "C" {
 #include <elfutils/libdwfl.h>
 
 #include "drgn.h"
-#include "dwarf.h"
+#include "libdw/dwarf.h"
 }
 
 namespace fs = std::filesystem;

--- a/oi/type_graph/CMakeLists.txt
+++ b/oi/type_graph/CMakeLists.txt
@@ -20,12 +20,10 @@ add_library(type_graph
   TypeIdentifier.cpp
   Types.cpp
 )
-add_dependencies(type_graph libdrgn)
 target_link_libraries(type_graph
   container_info
   symbol_service
 
-  "-L${DRGN_PATH}/.libs"
   drgn
 )
 target_include_directories(type_graph SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})

--- a/oi/type_graph/ClangTypeParserTest.cpp
+++ b/oi/type_graph/ClangTypeParserTest.cpp
@@ -1,0 +1,177 @@
+#include <gtest/gtest.h>
+
+#include <clang/AST/Mangle.h>
+#include <clang/AST/QualTypeNames.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/CompilerInvocation.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Sema/Lookup.h>
+#include <clang/Sema/Sema.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Tooling/CompilationDatabase.h>
+#include <range/v3/core.hpp>
+#include <range/v3/view/drop.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/for_each.hpp>
+#include <range/v3/view/take.hpp>
+#include <range/v3/view/transform.hpp>
+#include <string>
+#include <string_view>
+
+#include "oi/type_graph/ClangTypeParser.h"
+#include "oi/type_graph/Printer.h"
+
+using namespace oi::detail;
+using namespace oi::detail::type_graph;
+
+class ClangTypeParserTest : public ::testing::Test {
+ public:
+  std::string run(std::string_view function, ClangTypeParserOptions opt);
+  void test(std::string_view function,
+            std::string_view expected,
+            ClangTypeParserOptions opts = {
+                .chaseRawPointers = true,
+                .readEnumValues = true,
+            });
+};
+
+// This stuff is a total mess. Set up factories as ClangTooling expects them.
+class ConsumerContext;
+class CreateTypeGraphConsumer;
+
+class CreateTypeGraphAction : public clang::ASTFrontendAction {
+ public:
+  CreateTypeGraphAction(ConsumerContext& ctx_) : ctx{ctx_} {
+  }
+
+  void ExecuteAction() override;
+  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
+      clang::CompilerInstance& CI, clang::StringRef file) override;
+
+ private:
+  ConsumerContext& ctx;
+};
+
+class CreateTypeGraphActionFactory
+    : public clang::tooling::FrontendActionFactory {
+ public:
+  CreateTypeGraphActionFactory(ConsumerContext& ctx_) : ctx{ctx_} {
+  }
+
+  std::unique_ptr<clang::FrontendAction> create() override {
+    return std::make_unique<CreateTypeGraphAction>(ctx);
+  }
+
+ private:
+  ConsumerContext& ctx;
+};
+
+class ConsumerContext {
+ public:
+  ConsumerContext(const std::vector<std::unique_ptr<ContainerInfo>>& containerInfos_) : containerInfos{containerInfos_} {}
+  std::string_view fullyQualifiedName;
+  ClangTypeParserOptions opts;
+  const std::vector<std::unique_ptr<ContainerInfo>>& containerInfos;
+  TypeGraph typeGraph;
+  Type* result = nullptr;
+ private:
+  clang::Sema* sema = nullptr;
+  friend CreateTypeGraphConsumer;
+  friend CreateTypeGraphAction;
+};
+
+class CreateTypeGraphConsumer : public clang::ASTConsumer {
+ private:
+  ConsumerContext& ctx;
+
+ public:
+  CreateTypeGraphConsumer(ConsumerContext& ctx_) : ctx{ctx_} {
+  }
+
+  void HandleTranslationUnit(clang::ASTContext& Context) override {
+    const clang::Type* type = nullptr;
+    for (const clang::Type* ty : Context.getTypes()) {
+      std::string fqnWithoutTemplateParams;
+      switch (ty->getTypeClass()) {
+        case clang::Type::Record:
+          fqnWithoutTemplateParams = llvm::cast<const clang::RecordType>(ty)->getDecl()->getQualifiedNameAsString();
+          break;
+        default:
+          continue;
+      }
+      if (fqnWithoutTemplateParams != ctx.fullyQualifiedName)
+        continue;
+
+      type = ty;
+      break;
+    }
+    EXPECT_NE(type, nullptr);
+
+    ClangTypeParser parser{ctx.typeGraph, ctx.containerInfos, ctx.opts};
+    ctx.result = &parser.parse(Context, *ctx.sema, *type);
+  }
+};
+
+void CreateTypeGraphAction::ExecuteAction() {
+  clang::CompilerInstance& CI = getCompilerInstance();
+
+  if (!CI.hasSema())
+    CI.createSema(clang::TU_Complete, nullptr);
+  ctx.sema = &CI.getSema();
+
+  clang::ASTFrontendAction::ExecuteAction();
+}
+
+std::unique_ptr<clang::ASTConsumer> CreateTypeGraphAction::CreateASTConsumer(
+    [[maybe_unused]] clang::CompilerInstance& CI,
+    [[maybe_unused]] clang::StringRef file) {
+  return std::make_unique<CreateTypeGraphConsumer>(ctx);
+}
+
+std::string ClangTypeParserTest::run(std::string_view type,
+                                     ClangTypeParserOptions opts) {
+  std::string err{"failed to load compilation database"};
+  auto db = clang::tooling::CompilationDatabase::loadFromDirectory(BUILD_DIR, err);
+  if (!db) {
+    throw std::runtime_error("failed to load compilation database");
+  }
+
+  std::vector<std::unique_ptr<ContainerInfo>> cis;
+  ConsumerContext ctx{ cis };
+  ctx.fullyQualifiedName = type;
+  ctx.opts = std::move(opts);
+  CreateTypeGraphActionFactory factory{ctx};
+
+  std::vector<std::string> sourcePaths{TARGET_CPP_PATH};
+  clang::tooling::ClangTool tool{*db, sourcePaths};
+  if (auto retCode = tool.run(&factory); retCode != 0) {
+    throw std::runtime_error("clang type parsing failed");
+  }
+
+  std::stringstream out;
+  NodeTracker tracker;
+  Printer printer{out, tracker, ctx.typeGraph.size()};
+  printer.print(*ctx.result);
+
+  return std::move(out).str();
+}
+
+void ClangTypeParserTest::test(std::string_view type,
+                               std::string_view expected,
+                               ClangTypeParserOptions opts) {
+  std::string actual = run(type, std::move(opts));
+  expected.remove_prefix(1);  // Remove initial '\n'
+  EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ClangTypeParserTest, SimpleStruct) {
+  test("ns_simple::SimpleStruct", R"(
+[0] Struct: SimpleStruct [ns_simple::SimpleStruct] (size: 16, align: 8)
+      Member: a (offset: 0)
+        Primitive: int32_t
+      Member: b (offset: 4)
+        Primitive: int8_t
+      Member: c (offset: 8)
+        Primitive: int64_t
+)");
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,31 @@ target_link_libraries(test_type_graph
 include(GoogleTest)
 gtest_discover_tests(test_type_graph)
 
+add_executable(test_clang_type_parser
+  main.cpp
+  ../oi/type_graph/ClangTypeParserTest.cpp
+)
+add_dependencies(test_clang_type_parser integration_test_target)
+target_compile_definitions(test_clang_type_parser PRIVATE
+  TARGET_CPP_PATH="${CMAKE_CURRENT_BINARY_DIR}/integration/integration_test_target.cpp"
+  BUILD_DIR="${CMAKE_BINARY_DIR}"
+)
+target_link_libraries(test_clang_type_parser
+  codegen
+  container_info
+  type_graph
+
+  range-v3
+
+  GTest::gmock_main
+)
+if (FORCE_LLVM_STATIC)
+  target_link_libraries(test_clang_type_parser clangTooling ${llvm_libs})
+else()
+  target_link_libraries(test_clang_type_parser clang-cpp LLVM)
+endif()
+gtest_discover_tests(test_clang_type_parser)
+
 cpp_unittest(
   NAME test_parser
   SRCS test_parser.cpp

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -28,7 +28,7 @@ add_link_options(-no-pie)
 set(INTEGRATION_TEST_TARGET_SRC integration_test_target.cpp)
 set(INTEGRATION_TEST_RUNNER_SRC integration_test_runner.cpp)
 
-find_program(PYTHON_CMD NAMES python3.6 python3)
+find_program(PYTHON_CMD NAMES python3.9 python3)
 
 set(INTEGRATION_TEST_THRIFT_SRCS ${THRIFT_TESTS})
 list(TRANSFORM INTEGRATION_TEST_THRIFT_SRCS APPEND ".thrift")


### PR DESCRIPTION
tests: add ClangTypeParserTest

Currently there is no testing for ClangTypeParser even though it's used in
production. This is because adding integration tests is very hard: they require
testing the build time behaviour at runtime, or else they'd be build failures
intead of test failures. There's a PR available for integration tests but it's
incomplete.

In contrast ClangTypeParser can be sort of unit tested. This follows the
structure of `test/test_drgn_parser.cpp` with some differences. There is a
tonne of boilerplate for setting up the Clang tool, and this set of testing
operates on type names instead of OID functions. The new tests are also
incredibly slow as they compile the entire `integration_test_target.cpp` (which
is huge) for every test case. I don't think this is avoidable without
compromising the separation of the tests somewhat due to the way Clang tooling
forces the code to be structured.

Test plan:
- Tested locally
- CI
