### PR TITLE
chore(deps): lock file maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: 16-core-ubuntu
     strategy:
       matrix:
-        llvm_version: [15, 16]
+        llvm_version: [16]
     steps:
     - uses: actions/checkout@v4.1.7
     - uses: cachix/install-nix-action@v27
@@ -39,16 +39,16 @@ jobs:
     - name: build (LLVM ${{ matrix.llvm_version }})
       # Run the build manually in `nix develop` to keep non-outputs around
       run: |
-        nix develop .#oid-llvm${{ matrix.llvm_version }} --command cmake -B build -G Ninja -DWITH_FLAKY_TESTS=Off -DFORCE_BOOST_STATIC=Off
-        nix develop .#oid-llvm${{ matrix.llvm_version }} --command ninja -C build
+        nix develop -i .#oid-llvm${{ matrix.llvm_version }} --command cmake -B build -G Ninja -DWITH_FLAKY_TESTS=Off -DFORCE_BOOST_STATIC=Off
+        nix develop -i .#oid-llvm${{ matrix.llvm_version }} --command ninja -C build
     - name: test (LLVM ${{ matrix.llvm_version }})
       env:
         # disable drgn multithreading as tests are already run in parallel
         OMP_NUM_THREADS: 1
       run: |
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-        nix develop .#oid-llvm${{ matrix.llvm_version }} --command ./tools/config_gen.py -c clang++ build/testing.oid.toml
-        nix develop .#oid-llvm${{ matrix.llvm_version }} --command ctest \
+        nix develop -i .#oid-llvm${{ matrix.llvm_version }} --command ./tools/config_gen.py -c clang++ build/testing.oid.toml
+        nix develop -i .#oid-llvm${{ matrix.llvm_version }} --command ctest \
           --test-dir build/test/ \
           --test-action Test \
           --parallel \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,8 +224,8 @@ find_package(LLVM ${LLVM_REQUESTED_VERSION} REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-if((${LLVM_VERSION_MAJOR} VERSION_LESS 15) OR (${LLVM_VERSION_MAJOR} VERSION_GREATER 16))
-  message(SEND_ERROR "Object Introspection currently requires an LLVM version between 15 and 16!")
+if((${LLVM_VERSION_MAJOR} VERSION_LESS 16) OR (${LLVM_VERSION_MAJOR} VERSION_GREATER 16))
+  message(SEND_ERROR "Object Introspection currently requires LLVM version 16!")
 endif()
 
 find_package(Clang REQUIRED CONFIG)

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723362943,
-        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
+        "lastModified": 1752950548,
+        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723454642,
-        "narHash": "sha256-S0Gvsenh0II7EAaoc9158ZB4vYyuycvMGKGxIbERNAM=",
+        "lastModified": 1753006367,
+        "narHash": "sha256-tzbhc4XttkyEhswByk5R38l+ztN9UDbnj0cTcP6Hp9A=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "349de7bc435bdff37785c2466f054ed1766173be",
+        "rev": "421b56313c65a0815a52b424777f55acf0b56ddf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -84,12 +84,12 @@
                 libmicrohttpd
                 liburing
                 libxml2
-                lzma
                 msgpack
                 range-v3
                 rocksdb_8_11
                 sqlite
                 tomlplusplus
+                xz
                 zstd
               ]);
 
@@ -115,13 +115,11 @@
         packages = rec {
           default = self.packages.${system}."oid-llvm${toString defaultLlvmVersion}";
 
-          oid-llvm15 = mkOidPackage 15;
           oid-llvm16 = mkOidPackage 16;
         };
         devShells = rec {
           default = self.devShells.${system}."oid-llvm${toString defaultLlvmVersion}";
 
-          oid-llvm15 = mkOidDevShell 15;
           oid-llvm16 = mkOidDevShell 16;
         };
 

