### PR TITLE
build and test LLVM version 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - run:
           name: Build
           command: |
-            /tmp/cmake/build/bin/cmake -G Ninja -B build/ -DWITH_FLAKY_TESTS=Off -DCODE_COVERAGE=On -DWARNINGS_AS_ERRORS=<< parameters.warnings_as_errors >>
+            /tmp/cmake/build/bin/cmake -G Ninja -B build/ -DLLVM_REQUESTED_VERSION=15 -DWITH_FLAKY_TESTS=Off -DCODE_COVERAGE=On -DWARNINGS_AS_ERRORS=<< parameters.warnings_as_errors >>
             ninja -C build/
             # Testing rubbish:
             cp test/ci.oid.toml build/testing.oid.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: 16-core-ubuntu
     strategy:
       matrix:
-        llvm_version: [15]
+        llvm_version: [15, 16]
     steps:
     - uses: actions/checkout@v4.1.7
     - uses: cachix/install-nix-action@v27

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: dorny/test-reporter@v1
       with:
-        artifact: test-results-15
+        artifact: test-results-16
         name: CTest Tests
         path: results.xml
         reporter: jest-junit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,10 +218,15 @@ find_package(Boost REQUIRED COMPONENTS
 )
 message(STATUS "Linking Boost libraries: ${Boost_LIBRARIES}")
 
-### LLVM and Clang - Preferring Clang 15
-find_package(LLVM 15 REQUIRED CONFIG)
+### LLVM and Clang
+find_package(LLVM ${LLVM_REQUESTED_VERSION} REQUIRED CONFIG)
+
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+if((${LLVM_VERSION_MAJOR} VERSION_LESS 15) OR (${LLVM_VERSION_MAJOR} VERSION_GREATER 16))
+  message(SEND_ERROR "Object Introspection currently requires an LLVM version between 15 and 16!")
+endif()
 
 find_package(Clang REQUIRED CONFIG)
 message(STATUS "Found Clang ${LLVM_PACKAGE_VERSION}")

--- a/flake.nix
+++ b/flake.nix
@@ -99,9 +99,10 @@
       in
       {
         packages = rec {
-          default = oid-llvm15;
+          default = oid-llvm16;
 
           oid-llvm15 = mkOidPackage pkgs.llvmPackages_15;
+          oid-llvm16 = mkOidPackage pkgs.llvmPackages_16;
         };
 
         apps.default = {


### PR DESCRIPTION

Add LLVM-16 to the Nix builds and CI matrix. Also add the option to explicitly
select an LLVM version so the CircleCI build can still work as before.

We should support at least LLVM-17 currently, but there appears to be a
significant performance regression in compiling the generated code for large
variants that I'm going to debug separately. The long term goal is to support
and test all versions 15 and up.

Test plan:
- CI
