### PR TITLE
clangparser: add support for parents

### DIFF
--- a/oi/type_graph/ClangTypeParser.h
+++ b/oi/type_graph/ClangTypeParser.h
@@ -50,6 +50,7 @@ class Array;
 class Class;
 class Enum;
 class Member;
+struct Parent;
 class Primitive;
 class Reference;
 class Type;
@@ -116,6 +117,7 @@ class ClangTypeParser {
   std::optional<TemplateParam> enumerateTemplateTemplateParam(
       const clang::TemplateName&);
 
+  void enumerateClassParents(const clang::RecordType&, std::vector<Parent>&);
   void enumerateClassMembers(const clang::RecordType&, std::vector<Member>&);
 
   ContainerInfo* getContainerInfo(const std::string& fqName) const;


### PR DESCRIPTION
Summary: Add support in ClangTypeParser for parents.

Reviewed By: JakeHillion

Differential Revision: D53708619


