### PR TITLE
Keep template parameters for pass-through types

### DIFF
--- a/oi/OIGenerator.cpp
+++ b/oi/OIGenerator.cpp
@@ -88,6 +88,7 @@ class ConsumerContext {
   std::optional<bool> pic;
   const std::vector<std::unique_ptr<ContainerInfo>>& containerInfos;
   std::set<std::string_view> typesToStub;
+  std::set<std::string_view> mustProcessTemplateParams;
 
  private:
   clang::Sema* sema = nullptr;
@@ -141,6 +142,9 @@ int OIGenerator::generate(clang::tooling::CompilationDatabase& db,
     if (stubMember == "*")
       ctx.typesToStub.insert(stubType);
   }
+
+  for (const auto& cInfo : generatorConfig.passThroughTypes)
+    ctx.mustProcessTemplateParams.insert(cInfo.typeName);
 
   CreateTypeGraphActionFactory factory{ctx};
 
@@ -249,6 +253,7 @@ class CreateTypeGraphConsumer : public clang::ASTConsumer {
 
     type_graph::ClangTypeParserOptions opts;
     opts.typesToStub = ctx.typesToStub;
+    opts.mustProcessTemplateParams = ctx.mustProcessTemplateParams;
 
     type_graph::ClangTypeParser parser{ctx.typeGraph, ctx.containerInfos, opts};
 

--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -211,10 +211,11 @@ Type& ClangTypeParser::enumerateClass(const clang::RecordType& ty) {
       ty, kind, std::move(name), std::move(fqName), size, virtuality);
   c.setAlign(ast->getTypeAlign(clang::QualType(&ty, 0)) / 8);
 
-  enumerateClassTemplateParams(ty, c.templateParams);
+  if (options_.mustProcessTemplateParams.contains(fqnWithoutTemplateParams))
+    enumerateClassTemplateParams(ty, c.templateParams);
+
   // enumerateClassParents(ty, c.parents);
   enumerateClassMembers(ty, c.members);
-  // enumerateClassFunctions(type, c.functions);
 
   return c;
 }

--- a/oi/type_graph/ClangTypeParser.h
+++ b/oi/type_graph/ClangTypeParser.h
@@ -61,6 +61,7 @@ struct ClangTypeParserOptions {
   bool chaseRawPointers = false;
   bool readEnumValues = false;
   std::set<std::string_view> typesToStub;
+  std::set<std::string_view> mustProcessTemplateParams;
 };
 
 /*


### PR DESCRIPTION
Summary: Implement the pass-through feature in ClangTypeParser (keeping template parameters for specified types0.

Reviewed By: JakeHillion

Differential Revision: D53815662


