### PR TITLE
tests: add support for dynamically skipping tests based on llvm version

### DIFF
--- a/oi/OICompiler.cpp
+++ b/oi/OICompiler.cpp
@@ -738,4 +738,8 @@ std::optional<OICompiler::RelocResult> OICompiler::applyRelocs(
   return res;
 }
 
+int OICompiler::getLLVMVersionMajor() {
+  return LLVM_VERSION_MAJOR;
+}
+
 }  // namespace oi::detail

--- a/oi/OICompiler.h
+++ b/oi/OICompiler.h
@@ -183,6 +183,11 @@ class OICompiler {
   static std::optional<std::string> decodeInst(const std::vector<std::byte>&,
                                                uintptr_t);
 
+  /**
+   * @return the major version of LLVM this was compiled with
+   */
+  static int getLLVMVersionMajor();
+
  private:
   std::shared_ptr<SymbolService> symbols;
   Config config;

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(integration_test_runner PRIVATE
   Boost::headers
   ${Boost_LIBRARIES}
   toml
+  oicore
 )
 target_compile_definitions(integration_test_runner PRIVATE
   TARGET_EXE_PATH="${CMAKE_CURRENT_BINARY_DIR}/integration_test_target"

--- a/test/integration/runner_common.cpp
+++ b/test/integration/runner_common.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <utility>
 
+#include "oi/OICompiler.h"
 #include "oi/OIOpts.h"
 #include "oi/support/Toml.h"
 
@@ -22,6 +23,7 @@ namespace bpt = boost::property_tree;
 namespace fs = std::filesystem;
 
 bool run_skipped_tests = false;
+int llvm_version_major = oi::detail::OICompiler::getLLVMVersionMajor();
 
 namespace {
 


### PR DESCRIPTION
Some tests are useful but are either broken on individual LLVM versions or before/after an LLVM version. Add new options to the test TOML that let us skip tests dynamically based on too old/too new/explicitly skipped LLVM major versions.

Test plan:
- CI
- Used in stacked PRs