--- a/oi/Descs.cpp
+++ b/oi/Descs.cpp
@@ -42,7 +42,7 @@ std::optional<uintptr_t> FuncDesc::Arg::findAddress(
   user_regs_struct modifiedRegs = *regs;
   oi::detail::arch::setProgramCounter(modifiedRegs, pc);
 
-  struct drgn_object object {};
+  struct drgn_object object{};
   BOOST_SCOPE_EXIT_ALL(&) {
     drgn_object_deinit(&object);
   };

--- a/oi/OID.cpp
+++ b/oi/OID.cpp
@@ -236,8 +236,8 @@ void sigIntHandler(int sigNum) {
 }
 
 void installSigHandlers(void) {
-  struct sigaction nact {};
-  struct sigaction oact {};
+  struct sigaction nact{};
+  struct sigaction oact{};
 
   nact.sa_handler = sigIntHandler;
   sigemptyset(&nact.sa_mask);

--- a/oi/OIDebugger.cpp
+++ b/oi/OIDebugger.cpp
@@ -181,7 +181,7 @@ void OIDebugger::dumpRegs(const char* text,
  */
 bool OIDebugger::singleStepFunc(pid_t pid, uint64_t real_end) {
   uint64_t addr = 0x0;
-  struct user_regs_struct regs {};
+  struct user_regs_struct regs{};
   uint64_t prev = 0;
 
   do {
@@ -816,7 +816,7 @@ OIDebugger::processTrapRet OIDebugger::processJitCodeRet(
 
       if (VLOG_IS_ON(4)) {
         errno = 0;
-        struct user_regs_struct newregs {};
+        struct user_regs_struct newregs{};
         if (ptrace(PTRACE_GETREGS, pid, NULL, &newregs) < 0) {
           LOG(ERROR) << "Execute: Couldn't restore registers: "
                      << strerror(errno);
@@ -875,14 +875,14 @@ bool OIDebugger::processGlobal(const std::string& varName) {
   }
 
   errno = 0;
-  struct user_regs_struct regs {};
+  struct user_regs_struct regs{};
   if (ptrace(PTRACE_GETREGS, traceePid, nullptr, &regs) < 0) {
     LOG(ERROR) << "processGlobal: failed to read registers" << strerror(errno);
     return false;
   }
 
   errno = 0;
-  struct user_fpregs_struct fpregs {};
+  struct user_fpregs_struct fpregs{};
   if (ptrace(PTRACE_GETFPREGS, traceePid, nullptr, &fpregs) < 0) {
     LOG(ERROR) << "processGlobal: Couldn't get fp registers: "
                << strerror(errno);
@@ -1109,7 +1109,7 @@ OIDebugger::processTrapRet OIDebugger::processTrap(pid_t pid,
     case SIGSEGV: {
       {
         errno = 0;
-        struct user_regs_struct regs {};
+        struct user_regs_struct regs{};
         if (ptrace(PTRACE_GETREGS, newpid, nullptr, &regs) < 0) {
           LOG(ERROR) << "SIGSEGV handling: failed to read registers"
                      << strerror(errno);
@@ -1175,8 +1175,8 @@ OIDebugger::processTrapRet OIDebugger::processTrap(pid_t pid,
        * entry/return point vectoring. We therefore must be able to match
        * which interrupt this is for and act accordingly.
        */
-      struct user_regs_struct regs {};
-      struct user_fpregs_struct fpregs {};
+      struct user_regs_struct regs{};
+      struct user_fpregs_struct fpregs{};
 
       errno = 0;
       if (ptrace(PTRACE_GETREGS, newpid, nullptr, &regs) < 0) {
@@ -1599,7 +1599,7 @@ std::optional<typename Sys::RetType> OIDebugger::remoteSyscall(Args... _args) {
 
   /* Saving current registers states */
   errno = 0;
-  struct user_regs_struct oldregs {};
+  struct user_regs_struct oldregs{};
   if (ptrace(PTRACE_GETREGS, traceePid, nullptr, &oldregs) < 0) {
     LOG(ERROR) << "syscall: GETREGS failed for process " << traceePid << ": "
                << strerror(errno);
@@ -1607,7 +1607,7 @@ std::optional<typename Sys::RetType> OIDebugger::remoteSyscall(Args... _args) {
   }
 
   errno = 0;
-  struct user_fpregs_struct oldfpregs {};
+  struct user_fpregs_struct oldfpregs{};
   if (ptrace(PTRACE_GETFPREGS, traceePid, nullptr, &oldfpregs) < 0) {
     LOG(ERROR) << "syscall: GETFPREGS failed for process " << traceePid << ": "
                << strerror(errno);
@@ -2485,7 +2485,7 @@ void OIDebugger::restoreState(void) {
         continue;
       }
 
-      struct user_regs_struct regs {};
+      struct user_regs_struct regs{};
 
       /* Find the trapInfo for this tgid */
       if (auto iter{threadTrapState.find(p)};
@@ -2495,7 +2495,7 @@ void OIDebugger::restoreState(void) {
         /* Paranoia really */
         assert(p == iter->first);
 
-        struct user_fpregs_struct fpregs {};
+        struct user_fpregs_struct fpregs{};
 
         if (VLOG_IS_ON(1)) {
           errno = 0;
@@ -2573,7 +2573,7 @@ void OIDebugger::restoreState(void) {
 
       if (VLOG_IS_ON(1)) {
         errno = 0;
-        struct user_regs_struct regs {};
+        struct user_regs_struct regs{};
         if (ptrace(PTRACE_GETREGS, p, NULL, &regs) < 0) {
           LOG(ERROR) << "restoreState unknown sig handling: getregs failed- "
                      << strerror(errno);
@@ -2708,7 +2708,7 @@ bool OIDebugger::stopTarget(void) {
 
   if (VLOG_IS_ON(1)) {
     errno = 0;
-    struct user_regs_struct stopregs {};
+    struct user_regs_struct stopregs{};
     if (ptrace(PTRACE_GETREGS, traceePid, NULL, &stopregs) < 0) {
       LOG(ERROR) << "stopTarget getregs failed for process " << traceePid
                  << " : " << strerror(errno);

--- a/oi/SymbolService.cpp
+++ b/oi/SymbolService.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <boost/scope_exit.hpp>
 #include <cassert>
+#include <cinttypes>
 #include <cstring>
 #include <fstream>
 
@@ -772,7 +773,7 @@ std::shared_ptr<GlobalDesc> SymbolService::findGlobalDesc(
 
   auto gd = std::make_shared<GlobalDesc>(global, sym->addr);
 
-  struct drgn_object globalObj {};
+  struct drgn_object globalObj{};
   drgn_object_init(&globalObj, drgnProg);
   BOOST_SCOPE_EXIT_ALL(&) {
     drgn_object_deinit(&globalObj);

--- a/test/integration/folly_shims.cpp
+++ b/test/integration/folly_shims.cpp
@@ -32,10 +32,6 @@ namespace detail {
 void F14LinkCheck<getF14IntrinsicsMode()>::check() noexcept {
 }
 
-#if FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE
-EmptyTagVectorType kEmptyTagVector = {};
-#endif
-
 bool tlsPendingSafeInserts(std::ptrdiff_t /*delta*/) {
   /* Disable extra debugging re-hash by classifying all inserts as safe (return
    * true) */

--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -172,7 +172,7 @@ def pull_base_toml() -> typing.Dict:
     # Now, we need to replace any placeholders that might be present in the base toml file with the real verisons.
     user = getpass.getuser()
     if "IN_NIX_SHELL" in os.environ and "src" in os.environ:
-        pwd = os.environ['src']
+        pwd = os.environ["src"]
     else:
         pwd = str(repo_path.resolve())
 


### PR DESCRIPTION
Update system dependencies with `nix flake update`. This update comes
with a bunch of formatting changes, but the most significant change is
dropping support for LLVM 15. With enough Nix work this can be avoided,
and it's unfortunate because LLVM 17 is as yet unsupported (by memory a
big perf regression in compilation speed), so we'll only support one
version for a while. I think it makes more sense given the current
state of the project to localise all users on exactly one working config
than attempt to support multiple.