### PR TITLE
convert circleci lint job to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ version: 2.1
 workflows:
   object-introspection:
     jobs:
-      - lint
-
       - build:
           name: build-gcc
           cc: /usr/bin/gcc
@@ -33,10 +31,6 @@ workflows:
           exclude_regex: ".*inheritance_polymorphic.*|.*arrays_member_int0|.*fbstring.*|.*std_string_*|.*multi_arg_tb_.*|.*ignored_member|OilIntegration.fbstring_.*|OilIntegration.capture_keys_string|OilIntegration.capture_keys_multi_level"
 
 executors:
-  nix-docker:
-    docker:
-      - image: nixos/nix:latest
-    resource_class: small
   ubuntu-docker:
     docker:
       - image: ubuntu:jammy
@@ -47,14 +41,6 @@ executors:
     resource_class: 2xlarge
 
 jobs:
-  lint:
-    executor: nix-docker
-    steps:
-      - checkout
-      - run:
-          name: Flake check
-          command: nix --experimental-features 'nix-command flakes' flake check
-
   build:
     # TODO this job could be run in Docker
     executor: big-boy

--- a/.github/workflows/object-introspection.yml
+++ b/.github/workflows/object-introspection.yml
@@ -1,0 +1,15 @@
+name: facebookexperimental/object-introspection
+on:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: cachix/install-nix-action@v25
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: nix fmt
+      run: |-
+        nix --experimental-features 'nix-command flakes' fmt
+        git diff --exit-code


### PR DESCRIPTION
convert circleci lint job to github actions

Start the migration from CircleCI to GitHub Actions with migrating the lint
job. Used the structure from @robandpdx to setup Nix and use a GitHub key.
Restructured the check from `nix flake check` to
`nix fmt; git diff --exit-code` so we get a full patch again.

Test plan:
- Submitted this PR with a formatting error. CI failed. Submitted without and
  it passed.

Co-authored-by: Rob Anderson <robandpdx@github.com>
