### PR TITLE
stub types in OIL via config

### DIFF
--- a/oi/type_graph/ClangTypeParser.h
+++ b/oi/type_graph/ClangTypeParser.h
@@ -60,6 +60,7 @@ struct TemplateParam;
 struct ClangTypeParserOptions {
   bool chaseRawPointers = false;
   bool readEnumValues = false;
+  std::set<std::string_view> typesToStub;
 };
 
 /*


### PR DESCRIPTION
## Summary
This diff provides the ability to stub types via config in ClangTypeParser. Each type should be listed individually in extra config.


## Test plan
Tested internally.
CI.