### PR TITLE
ClangTypeParser: handle clang::MemberPointer

### DIFF
--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -109,6 +109,9 @@ Type& ClangTypeParser::enumerateType(const clang::Type& ty) {
       return enumerateArray(llvm::cast<const clang::ConstantArrayType>(ty));
     case clang::Type::Enum:
       return enumerateEnum(llvm::cast<const clang::EnumType>(ty));
+    case clang::Type::MemberPointer:
+      return enumerateMemberPointer(
+          llvm::cast<const clang::MemberPointerType>(ty));
 
     default:
       throw std::logic_error(std::string("unsupported TypeClass `") +
@@ -383,6 +386,12 @@ Type& ClangTypeParser::enumeratePointer(const clang::PointerType& ty) {
 
   Type& t = enumerateType(*ty.getPointeeType());
   return makeType<Reference>(ty, t);
+}
+
+Type& ClangTypeParser::enumerateMemberPointer(
+    const clang::MemberPointerType& ty) {
+  // TODO: chase anything not a function pointer (same as regular pointers).
+  return makeType<Primitive>(ty, Primitive::Kind::StubbedPointer);
 }
 
 Type& ClangTypeParser::enumerateSubstTemplateTypeParm(

--- a/oi/type_graph/ClangTypeParser.h
+++ b/oi/type_graph/ClangTypeParser.h
@@ -29,6 +29,7 @@ class DecltypeType;
 class ElaboratedType;
 class EnumType;
 class LValueReferenceType;
+class MemberPointerType;
 class PointerType;
 class RecordType;
 class Sema;
@@ -97,6 +98,7 @@ class ClangTypeParser {
   Type& enumerateClass(const clang::RecordType&);
   Type& enumerateReference(const clang::LValueReferenceType&);
   Type& enumeratePointer(const clang::PointerType&);
+  Type& enumerateMemberPointer(const clang::MemberPointerType&);
   Type& enumerateSubstTemplateTypeParm(const clang::SubstTemplateTypeParmType&);
   Primitive& enumeratePrimitive(const clang::BuiltinType&);
   Type& enumerateElaboratedType(const clang::ElaboratedType&);


### PR DESCRIPTION
## Summary
This diff implements the handling on a clang::MemberPointer. We simply stub the type.

## Test plan

A 'make test` shows no new failures.