### PR TITLE
Correct offset calculation with multiple base classes

### DIFF
--- a/oi/type_graph/ClangTypeParser.cpp
+++ b/oi/type_graph/ClangTypeParser.cpp
@@ -335,7 +335,8 @@ void ClangTypeParser::enumerateClassParents(const clang::RecordType& ty,
     if (baseCxxDecl == nullptr)
       continue;
 
-    auto offset = layout.getBaseClassOffset(baseCxxDecl).getQuantity();
+    auto offset =
+        layout.getBaseClassOffset(baseCxxDecl).getQuantity() * CHAR_BIT;
     auto& ptype = enumerateType(*baseType);
     parents.emplace_back(Parent{ptype, static_cast<uint64_t>(offset)});
   }


### PR DESCRIPTION
## Summary

If a class inherits from more than one base class Clang Parser currently calculates incorrect offsets for everything but the first base class. This is owing to the fact that TypeGraph needs offsets in bits but ClangParser is providing them in bytes.

## Test plan
`make test` contains no additional failures. This was tested internally against a Meta source base. 
