### PR TITLE
LLVM upstream removed Support/Host.h

### DIFF
--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -32,7 +32,11 @@
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
 #include <llvm/MC/TargetRegistry.h>
+#if LLVM_VERSION_MAJOR >= 16
+#include <llvm/TargetParser/Host.h>
+#else
 #include <llvm/Support/Host.h>
+#endif
 #include <llvm/Support/Memory.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_os_ostream.h>


### PR DESCRIPTION
Summary:
Adjust object-introspection code to LLVM upstreaming moving `Host.h` around. See also:

* https://github.com/llvm/llvm-project/commit/e1e34cc2a17c5f640333767df2d3bfe2b2f81a84
* https://github.com/llvm/llvm-project/commit/f09cf34d00625e57dea5317a3ac0412c07292148

Differential Revision: D61363387
