### PR TITLE
bump python version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/drgn")
 endif()
 
 ### Select Python version
-find_program(PYTHON NAMES python3.8 python3)
+find_program(PYTHON NAMES python3.9 python3)
 
 add_library(folly_headers INTERFACE)
 target_include_directories(folly_headers SYSTEM INTERFACE ${folly_SOURCE_DIR})

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -28,7 +28,7 @@ add_link_options(-no-pie)
 set(INTEGRATION_TEST_TARGET_SRC integration_test_target.cpp)
 set(INTEGRATION_TEST_RUNNER_SRC integration_test_runner.cpp)
 
-find_program(PYTHON_CMD NAMES python3.6 python3)
+find_program(PYTHON_CMD NAMES python3.9 python3)
 
 set(INTEGRATION_TEST_THRIFT_SRCS ${THRIFT_TESTS})
 list(TRANSFORM INTEGRATION_TEST_THRIFT_SRCS APPEND ".thrift")


### PR DESCRIPTION
## Summary
Bump python version to 3.9 for Centos9

## Test plan
No new failed tests seen with a `make test`.