### PR TITLE
TypeGraphv2: correctly handle bitfields in code generation

### DIFF
--- a/oi/CodeGen.cpp
+++ b/oi/CodeGen.cpp
@@ -822,17 +822,24 @@ void CodeGen::genClassTreeBuilderInstructions(const Class& c,
   code += std::to_string(numFields);
   code += "> fields{\n";
   index = 0;
+
   for (const auto& m : c.members) {
     ++index;
     if (m.name.starts_with(AddPadding::MemberPrefix))
       continue;
     std::string fullName = c.name() + "::" + m.name;
+    bool isbitField = m.bitsize;
     bool isPrimitive = dynamic_cast<const Primitive*>(&m.type());
-    code += "      inst::Field{sizeof(";
-    code += fullName;
-    code += "), ";
-    code += std::to_string(calculateExclusiveSize(m.type()));
-    code += ",\"";
+
+    if (!isbitField) {
+      code += "      inst::Field{sizeof(";
+      code += fullName;
+      code += "), ";
+      code += std::to_string(calculateExclusiveSize(m.type()));
+    } else {
+      code += "      inst::Field{0, 0";
+    }
+    code += ", \"";
     code += m.inputName;
     code += "\", member_";
     code += std::to_string(index);


### PR DESCRIPTION
## Summary
Currently in TypeGraph when generating inst::Field objects in the generated source we use the `sizeof` operator to construct the static and exclusive size. As you can't use sizeof() on a bitfield this generates invalid code. This fix special cases bit fields and sets the static and exclusive size to 0 as there size will be rolled up in the parent object.

## Test plan
A 'make test` has no new failures. This fix was tested against an object in a Meta source base.
